### PR TITLE
Add option to hide previous/next modes in ctrlp

### DIFF
--- a/autoload/airline/extensions/ctrlp.vim
+++ b/autoload/airline/extensions/ctrlp.vim
@@ -43,7 +43,12 @@ function! airline#extensions#ctrlp#ctrlp_airline(...)
   let focus = '%=%<%#CtrlPdark# '.a:1.' %*'
   let byfname = '%#CtrlParrow3#'.g:airline_right_alt_sep.'%#CtrlPdark# '.a:2.' %*'
   let dir = '%#CtrlParrow3#'.g:airline_right_sep.'%#CtrlPlight# '.getcwd().' %*'
-  return regex.prv.item.nxt.marked.focus.byfname.dir
+  if get(g:, 'airline#extensions#ctrlp#show_adjacent_modes', 1)
+    let modes = prv.item.nxt
+  else
+    let modes = item
+  endif
+  return regex.modes.marked.focus.byfname.dir
 endfunction
 
 " Argument: len

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -276,6 +276,11 @@ ctrlp <https://github.com/kien/ctrlp.vim>
   let g:airline#extensions#ctrlp#color_template = 'visual'
   let g:airline#extensions#ctrlp#color_template = 'replace'
 <
+
+* configure whether to show the previous and next modes (mru, buffer, etc...)
+>
+ let g:airline#extensions#ctrlp#show_adjacent_modes = 1
+<
 -------------------------------------                   *airline-virtualenv*
 virtualenv <https://github.com/jmcantrell/vim-virtualenv>
 


### PR DESCRIPTION
I don't like seeing the previous and next mode indicators in ctrlp. I find they add noise and make it hard to tell what the current mode and settings are (especially since they're the same colour as settings). Without airline, I can change the function that creates the status bar, but I can't see how to fix this without modifying airline. So I added an option.

New option airline#extensions#ctrlp#show_adjacent_modes allows users to
toggle showing the previous and next modes. The default is the same
behavior as before: show the modes.

Add documentation for new option.

These modes are useful if you switch forward and back through ctrlp's
functionality, but they are visual noise if you don't.
