### PR TITLE
Reload the solarized airline theme on the Colorscheme event.

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -1,3 +1,4 @@
+function! s:generate()
 """"""""""""""""""""""""""""""""""""""""""""""""
 " Options
 """"""""""""""""""""""""""""""""""""""""""""""""
@@ -162,3 +163,10 @@ let g:airline#themes#solarized#visual_modified = {
             \ s:VM.info_separator[0].t, s:VM.info_separator[1].t, s:VM.info_separator[2]],
             \ 'statusline': [s:VM.statusline[0].g, s:VM.statusline[1].g,
             \ s:VM.statusline[0].t, s:VM.statusline[1].t, s:VM.statusline[2]]}
+endfunction
+
+call s:generate()
+augroup airline_solarized
+  autocmd!
+  autocmd ColorScheme * call <sid>generate() | call airline#reload_highlight()
+augroup END


### PR DESCRIPTION
I'm using the following command in my .vimrc to fire the Colorscheme autocommand, in addition to toggling the background.

``` vimscript
" Toggles the background color, and reloads the colorscheme.
command! ToggleBackground call <SID>ToggleBackground()
function! <SID>ToggleBackground()
    let &background = ( &background == "dark"? "light" : "dark" )
    if exists("g:colors_name")
        exe "colorscheme " . g:colors_name
    endif
endfunction
```
