### PR TITLE
Include the quickfix title in the statusline

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -65,7 +65,7 @@ function! airline#extensions#apply(...)
 
   if &buftype == 'quickfix'
     let w:airline_section_a = '%q'
-    let w:airline_section_b = ''
+    let w:airline_section_b = '%{w:quickfix_title}'
     let w:airline_section_c = ''
     let w:airline_section_x = ''
   elseif &buftype == 'help'


### PR DESCRIPTION
The quickfix title often has useful information about how it was invoked. Include it in the statusline.

I like to see the grep or cscope query I executed (especially useful when there are no results).
