### PR TITLE
Disable white space detection for unmodifiable buffers

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -19,7 +19,7 @@ let s:mixed_indent_format = get(g:, 'airline#extensions#whitespace#mixed_indent_
 let s:enabled = 1
 
 function! airline#extensions#whitespace#check()
-  if &readonly || !s:enabled
+  if &readonly || !&modifiable || !s:enabled
     return ''
   endif
 


### PR DESCRIPTION
I think it should be excluded.
