### PR TITLE
solarized: use VertSplit bg for inactive statusline

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -47,9 +47,11 @@ function! airline#themes#solarized#refresh()
   let s:NF = [s:orange, s:N3[1], '']
   let s:NW = [s:base3, s:orange, '']
   if s:background == 'dark'
-    let s:NM = [s:base2, s:N3[1], '']
+    let s:NM = [s:base1, s:N3[1], '']
+    let s:NMi = [s:base2, s:N3[1], '']
   else
-    let s:NM = [s:base02, s:N3[1], '']
+    let s:NM = [s:base01, s:N3[1], '']
+    let s:NMi = [s:base02, s:N3[1], '']
   endif
 
   " Insert mode
@@ -99,7 +101,7 @@ function! airline#themes#solarized#refresh()
         \ [s:IA[0].g, s:IA[1].g, s:IA[0].t, s:IA[1].t, s:IA[2]],
         \ [s:IA[0].g, s:IA[1].g, s:IA[0].t, s:IA[1].t, s:IA[2]])
   let g:airline#themes#solarized#palette.inactive_modified = {
-        \ 'airline_c': [s:NM[0].g, '', s:NM[0].t, '', s:NM[2]]}
+        \ 'airline_c': [s:NMi[0].g, '', s:NMi[0].t, '', s:NMi[2]]}
 
   let g:airline#themes#solarized#palette.normal = airline#themes#generate_color_map(
         \ [s:N1[0].g, s:N1[1].g, s:N1[0].t, s:N1[1].t, s:N1[2]],


### PR DESCRIPTION
Adjust foreground color accordingly, also for non-active modified
filename (to stand out).

The intention is to have the same bg color for vertical and horizontal dividers.
Without this change, the horizontal divider for non-active windows has the same bg color as folds or the cursorline, which is hard on the eye.
