### PR TITLE
Add et for detect right indent

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -24,7 +24,7 @@ function! airline#extensions#whitespace#check()
           let b:airline_whitespace_check .= 'trailing['.trailing.'] '
         endif
         if mixed
-          let mixnr = indents[0] == indents[1] ? indents[0] : indents[2]
+          let mixnr = indents[0] == indents[1] || !&et ? indents[0] : indents[2]
           let b:airline_whitespace_check .= 'mixed-indent['.mixnr.'] '
         endif
       endif


### PR DESCRIPTION
If file have many line with worng indent, then spaces
are considered correct indentation.
This is wrong if noexpandtab setup.
