### PR TITLE
Minor improvements to help

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -19,7 +19,7 @@ FEATURES                                                  *airline-features*
 *  looks good with regular fonts, and provides configuration points so you
    can use unicode or powerline symbols.
 *  optimized for speed; it loads in under a millisecond.
-*  fully customizable; if you know a little |statusline| syntax you can
+*  fully customizable; if you know a little 'statusline' syntax you can
    tweak it to your needs.
 *  extremely easy to write themes.
 
@@ -116,7 +116,7 @@ COMMANDS                                                  *airline-commands*
   Toggles whitespace detection.
 
 :AirlineToggle                                              *:AirlineToggle*
-  Toggles between the standard `statusline`
+  Toggles between the standard 'statusline'
 
 ==============================================================================
 CUSTOMIZATION                                        *airline-customization*
@@ -347,7 +347,7 @@ virtualenv <https://github.com/jmcantrell/vim-virtualenv>
   let g:airline#extensions#tabline#right_sep = ''
   let g:airline#extensions#tabline#right_alt_sep = ''
 <
-Note: Enabling this extension will modify |showtabline| and |guioptions|.
+Note: Enabling this extension will modify 'showtabline' and 'guioptions'.
 
 ==============================================================================
 ADVANCED CUSTOMIZATION                      *airline-advanced-customization*
@@ -396,13 +396,13 @@ the space and cwd are not defined parts. For convenience, if a part of that
 key does not exist, it will be inserted as is. The unit tests will be a good
 resource for possibilities.
 
-Note: The use of `VimEnter` is important, because most extensions are lazily
+Note: The use of |VimEnter| is important, because most extensions are lazily
 loaded, so we must give them a chance to define their parts before we can use
 them.
 
 Note: The `airline#section#create` function and friends will do its best to
 create a section with the appropriate separators, but it only works for
-function and text parts. Special |statusline| items like %f or raw/undefined
+function and text parts. Special 'statusline' items like %f or raw/undefined
 parts will not work as it is not possible to inspect their widths/contents
 before rendering to the statusline.
 
@@ -492,15 +492,15 @@ WRITING EXTENSIONS                              *airline-writing-extensions*
 
 For contributions into the plugin, here are the following guidelines:
 
-1.  For simple |&filetype| checks, they can be added directly into the
+1.  For simple 'filetype' checks, they can be added directly into the
 `extensions.vim` file.
 
 2.  Pretty much everything else should live as a separate file under the
 `extensions/` directory.
 
   a.  Inside `extensions.vim`, add a check for some variable or command that
-      is always available (these must be defined in `plugin`, and _not_
-      `autoload` of the other plugin).  If it exists, then initialize the
+      is always available (these must be defined in `plugin/`, and _not_
+      `autoload/` of the other plugin).  If it exists, then initialize the
       extension. This ensures that the extension is loaded if and only if the
       user has the other plugin installed.  Also, a check to
       `airline#extensions#foo_plugin#enabled` should be performed to allow the
@@ -535,7 +535,7 @@ A. You need to set up your terminal correctly.  For more details, see
   set t_Co=256
 <
 Q. The statusline does not appear until I create a split.
-A. This is the default setting of |laststatus|.  If you want it to appear all
+A. This is the default setting of 'laststatus'.  If you want it to appear all
    the time, add the following to your vimrc: >
   set laststatus=2
 <


### PR DESCRIPTION
Fix a missing < that was messing with syntax.

Use the correct tagging syntax for options vs help topics.
