### PR TITLE
Add autoload from autoload/airline/autoload_extensions/*.vim

### DIFF
--- a/autoload/airline/autoload_extensions/example.vim
+++ b/autoload/airline/autoload_extensions/example.vim
@@ -1,0 +1,36 @@
+" MIT License. Copyright (c) 2013 Bailey Ling.
+" vim: ts=2 sts=2 sw=2 fdm=indent
+
+" Extension specific variables can be defined the usual fashion.
+if !exists('g:airline#autoload_extensions#example#number_of_cats')
+  let g:airline#autoload_extensions#example#number_of_cats = 42
+endif
+
+
+function! airline#autoload_extensions#example#init()
+"   call a:ext.add_statusline_funcref(function('airline#extensions#example#apply'))
+"   let g:airline_section_y .= '%{airline#autoload_extensions#example#get_cats()}'
+endfunction
+
+function! airline#autoload_extensions#example#apply()
+  " Here we are checking for the filetype, allowing for the extension to
+  " be loaded only in certain cases.
+  if &filetype == "nyancat"
+
+    " Then we define a window-local variable, which overrides the default
+    " g: variable.
+    let w:airline_section_gutter =
+          \ g:airline_section_gutter
+          \ .' %{airline#autoload_extensions#example#get_cats()}'
+  endif
+endfunction
+
+" Finally, this function will be invoked from the statusline.
+function! airline#autoload_extensions#example#get_cats()
+  let cats = ''
+  for i in range(1, g:airline#autoload_extensions#example#number_of_cats)
+    let cats .= ' (,,,)=(^.^)=(,,,) '
+  endfor
+  return cats
+endfunction
+

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -181,6 +181,25 @@ function! airline#extensions#load()
     call airline#extensions#iminsert#init()
   endif
 
+
+  " Load autoload/airline/autoload_extensions/*.vim files
+  for file in split(globpath(&rtp, "autoload/airline/autoload_extensions/*.vim"), "\n")
+    source`=file`
+    let name = fnamemodify(file, ':t:r')
+
+    if !get(g:, 'airline#autoload_extensions#' . name . '#enabled', 1)
+      continue
+    endif
+
+    if exists('*airline#autoload_extensions#' . name . '#init')
+      call airline#autoload_extensions#{name}#init()
+    endif
+
+    if exists('*airline#autoload_extensions#' . name . '#apply')
+      call add(g:airline_statusline_funcrefs, function('airline#autoload_extensions#' . name . '#apply'))
+    endif
+  endfor
+
   call airline#util#exec_funcrefs(g:airline_statusline_funcrefs, 0)
 endfunction
 


### PR DESCRIPTION
Add autoload extensions files from autoload/airline/autoload_extensions/*.vim
It is possible to load the extensions from other plug-ins.
(e.g. https://github.com/osyo-manga/vim-anzu/blob/master/autoload/airline/autoload_extensions/anzu.vim

Are you interested in this kind of work?
