### PR TITLE
Improve jellybeans theme

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -22,10 +22,11 @@ function! s:get_syn(group, what)
     let color = synIDattr(synIDtrans(hlID('Normal')), a:what, mode)
   endif
   if empty(color) || color == -1
+    let darkattr = &background == 'dark' ? 'bg' : 'fg'
     if has('gui_running')
-      let color = a:what ==# 'fg' ? '#000000' : '#FFFFFF'
+      let color = a:what ==# darkattr ? '#000000' : '#FFFFFF'
     else
-      let color = a:what ==# 'fg' ? 0 : 1
+      let color = a:what ==# darkattr ? '0' : '15'
     endif
   endif
   return color

--- a/autoload/airline/themes.vim
+++ b/autoload/airline/themes.vim
@@ -34,6 +34,10 @@ function! airline#themes#get_highlight2(fg, bg, ...)
   return call('airline#highlighter#get_highlight2', [a:fg, a:bg] + a:000)
 endfunction
 
+function! airline#themes#get_highlight_reverse(group, ...)
+  return call('airline#themes#get_highlight2', [[a:group, 'bg'], [a:group, 'fg']] + a:000)
+endfunction
+
 function! airline#themes#patch(palette)
   for mode in keys(a:palette)
     if !has_key(a:palette[mode], 'airline_warning')

--- a/autoload/airline/themes/jellybeans.vim
+++ b/autoload/airline/themes/jellybeans.vim
@@ -19,7 +19,6 @@ function! airline#themes#jellybeans#refresh()
   " is very minimalistic. If you are a jellybeans user and want to make updates,
   " please send pull requests.
 
-  " And of course, you can always do it manually as well.
   let s:warn = s:get_highlight('ErrorMsg')
 
   let s:N1 = s:get_highlight_inverse('Statement')

--- a/autoload/airline/themes/jellybeans.vim
+++ b/autoload/airline/themes/jellybeans.vim
@@ -1,17 +1,5 @@
 let g:airline#themes#jellybeans#palette = {}
 
-" Here are examples where the entire highlight group is copied and an airline
-" compatible color array is generated.
-function! s:get_highlight(group)
-  return airline#themes#get_highlight(a:group)
-endfunction
-
-" Sometimes you want to mix and match colors from different groups, you can do
-" that with this method.
-function! s:get_highlight_inverse(group)
-  return airline#themes#get_highlight2([a:group, 'bg'], [a:group, 'fg'])
-endfunction
-
 " The name of the function must be 'refresh'.
 function! airline#themes#jellybeans#refresh()
   " This theme is an example of how to use helper functions to extract highlight
@@ -19,38 +7,38 @@ function! airline#themes#jellybeans#refresh()
   " is very minimalistic. If you are a jellybeans user and want to make updates,
   " please send pull requests.
 
-  let s:warn = s:get_highlight('ErrorMsg')
+  let s:warn = airline#themes#get_highlight('ErrorMsg')
 
-  let s:N1 = s:get_highlight_inverse('Statement')
-  let s:N2 = s:get_highlight('StatusLine')
-  let s:N3 = s:get_highlight('NonText')
+  let s:N1 = airline#themes#get_highlight_reverse('Statement')
+  let s:N2 = airline#themes#get_highlight('StatusLine')
+  let s:N3 = airline#themes#get_highlight('NonText')
 
   let g:airline#themes#jellybeans#palette.accents = {
-        \ 'red': s:get_highlight('Constant'),
+        \ 'red': airline#themes#get_highlight('Constant'),
         \ }
 
   let g:airline#themes#jellybeans#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
   let g:airline#themes#jellybeans#palette.normal.airline_warning = s:warn
   let g:airline#themes#jellybeans#palette.normal_modified = {
-        \ 'airline_c': s:get_highlight('Type'),
+        \ 'airline_c': airline#themes#get_highlight2(['Type', 'fg'], ['NonText', 'bg']),
         \ 'airline_warning': s:warn }
 
-  let s:I = s:get_highlight_inverse('Type')
+  let s:I = airline#themes#get_highlight_reverse('Type')
   let g:airline#themes#jellybeans#palette.insert = airline#themes#generate_color_map(s:I, s:N2, s:N3)
   let g:airline#themes#jellybeans#palette.insert.airline_warning = g:airline#themes#jellybeans#palette.normal.airline_warning
   let g:airline#themes#jellybeans#palette.insert_modified = g:airline#themes#jellybeans#palette.normal_modified
 
