### PR TITLE
Solarized light

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -34,10 +34,11 @@ let s:c52     = {'t': 52,  'g': '#5f0000'}
 """"""""""""""""""""""""""""""""""""""""""""""""
 " Normal mode
 let s:N1 = [s:base2, s:blue, 'bold']
-let s:N2 = [s:base2, s:base01, '']
 if s:background == 'dark'
+    let s:N2 = [s:base2, s:base01, '']
     let s:N3 = [s:base1, s:base02, '']
 else
+    let s:N2 = [s:base2, s:base1, '']
     let s:N3 = [s:base00, s:base2, '']
 endif
 let s:NF = [s:orange, s:N3[1], '']


### PR DESCRIPTION
Update the solarized theme to look better with the solarized light theme, and also correct a typo in the blue definition. Based on [the vim colourscheme](https://github.com/altercation/vim-colors-solarized/blob/master/colors/solarized.vim#L98-115) it was previously incorrect.
