### PR TITLE
Prompt extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ vim-airline integrates with a variety of plugins out of the box.  These extensio
 #### [tmuxline][35]
 ![image](https://f.cloud.github.com/assets/1532071/1559276/4c28fbac-4fc7-11e3-90ef-7e833d980f98.gif)
 
+#### [promptline][36]
+![airline-promptline-sc](https://f.cloud.github.com/assets/1532071/1871900/7d4b28a0-789d-11e3-90e4-16f37269981b.gif)
+
 ## Extras
 
 vim-airline also supplies some supplementary stand-alone extensions.  In addition to the tabline extension mentioned earlier, there is also:
@@ -204,3 +207,4 @@ MIT License. Copyright (c) 2013 Bailey Ling.
 [33]: https://github.com/bling/vim-airline/wiki/Test-Plan
 [34]: http://eclim.org
 [35]: https://github.com/edkolev/tmuxline.vim
+[36]: https://github.com/edkolev/promptline.vim

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -199,6 +199,10 @@ function! airline#extensions#load()
     call airline#extensions#tmuxline#init(s:ext)
   endif
 
+  if get(g:, 'airline#extensions#promptline#enabled', 1) && exists(':PromptlineSnapshot') && len(get(g:, 'airline#extensions#promptline#snapshot_file', ''))
+    call airline#extensions#promptline#init(s:ext)
+  endif
+
   " load all other extensions not part of the default distribution
   for file in split(globpath(&rtp, "autoload/airline/extensions/*.vim"), "\n")
     " we have to check both resolved and unresolved paths, since it's possible

--- a/autoload/airline/extensions/promptline.vim
+++ b/autoload/airline/extensions/promptline.vim
@@ -1,0 +1,34 @@
+
+" MIT License. Copyright (c) 2013 Bailey Ling.
+" vim: et ts=2 sts=2 sw=2
+
+if !exists(':PromptlineSnapshot')
+  finish
+endif
+
+if !exists('airline#extensions#promptline#snapshot_file') || !len('airline#extensions#promptline#snapshot_file')
+  finish
+endif
+
+let s:prompt_snapshot_file = get(g:, 'airline#extensions#promptline#snapshot_file', '')
+let s:color_template = get(g:, 'airline#extensions#promptline#color_template', 'normal')
+
+function! airline#extensions#promptline#init(ext)
+  call a:ext.add_theme_func('airline#extensions#promptline#set_prompt_colors')
+endfunction
+
+function! airline#extensions#promptline#set_prompt_colors(palette)
+  let color_template = has_key(a:palette, s:color_template) ? s:color_template : 'normal'
+  let mode_palette = a:palette[color_template]
+
+  if !has_key(g:, 'promptline_symbols')
+    let g:promptline_symbols = {
+          \ 'left'           : g:airline_left_sep,
+          \ 'right'          : g:airline_right_sep,
+          \ 'left_alt'       : g:airline_left_alt_sep,
+          \ 'right_alt'      : g:airline_right_alt_sep}
+  endif
+
+  let promptline_theme = promptline#api#create_theme_from_airline(mode_palette)
+  call promptline#api#create_snapshot_with_theme(s:prompt_snapshot_file, promptline_theme)
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -433,7 +433,7 @@ eclim <https://eclim.org>
 <
 Note: Enabling this extension will modify 'showtabline' and 'guioptions'.
 
--------------------------------------                    *airline-tmuxline*
+-------------------------------------                     *airline-tmuxline*
 tmuxline <https://github.com/edkolev/tmuxline.vim>
 
 * enable/disable tmuxline integration >
@@ -449,6 +449,26 @@ tmuxline <https://github.com/edkolev/tmuxline.vim>
   airline theme is applied, i.e. when :AirlineTheme is executed and on vim
   startup >
   airline#extensions#tmuxline#snapshot_file = "~/.tmux-statusline-colors.conf"
+<
+-------------------------------------                   *airline-promptline*
+promptline <https://github.com/edkolev/promptline.vim>
+
+* configure the path to the snapshot .sh file. Mandatory option. The created
+  file should be sourced by the shell on login >
+  " in .vimrc
+  airline#extensions#promptline#snapshot_file = "~/.shell_prompt.sh"
+
+  " in .bashrc/.zshrc
+  [ -f ~/.shell_prompt.sh ] && source ~/.shell_prompt.sh
+<
+* enable/disable promptline integration >
+  let g:airline#extensions#promptline#enabled = 0
+<
+* configure which mode colors should be used in prompt >
+  let airline#extensions#promptline#color_template = 'normal' (default)
+  let airline#extensions#promptline#color_template = 'insert'
+  let airline#extensions#promptline#color_template = 'visual'
+  let airline#extensions#promptline#color_template = 'replace'
 <
 
 ==============================================================================


### PR DESCRIPTION
As discussed in #389, this is the airline-promptline extension. Please let me know if you think the code can be improved.

This is how it works:
- whenever `add_theme_func`-registered functions are executed, this extension calls `promptline#api#create_snapshot_with_theme(file, theme)`
- `promptline#api#create_snapshot_with_theme(..)` creates a shell file which should be sourced on shell login

Currently, the end-user has to set `airline#extensions#promptline#snapshot_file`, otherwise this extension will not be enabled.

Also, please don't merge the PR yet. I still have to create a showcase png/giff for the README

I'm open for any suggestions for improvement :)