-  let s:R = s:get_highlight_inverse('Constant')
+  let s:R = airline#themes#get_highlight_reverse('Constant')
   let g:airline#themes#jellybeans#palette.replace = airline#themes#generate_color_map(s:R, s:N2, s:N3)
   let g:airline#themes#jellybeans#palette.replace.airline_warning = g:airline#themes#jellybeans#palette.normal.airline_warning
   let g:airline#themes#jellybeans#palette.replace_modified = g:airline#themes#jellybeans#palette.normal_modified
 
-  let s:V = s:get_highlight_inverse('Identifier')
+  let s:V = airline#themes#get_highlight_reverse('Identifier')
   let g:airline#themes#jellybeans#palette.visual = airline#themes#generate_color_map(s:V, s:N2, s:N3)
   let g:airline#themes#jellybeans#palette.visual.airline_warning = g:airline#themes#jellybeans#palette.normal.airline_warning
   let g:airline#themes#jellybeans#palette.visual_modified = g:airline#themes#jellybeans#palette.normal_modified
 
-  let s:N2 = s:get_highlight('StatusLineNC')
+  let s:N2 = airline#themes#get_highlight('StatusLineNC')
   let g:airline#themes#jellybeans#palette.inactive = airline#themes#generate_color_map(s:N2, s:N2, s:N3)
   let g:airline#themes#jellybeans#palette.inactive_modified = g:airline#themes#jellybeans#palette.normal_modified
 endfunction

--- a/autoload/airline/themes/jellybeans.vim
+++ b/autoload/airline/themes/jellybeans.vim
@@ -1,5 +1,17 @@
 let g:airline#themes#jellybeans#palette = {}
 
+" Here are examples where the entire highlight group is copied and an airline
+" compatible color array is generated.
+function! s:get_highlight(group)
+  return airline#themes#get_highlight(a:group)
+endfunction
+
+" Sometimes you want to mix and match colors from different groups, you can do
+" that with this method.
+function! s:get_highlight_inverse(group)
+  return airline#themes#get_highlight2([a:group, 'bg'], [a:group, 'fg'])
+endfunction
+
 " The name of the function must be 'refresh'.
 function! airline#themes#jellybeans#refresh()
   " This theme is an example of how to use helper functions to extract highlight
@@ -7,44 +19,40 @@ function! airline#themes#jellybeans#refresh()
   " is very minimalistic. If you are a jellybeans user and want to make updates,
   " please send pull requests.
 
-  " Here are examples where the entire highlight group is copied and an airline
-  " compatible color array is generated.
-  let s:N1 = airline#themes#get_highlight('DbgCurrent', 'bold')
-  let s:N2 = airline#themes#get_highlight('Folded')
-  let s:N3 = airline#themes#get_highlight('NonText')
+  " And of course, you can always do it manually as well.
+  let s:warn = s:get_highlight('ErrorMsg')
+
+  let s:N1 = s:get_highlight_inverse('Statement')
+  let s:N2 = s:get_highlight('StatusLine')
+  let s:N3 = s:get_highlight('NonText')
 
   let g:airline#themes#jellybeans#palette.accents = {
-        \ 'red': airline#themes#get_highlight('Constant'),
+        \ 'red': s:get_highlight('Constant'),
         \ }
 
   let g:airline#themes#jellybeans#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
+  let g:airline#themes#jellybeans#palette.normal.airline_warning = s:warn
   let g:airline#themes#jellybeans#palette.normal_modified = {
-        \ 'airline_c': [ '#ffb964', '', 215, '', '' ]
-        \ }
+        \ 'airline_c': s:get_highlight('Type'),
+        \ 'airline_warning': s:warn }
 
-  let s:I1 = airline#themes#get_highlight('DiffAdd', 'bold')
-  let s:I2 = s:N2
-  let s:I3 = s:N3
-  let g:airline#themes#jellybeans#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+  let s:I = s:get_highlight_inverse('Type')
+  let g:airline#themes#jellybeans#palette.insert = airline#themes#generate_color_map(s:I, s:N2, s:N3)
+  let g:airline#themes#jellybeans#palette.insert.airline_warning = g:airline#themes#jellybeans#palette.normal.airline_warning
   let g:airline#themes#jellybeans#palette.insert_modified = g:airline#themes#jellybeans#palette.normal_modified
 
-  let s:R1 = airline#themes#get_highlight('WildMenu', 'bold')
-  let s:R2 = s:N2
-  let s:R3 = s:N3
-  let g:airline#themes#jellybeans#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
+  let s:R = s:get_highlight_inverse('Constant')
+  let g:airline#themes#jellybeans#palette.replace = airline#themes#generate_color_map(s:R, s:N2, s:N3)
+  let g:airline#themes#jellybeans#palette.replace.airline_warning = g:airline#themes#jellybeans#palette.normal.airline_warning
   let g:airline#themes#jellybeans#palette.replace_modified = g:airline#themes#jellybeans#palette.normal_modified
 
