### PR TITLE
Show unsaved changes in unfocused split

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -117,7 +117,7 @@ function! airline#update_statusline(active)
           \ ? s:get_section('gutter')
           \ : '%#warningmsg#'.g:airline_externals_syntastic.l:file_flag_color."%{&ro ? g:airline_readonly_symbol : ''}".l:status_color
   else
-    let sl.=' %f'
+    let sl.=' %f%m'
   endif
   if !exists('w:airline_left_only')
     let sl.='%= '.s:get_section('x').' '


### PR DESCRIPTION
This fixes #38, and the 3 extra characters shouldn't be a problem for #35 (I hope).

I don't know much of anything about vim-script, so if you've got a better way of doing this go for it.
