### PR TITLE
Add null accent, to allow accents to be removed

### DIFF
--- a/autoload/airline/themes.vim
+++ b/autoload/airline/themes.vim
@@ -42,6 +42,7 @@ function! airline#themes#patch(palette)
   endfor
 
   let a:palette.accents = get(a:palette, 'accents', {})
+  let a:palette.accents.none = [ '', '', '', '', '' ]
   let a:palette.accents.bold = [ '', '', '', '', 'bold' ]
   let a:palette.accents.italic = [ '', '', '', '', 'italic' ]
 


### PR DESCRIPTION
This allows one to disable, for example, the default bold accents, from within .vimrc without having to redefine all the relevant parts/sections:
```
call airline#parts#define_accent('mode', 'none')
```