### PR TITLE
Fixed a weird character drawing problem that happens

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -24,6 +24,7 @@ function! s:init()
       call airline#switch_theme(g:airline_theme)
     endif
   endif
+  redraw
 endfunction
 
 function! s:on_window_changed()


### PR DESCRIPTION
I added a redraw call after airline is initialized.  This avoids a problem where the character string ^[[>1;3400;0c or similar random looking character strings show up on the end of the last line in the file.

This also only happens maybe once every 10 times vim is started.  But with this change it doesn't seem to happen at all.