-  " Sometimes you want to mix and match colors from different groups, you can do
-  " that with this method.
-  let s:V1 = airline#themes#get_highlight2(['TabLineSel', 'bg'], ['DiffDelete', 'bg'], 'bold')
-  let s:V2 = s:N2
-  let s:V3 = s:N3
-  let g:airline#themes#jellybeans#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
+  let s:V = s:get_highlight_inverse('Identifier')
+  let g:airline#themes#jellybeans#palette.visual = airline#themes#generate_color_map(s:V, s:N2, s:N3)
+  let g:airline#themes#jellybeans#palette.visual.airline_warning = g:airline#themes#jellybeans#palette.normal.airline_warning
   let g:airline#themes#jellybeans#palette.visual_modified = g:airline#themes#jellybeans#palette.normal_modified
 
-  " And of course, you can always do it manually as well.
-  let s:IA = [ '#444444', '#1c1c1c', 237, 234 ]
-  let g:airline#themes#jellybeans#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
+  let s:N2 = s:get_highlight('StatusLineNC')
+  let g:airline#themes#jellybeans#palette.inactive = airline#themes#generate_color_map(s:N2, s:N2, s:N3)
   let g:airline#themes#jellybeans#palette.inactive_modified = g:airline#themes#jellybeans#palette.normal_modified
 endfunction
 

--- a/t/themes.vim
+++ b/t/themes.vim
@@ -11,12 +11,51 @@ describe 'themes'
     Expect colors[3] == '2'
   end
 
+  it 'should extract reversed colors'
+    highlight Foo ctermfg=1 ctermbg=2
+    let colors = airline#themes#get_highlight_reverse('Foo')
+    Expect colors[2] == '2'
+    Expect colors[3] == '1'
+  end
+
   it 'should extract from normal if colors unavailable'
     highlight Normal ctermfg=100 ctermbg=200
     highlight Foo ctermbg=2
     let colors = airline#themes#get_highlight('Foo')
     Expect colors[2] == '100'
     Expect colors[3] == '2'
+  end
+
+  it 'should return default light fg if normal unavailable'
+    set background=light
+    highlight Foo ctermbg=2
+    let colors = airline#themes#get_highlight('Foo')
+    Expect colors[2] == '0'
+    Expect colors[3] == '2'
+  end
+
+  it 'should return default light bg if normal unavailable'
+    set background=light
+    highlight Foo ctermfg=2
+    let colors = airline#themes#get_highlight('Foo')
+    Expect colors[2] == '2'
+    Expect colors[3] == '15'
+  end
+
+  it 'should return default dark fg if normal unavailable'
+    set background=dark
+    highlight Foo ctermbg=2
+    let colors = airline#themes#get_highlight('Foo')
+    Expect colors[2] == '15'
+    Expect colors[3] == '2'
+  end
+
+  it 'should return default dark bg if normal unavailable'
+    set background=dark
+    highlight Foo ctermfg=2
+    let colors = airline#themes#get_highlight('Foo')
+    Expect colors[2] == '2'
+    Expect colors[3] == '0'
   end
 
   it 'should flip target group if it is reversed'
@@ -27,11 +66,16 @@ describe 'themes'
   end
 
   it 'should pass args through correctly'
+    highlight Foo ctermfg=1 ctermbg=2
+
     let hl = airline#themes#get_highlight('Foo', 'bold', 'italic')
-    Expect hl == ['', '', 0, 1, 'bold,italic']
+    Expect hl == ['', '', '1', '2', 'bold,italic']
 
     let hl = airline#themes#get_highlight2(['Foo','bg'], ['Foo','fg'], 'italic', 'bold')
-    Expect hl == ['', '', 1, 0, 'italic,bold']
+    Expect hl == ['', '', '2', '1', 'italic,bold']
+
+    let hl = airline#themes#get_highlight_reverse('Foo', 'italic', 'bold')
+    Expect hl == ['', '', '2', '1', 'italic,bold']
   end
 
   it 'should generate color map with mirroring'


### PR DESCRIPTION
This change uses colorscheme-defined StatusLine and StatusLineNC, so if you customise them the theme still makes sense.

Also, fix the default cterm colours for dark backgrounds; all foregrounds were defaulting to dark blue, which made a mess of the 16-colour terminals.