### PR TITLE
Add tmuxline extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Lean &amp; mean status/tabline for vim that's light as air.
 # Features
 
 *  Tiny core written with extensibility in mind ([open/closed principle][8]).
-*  Integrates with a variety of plugins, including: [vim-bufferline][6], [fugitive][4], [unite][9], [ctrlp][10], [minibufexpl][15], [gundo][16], [undotree][17], [nerdtree][18], [tagbar][19], [vim-gitgutter][29], [vim-signify][30], [syntastic][5], [eclim][34], [lawrencium][21] and [virtualenv][31].
+*  Integrates with a variety of plugins, including: [vim-bufferline][6], [fugitive][4], [unite][9], [ctrlp][10], [minibufexpl][15], [gundo][16], [undotree][17], [nerdtree][18], [tagbar][19], [vim-gitgutter][29], [vim-signify][30], [syntastic][5], [eclim][34], [lawrencium][21], [virtualenv][31], [tmuxline][35].
 *  Looks good with regular fonts and provides configuration points so you can use unicode or powerline symbols.
 *  Optimized for speed; it loads in under a millisecond.
 *  Extensive suite of themes for popular colorschemes including [solarized][23] (dark and light), [tomorrow][24] (all variants), [base16][32] (all variants), [molokai][25], [jellybeans][26] and others; have a look at the [screenshots][14] in the wiki.
@@ -66,6 +66,9 @@ vim-airline integrates with a variety of plugins out of the box.  These extensio
 
 #### [virtualenv][31]
 ![image](https://f.cloud.github.com/assets/390964/1022566/cf81f830-0d98-11e3-904f-cf4fe3ce201e.png)
+
+#### [tmuxline][35]
+![image](https://f.cloud.github.com/assets/1532071/1559276/4c28fbac-4fc7-11e3-90ef-7e833d980f98.gif)
 
 ## Extras
 
@@ -197,3 +200,4 @@ MIT License. Copyright (c) 2013 Bailey Ling.
 [32]: https://github.com/chriskempson/base16-vim
 [33]: https://github.com/bling/vim-airline/wiki/Test-Plan
 [34]: http://eclim.org
+[35]: https://github.com/edkolev/tmuxline.vim

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -195,6 +195,10 @@ function! airline#extensions#load()
     call airline#extensions#tabline#init(s:ext)
   endif
 
+  if get(g:, 'airline#extensions#tmuxline#enabled', 1) && exists(':Tmuxline')
+    call airline#extensions#tmuxline#init(s:ext)
+  endif
+
   " load all other extensions not part of the default distribution
   for file in split(globpath(&rtp, "autoload/airline/extensions/*.vim"), "\n")
     " we have to check both resolved and unresolved paths, since it's possible

--- a/autoload/airline/extensions/tmuxline.vim
+++ b/autoload/airline/extensions/tmuxline.vim
@@ -1,0 +1,26 @@
+" MIT License. Copyright (c) 2013 Bailey Ling.
+" vim: et ts=2 sts=2 sw=2
+
+if !exists(':Tmuxline')
+  finish
+endif
+
+let s:tmuxline_snapshot_file = get(g:, 'airline#extensions#tmuxline#snapshot_file', '')
+let s:color_template = get(g:, 'airline#extensions#tmuxline#color_template', 'normal')
+
+function! airline#extensions#tmuxline#init(ext)
+  call a:ext.add_theme_func('airline#extensions#tmuxline#set_tmux_colors')
+endfunction
+
+function! airline#extensions#tmuxline#set_tmux_colors(palette)
+  let color_template = has_key(a:palette, s:color_template) ? s:color_template : 'normal'
+  let mode_palette = a:palette[color_template]
+
+  let tmuxline_theme = tmuxline#api#create_theme_from_airline(mode_palette)
+  call tmuxline#api#set_theme(tmuxline_theme)
+
+  if strlen(s:tmuxline_snapshot_file)
+    call tmuxline#api#snapshot(s:tmuxline_snapshot_file)
+  endif
+endfunction
+

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -423,6 +423,24 @@ eclim <https://eclim.org>
 <
 Note: Enabling this extension will modify 'showtabline' and 'guioptions'.
 
+-------------------------------------                    *airline-tmuxline*
+tmuxline <https://github.com/edkolev/tmuxline.vim>
+
+* enable/disable tmuxline integration >
+  let g:airline#extensions#tmuxline#enabled = 0
+<
+* configure which mode colors should be used in tmux statusline >
+  let airline#extensions#tmuxline#color_template = 'normal' (default)
+  let airline#extensions#tmuxline#color_template = 'insert'
+  let airline#extensions#tmuxline#color_template = 'visual'
+  let airline#extensions#tmuxline#color_template = 'replace'
+<
+* if specified, setting this option will trigger writing to the file whenever the
+  airline theme is applied, i.e. when :AirlineTheme is executed and on vim
+  startup >
+  airline#extensions#tmuxline#snapshot_file = "~/.tmux-statusline-colors.conf"
+<
+
 ==============================================================================
 ADVANCED CUSTOMIZATION                      *airline-advanced-customization*
 


### PR DESCRIPTION
As discussed, I've used `add_theme_func` to hook up to `:AirlineTheme`. Nice :)

However, I'm not sure if this extension is ready to be merged into airline just yet:
- tmuxline.vim still lacks a `doc/tmuxline.vim` file (will write it within the next few days)
- tmuxline.vim probably has some bugs lurking around (I've tested it on latest vim + latest tmux + latest iterm2 only)

Let me know if you have some ideas on how tmux integration can be improved.

Showcase:
![tmuxline-showcase](https://f.cloud.github.com/assets/1532071/1559276/4c28fbac-4fc7-11e3-90ef-7e833d980f98.gif)

Refs #345
