### PR TITLE
Adding alternate separator for consistent visuals

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -96,16 +96,23 @@ function! airline#update_statusline(active)
   let sl.= a:active
         \ ? '%{airline#update_highlight()} '.s:get_section('a').' %{&paste ? g:airline_paste_symbol." " : ""}'
         \ : ' '.s:get_section('a').' %#Al9#'
-  let sl.=l:mode_sep_color.g:airline_left_sep.l:info_color
+  let sl.=l:mode_sep_color
+  let sl.=a:active ? g:airline_left_sep : g:airline_left_alt_sep
+  let sl.=l:info_color
   let sl.=' '.s:get_section('b').' '
-  let sl.=l:info_sep_color.g:airline_left_sep
+  let sl.=l:info_sep_color
+  let sl.=a:active ? g:airline_left_sep : g:airline_left_alt_sep
   let sl.=a:active ? l:status_color.' '.s:get_section('c').' ' : ' '.bufname(winbufnr(winnr()))
   let sl.='%#warningmsg#'.g:airline_externals_syntastic
   let sl.=l:status_color."%<%=".l:file_flag_color."%{&ro ? g:airline_readonly_symbol : ''}".l:status_color
   let sl.=' '.s:get_section('x').' '
-  let sl.=l:info_sep_color.g:airline_right_sep.l:info_color
+  let sl.=l:info_sep_color
+  let sl.=a:active ? g:airline_right_sep : g:airline_right_alt_sep
+  let sl.=l:info_color
   let sl.=' '.s:get_section('y').' '
-  let sl.=l:mode_sep_color.g:airline_right_sep.l:mode_color
+  let sl.=l:mode_sep_color
+  let sl.=a:active ? g:airline_right_sep : g:airline_right_alt_sep
+  let sl.=l:mode_color
   let sl.=' '.s:get_section('z').' '
   call setwinvar(winnr(), '&statusline', sl)
 endfunction

--- a/autoload/airline/extensions/ctrlp.vim
+++ b/autoload/airline/extensions/ctrlp.vim
@@ -22,7 +22,7 @@ function! airline#extensions#ctrlp#ctrlp_airline(...)
   let nxt = '%#CtrlPlight# '.a:6.' %#CtrlParrow3#'.g:airline_left_sep
   let marked = '%#CtrlPdark# '.a:7.' '
   let focus = '%=%<%#CtrlPdark# '.a:1.' %*'
-  let byfname = '%#CtrlParrow4#'.g:airline_right_sep.'%#CtrlPdark# '.a:2.' %*'
+  let byfname = '%#CtrlParrow4#'.g:airline_right_alt_sep.'%#CtrlPdark# '.a:2.' %*'
   let dir = '%#CtrlParrow3#'.g:airline_right_sep.'%#CtrlPlight# '.getcwd().' %*'
   " Return the full statusline
   return regex.prv.item.nxt.marked.focus.byfname.dir

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -9,7 +9,9 @@ function! s:check_defined(variable, default)
   endif
 endfunction
 call s:check_defined('g:airline_left_sep', exists('g:airline_powerline_fonts')?"":">")
+call s:check_defined('g:airline_left_alt_sep', exists('g:airline_powerline_fonts')?"":">")
 call s:check_defined('g:airline_right_sep', exists('g:airline_powerline_fonts')?"":"<")
+call s:check_defined('g:airline_right_alt_sep', exists('g:airline_powerline_fonts')?"":"<")
 call s:check_defined('g:airline_enable_bufferline', 1)
 call s:check_defined('g:airline_enable_fugitive', 1)
 call s:check_defined('g:airline_enable_syntastic', 1)


### PR DESCRIPTION
Some of the visuals were a bit off when switching between buffers or viewing ctrl-p results. I added an alternate separator for this.
