### PR TITLE
Win32console

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -1,3 +1,7 @@
+if &cp || v:version < 702 || (exists('g:loaded_airline') && g:loaded_airline)
+  finish
+endif
+let g:loaded_airline = 1
 if !exists('g:airline_left_sep')
   let g:airline_left_sep = exists('g:airline_powerline_fonts')?"":">"
 endif


### PR DESCRIPTION
On windows console, ctermfg or ctermbg become strange behavior when the greater value than 128 is passed.

![](http://go-gyazo.appspot.com/c0f9f8a3772bf6cf.png)

This patch fixes the issue.

![](http://go-gyazo.appspot.com/798eab0cea48777d.png)

But the indicator is harder to look...
