### PR TITLE
Set t_Co=256 forcely

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -105,6 +105,13 @@ values):
   let g:airline_exclude_preview = 0
 <
 
+* vim-airline set update t_Co to 256 forcely because background color won't
+ set correctly. If you have a problem for this update, please set below in
+ your vimrc.
+>
+  let g:airline_force_256color = 0
+<
+
 ==============================================================================
 COMMANDS                                                  *airline-commands*
 

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -92,3 +92,11 @@ augroup airline
   autocmd ShellCmdPost * call airline#update_externals()
   autocmd CursorMoved * call <sid>sync_active_winnr()
 augroup END
+
+" NOTE: airline set update t_Co to 256 forcely because background color won't
+" set correctly. If you have a problem for this update, please set below in
+" your vimrc.
+"   let g:airline_force_256color = 0
+if get(g:, 'airline_force_256color', 1)
+  set t_Co=256
+endif


### PR DESCRIPTION
I guess, most of users don't use 256 color environment, and vim-airline use background color with the numeric value that higher than 16. For example, my ubuntu box set t_Co to 8 in default. How about set t_Co=256 forcely?

When don't set t_Co=256 on gnome-terminal
![](http://go-gyazo.appspot.com/97f359ac9d60197f.png)

When set t_Co=256 on gnome-terminal
![](http://go-gyazo.appspot.com/a79c84baed07ed70.png)
