### PR TITLE
Completely overhauled solarized theme.

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -1,30 +1,31 @@
-let g:airline#themes#solarized#inactive = { 'mode': [ '#4e4e4e' , '#1c1c1c' , 239 , 234 , '' ] }
+let g:airline#themes#solarized#inactive = { 'mode': [ '#073642' , '#586e75' , 235 , 240 , '' ] }
 
 let s:N1 = [ '#fdf6e3' , '#657b83' , 230 , 241 ]
 let s:N2 = [ '#fdf6e3' , '#93a1a1' , 230 , 245 ]
 let s:N3 = [ '#657b83' , '#fdf6e3' , 241 , 230 ]
+let s:NM = {
+      \ 'info_separator': [ '#d33682' , '#fdf6e3' , 125     , 230     , ''     ] ,
+      \ 'statusline':     [ '#d33682' , '#fdf6e3' , 125     , 230     , ''     ] ,
+      \ }
 let g:airline#themes#solarized#normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
-let g:airline#themes#solarized#normal.file = [ '#ff0000' , '#1c1c1c' , 160 , 233 , '' ]
+let g:airline#themes#solarized#normal_modified = s:NM
+let g:airline#themes#solarized#normal.file = [ '#cb4b16' , s:N3[1] , 166 , s:N3[3] , '' ]
 
-let g:airline#themes#solarized#normal_modified = {
-      \ 'info_separator': [ '#444444' , '#5f005f' , 238     , 53      , ''     ] ,
-      \ 'statusline':     [ '#ffffff' , '#5f005f' , 255     , 53      , ''     ] ,
-      \ }
 
-let s:I1 = [ '#073642' , '#d33682' , 235 , 125 ]
-let s:I2 = [ '#073642' , '#268bd2' , 235 , 33  ]
-let s:I3 = [ '#073642' , '#2aa198' , 235 , 37  ]
-let g:airline#themes#solarized#insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
-let g:airline#themes#solarized#insert_modified = {
-      \ 'info_separator': [ '#005fff' , '#5f005f' , 27      , 53      , ''     ] ,
-      \ 'statusline':     [ '#ffffff' , '#5f005f' , 255     , 53      , ''     ] ,
-      \ }
+let s:I1 = [ '#fdf6e3' , '#2aa198' , 230 , 37  ]
+let g:airline#themes#solarized#insert = airline#themes#generate_color_map(s:I1, s:N2, s:N3)
+let g:airline#themes#solarized#insert_modified = s:NM
 
-let s:V1 = [ '#002b36' , '#b58900' , 234 , 136 ]
-let s:V2 = [ '#073642' , '#cb4b16' , 235 , 166 ]
-let s:V3 = [ '#fdf6e3' , '#dc322f' , 230 , 160 ]
-let g:airline#themes#solarized#visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
-let g:airline#themes#solarized#visual_modified = {
-      \ 'info_separator': [ '#ff5f00' , '#5f005f' , 202     , 53      , ''     ] ,
-      \ 'statusline':     [ '#ffffff' , '#5f005f' , 255     , 53      , ''     ] ,
-      \ }
+" I can't find how to customise the paste and replace colors without breaking
+" the modified color. If someone knows how they can modify this below.
+"let s:IP1 = [ s:I1[0] , '#268bd2' , s:I1[2] , 33 ]
+"let g:airline#themes#solarized#insert_paste = airline#themes#generate_color_map(s:IP1, s:I2, s:I3)
+"let g:airline#themes#solarized#insert_paste_modified = s:NM
+"let s:IR1 = [ s:I1[0] , '#859900' , s:I1[2] , 64 ]
+"let g:airline#themes#solarized#insert_replace = airline#themes#generate_color_map(s:IR1, s:I2, s:I3)
+"let g:airline#themes#solarized#insert_replace_modified = s:NM
+
+let s:V1 = [ '#fdf6e3' , '#6c71c4' , 230 , 61  ]
+let g:airline#themes#solarized#visual = airline#themes#generate_color_map(s:V1, s:N2, s:N3)
+let g:airline#themes#solarized#visual_modified = s:NM
+


### PR DESCRIPTION
Colours now remain the same in all modes except for the outer segment
backgrounds.
Less use of solarized accent colours as backgrounds.
Clearer window separator colours.
Refactored source.
Mode background colours are now closer to blue to contrast less
with the body text background.

![airlinesolarizedmockup](https://f.cloud.github.com/assets/378622/768607/8c09f644-e8a3-11e2-9f7d-f2deebe8cb14.png)
