### PR TITLE
Don't use name 'vim-airline' to check loadable extensions.

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -10,6 +10,8 @@ function! s:ext.add_cursormove_funcref(funcref) dict
   call add(self._cursormove_funcrefs, a:funcref)
 endfunction
 
+let s:script_path = expand('<sfile>:p:h')
+
 let s:filetype_overrides = {
       \ 'netrw': [ 'netrw', '%f' ],
       \ 'unite': [ 'Unite', '%{unite#get_status_string()}' ],
@@ -183,7 +185,7 @@ function! airline#extensions#load()
 
   " load all other extensions not part of the default distribution
   for file in split(globpath(&rtp, "autoload/airline/extensions/*.vim"), '\n')
-    if match(fnamemodify(file, ':p'), '\vvim-airline(/|\\)autoload') < 0
+    if stridx(fnamemodify(file, ':p'), s:script_path) < 0
       let name = fnamemodify(file, ':t:r')
       if !get(g:, 'airline#extensions#'.name.'#enabled', 1)
         continue


### PR DESCRIPTION
Someone may git clone as another directory.
