### PR TITLE
Correct quickfix window detection pattern

### DIFF
--- a/autoload/airline/extensions/quickfix.vim
+++ b/autoload/airline/extensions/quickfix.vim
@@ -24,7 +24,7 @@ function! s:get_text()
 
   let nr = bufnr('%')
   for buf in split(buffers, '\n')
-    if match(buf, '\v^\s+'.nr) > -1
+    if match(buf, '\v^\s*'.nr) > -1
       if match(buf, '\[Quickfix List\]') > -1
         return g:airline#extensions#quickfix#quickfix_text
       else


### PR DESCRIPTION
I stole this code for my own personal use and ran into some cases where the pattern wasn't matching. I took a look at it and noticed a `\s+` where there ought to have been a `\s*` match. It fixed the issue for me, so I offer the fix back to the source.
