### PR TITLE
Added ctrlp support

### DIFF
--- a/autoload/airline/themes/ctrlp.vim
+++ b/autoload/airline/themes/ctrlp.vim
@@ -1,0 +1,39 @@
+
+fu! airline#themes#ctrlp#load_ctrlp_hi() 
+  hi! CtrlPdark ctermfg=189 ctermbg=55 guifg=#d7d7ff guibg=#5f00af
+  hi! CtrlPlight ctermfg=231 ctermbg=98 guifg=#ffffff guibg=#875fd7
+  hi! CtrlPwhite ctermfg=55 ctermbg=231 term=bold guifg=#5f00af guibg=#ffffff gui=bold
+  hi! CtrlParrow1 ctermfg=98 ctermbg=231 guifg=#875fd7 guibg=#ffffff
+  hi! CtrlParrow2 ctermfg=231 ctermbg=98 guifg=#ffffff guibg=#875fd7
+  hi! CtrlParrow3 ctermfg=98 ctermbg=55 guifg=#875fd7 guibg=#5f00af
+  hi! CtrlParrow4 ctermfg=231 ctermbg=55 guifg=#ffffff guibg=#5f00af
+  hi! CtrlParrow5 ctermfg=98 ctermbg=231 guifg=#875fd7 guibg=#ffffff
+endf
+
+" Recreate Ctrl-P status line with some slight modifications
+
+" Arguments: focus, byfname, s:regexp, prv, item, nxt, marked
+" a:1 a:2 a:3 a:4 a:5 a:6 a:7
+fu! airline#themes#ctrlp#ctrlp_airline(...)
+  let regex = a:3 ? '%#CtrlPlight#  regex %*' : ''
+  let prv = '%#CtrlPlight# '.a:4.' %#Ctrlparrow1#'.g:airline_left_sep
+  let item = '%#CtrlPwhite# '.a:5.' %#CtrlParrow2#'.g:airline_left_sep
+  let nxt = '%#CtrlPlight# '.a:6.' %#CtrlParrow3#'.g:airline_left_sep
+  let marked = '%#CtrlPdark# '.a:7.' '
+  let focus = '%=%<%#CtrlPdark# '.a:1.' %*'
+  let byfname = '%#CtrlParrow4#'.g:airline_right_sep.'%#CtrlPdark# '.a:2.' %*'
+  let dir = '%#CtrlParrow3#'.g:airline_right_sep.'%#CtrlPlight# '.getcwd().' %*'
+  " Return the full statusline
+  retu regex.prv.item.nxt.marked.focus.byfname.dir
+endf
+
+" Argument: len
+" a:1
+fu! airline#themes#ctrlp#ctrlp_airline_status(...)
+  let len = '%#CtrlPwhite# '.a:1
+  let dir = '%=%<%#CtrlParrow5#'.g:airline_right_sep.'%#CtrlPlight# '.getcwd().' %*'
+  " Return the full statusline
+  retu len.dir
+endf
+
+

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -24,6 +24,15 @@ call s:check_defined('g:airline_exclude_filetypes', ['qf','netrw','diff','undotr
 let s:is_win32term = (has('win32') || has('win64')) && !has('gui_running')
 let s:load_the_theme = g:airline#themes#{g:airline_theme}#normal
 
+if exists('g:loaded_ctrlp') && g:loaded_ctrlp
+  call airline#themes#ctrlp#load_ctrlp_hi()
+  " ctrlp only looks for this
+  let g:ctrlp_status_func = {
+  \ 'main': 'airline#themes#ctrlp#ctrlp_airline',
+  \ 'prog': 'airline#themes#ctrlp#ctrlp_airline_status',
+  \ }
+endif
+
 call s:check_defined('g:airline_mode_map', {
       \ 'n'  : 'NORMAL',
       \ 'i'  : 'INSERT',


### PR DESCRIPTION
Styled things much like the traditional powerline. Should use user defined separators correctly. 

Preview:
![ctrlp-airline](https://f.cloud.github.com/assets/2935111/757327/589f5b94-e689-11e2-869b-a85f7c217116.png)
