### PR TITLE
Added fontpatcher with new glyph codes.

### DIFF
--- a/fontpatcher/PowerlineSymbols.sfd
+++ b/fontpatcher/PowerlineSymbols.sfd
@@ -1,0 +1,216 @@
+SplineFontDB: 3.0
+FontName: Untitled1
+FullName: Untitled1
+FamilyName: Untitled1
+Weight: Medium
+Copyright: Created by Mihai Felseghi,,, with FontForge 2.0 (http://fontforge.sf.net)
+UComments: "2014-1-22: Created." 
+Version: 001.000
+ItalicAngle: 0
+UnderlinePosition: -100
+UnderlineWidth: 50
+Ascent: 800
+Descent: 200
+LayerCount: 2
+Layer: 0 0 "Back"  1
+Layer: 1 0 "Fore"  0
+XUID: [1021 271 1097878288 7980861]
+OS2Version: 0
+OS2_WeightWidthSlopeOnly: 0
+OS2_UseTypoMetrics: 1
+CreationTime: 1390396355
+ModificationTime: 1390396559
+OS2TypoAscent: 0
+OS2TypoAOffset: 1
+OS2TypoDescent: 0
+OS2TypoDOffset: 1
+OS2TypoLinegap: 0
+OS2WinAscent: 0
+OS2WinAOffset: 1
+OS2WinDescent: 0
+OS2WinDOffset: 1
+HheadAscent: 0
+HheadAOffset: 1
+HheadDescent: 0
+HheadDOffset: 1
+OS2Vendor: 'PfEd'
+DEI: 91125
+Encoding: UnicodeFull
+UnicodeInterp: none
+NameList: Adobe Glyph List
+DisplaySize: -24
+AntiAlias: 1
+FitToEm: 1
+WinInfo: 57424 74 22
+BeginChars: 1114112 7
+
+StartChar: uniE0A0
+Encoding: 57504 57504 0
+Width: 517
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+208 -178 m 1
+ 73 -178 l 1
+ 73 57 l 2
+ 73 115 86 163 112 200 c 0
+ 130 226 157 251 194 275 c 2
+ 269 323 l 2
+ 298 342 318 365 331 391 c 0
+ 344 417 350 451 350 493 c 2
+ 350 654 l 1
+ 248 654 l 1
+ 391 821 l 1
+ 533 654 l 1
+ 431 654 l 1
+ 431 466 l 2
+ 431 404 422 355 405 322 c 0
+ 388 289 362 261 327 238 c 2
+ 290 213 l 2
+ 260 193 239 174 228 153 c 0
+ 215 130 208 98 208 57 c 2
+ 208 -178 l 1
+208 400 m 1
+ 73 313 l 1
+ 73 952 l 1
+ 208 952 l 1
+ 208 400 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniE0A1
+Encoding: 57505 57505 1
+Width: 517
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+342 470 m 1
+ 342 406 l 1
+ 95 406 l 1
+ 95 845 l 1
+ 170 845 l 1
+ 170 470 l 1
+ 342 470 l 1
+345 366 m 1
+ 422 366 l 1
+ 422 -73 l 1
+ 341 -73 l 1
+ 221 212 l 1
+ 230 22 l 1
+ 230 -73 l 1
+ 154 -73 l 1
+ 154 366 l 1
+ 234 366 l 1
+ 355 80 l 1
+ 345 289 l 1
+ 345 366 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniE0A2
+Encoding: 57506 57506 2
+Width: 517
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+129 0 m 2
+ 83 0 61 23 61 69 c 2
+ 61 405 l 2
+ 61 454 81 479 120 479 c 1
+ 120 628 l 2
+ 120 673 134 710 161 740 c 0
+ 187 768 220 782 259 782 c 0
+ 298 782 331 768 357 740 c 0
+ 384 710 398 673 398 628 c 2
+ 398 479 l 1
+ 437 479 457 454 457 405 c 2
+ 457 69 l 2
+ 457 23 434 0 388 0 c 2
+ 129 0 l 2
+259 719 m 0
+ 237 719 219 710 206 694 c 0
+ 193 678 187 656 187 628 c 2
+ 187 479 l 1
+ 331 479 l 1
+ 331 628 l 2
+ 331 656 324 678 311 694 c 0
+ 298 710 281 719 259 719 c 0
+286 115 m 1
+ 286 273 l 1
+ 308 284 319 302 319 327 c 0
+ 319 344 314 358 302 370 c 0
+ 290 382 276 388 259 388 c 0
+ 242 388 228 382 216 370 c 0
+ 204 358 198 344 198 327 c 0
+ 198 302 209 284 231 273 c 1
+ 231 115 l 1
+ 286 115 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniE0B0
+Encoding: 57520 57520 3
+Width: 517
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+0 952 m 1
+ 518 385 l 1
+ 0 -183 l 1
+ 0 952 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniE0B1
+Encoding: 57521 57521 4
+Width: 517
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+-28 885 m 1
+ 19 931 l 1
+ 518 385 l 1
+ 19 -162 l 1
+ -28 -115 l 1
+ 427 385 l 1
+ -28 885 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniE0B2
+Encoding: 57522 57522 5
+Width: 517
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+518 -183 m 1
+ 0 385 l 1
+ 518 952 l 1
+ 518 -183 l 1
+EndSplineSet
+EndChar
+
+StartChar: uniE0B3
+Encoding: 57523 57523 6
+Width: 517
+Flags: HW
+LayerCount: 2
+Fore
+SplineSet
+90 385 m 1
+ 545 -115 l 1
+ 499 -162 l 1
+ 0 385 l 1
+ 499 931 l 1
+ 545 885 l 1
+ 90 385 l 1
+EndSplineSet
+EndChar
+EndChars
+EndSplineFont

--- a/fontpatcher/fontpatcher
+++ b/fontpatcher/fontpatcher
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+
+"""Font patcher for Powerline.
+
+Creates dividers and symbols for use with Powerline. Requires FontForge with Python bindings.
+
+Stores glyphs in the 2b60-2bff Unicode range ("Misc symbols and arrows").
+
+[e0a0] Branch symbol
+[e0a1] LN (line) symbol
+[e0a2] Padlock (closed) symbol
+[e0b0] Hard right arrow
+[e0b1] Soft right arrow
+[e0b2] Hard left arrow
+[e0b3] Soft left arrow
+"""
+
+from __future__ import division
+
+import argparse
+import os
+import sys
+import re
+
+try:
+	import fontforge
+	import psMat
+except ImportError:
+	sys.stderr.write('The required FontForge modules could not be loaded.\n\n')
+
+	if sys.version_info.major > 2:
+		sys.stderr.write('FontForge only supports Python 2. Please run this script with the Python 2 executable - e.g. "python2 {0}"\n'.format(sys.argv[0]))
+	else:
+		sys.stderr.write('You need FontForge with Python bindings for this script to work.\n')
+
+	sys.exit(1)
+
+# Handle command-line arguments
+parser = argparse.ArgumentParser(description='Font patcher for Powerline. Creates dividers and symbols in FontForge-compatible font files. Requires FontForge with Python bindings. Stores glyphs in the U+2B80-U+2BFF range ("Miscellaneous symbols and arrows"). Stores the patched font as a new, renamed font file by default.')
+
+parser.add_argument('fonts', help='font file to patch', metavar='font', nargs='+')
+parser.add_argument('--no-rename', help='don\'t add " for Powerline" to the font name', default=True, action='store_false', dest='rename')
+parser.add_argument('--symbol-font', help='font file with symbols', metavar='font', dest='symbol_font', default='{0}/PowerlineSymbols.sfd'.format(sys.path[0]))
+parser.add_argument('--fix-mono', help='fixes some mono-fonts which have glyphs of 0 widths', default=False, action='store_true', dest='fixmono')
+parser.add_argument('--fix-win', help='modifies font names such that Windows correctly recognizes font families', default=False, action='store_true', dest='fixwin')
+
+args = parser.parse_args()
+
+SYM_ATTR = {
+	# Right/left-aligned glyphs will have their advance width reduced in order to overlap the next glyph slightly
+	0xe0a0: { 'align': 'c', 'stretch': 'y' , 'overlap': False },
+	0xe0a1: { 'align': 'c', 'stretch': ''  , 'overlap': False },
+	0xe0a2: { 'align': 'c', 'stretch': ''  , 'overlap': False },
+	0xe0b0: { 'align': 'l', 'stretch': 'xy', 'overlap': True  },
+	0xe0b1: { 'align': 'l', 'stretch': 'xy', 'overlap': True  },
+	0xe0b2: { 'align': 'r', 'stretch': 'xy', 'overlap': True  },
+	0xe0b3: { 'align': 'r', 'stretch': 'xy', 'overlap': True  },
+}
+
+# Open symbol font
+try:
+	symbols = fontforge.open(args.symbol_font)
+except EnvironmentError:
+	sys.exit(1)
+
+# Patch provided fonts
+for font_path in args.fonts:
+	try:
+		font = fontforge.open(font_path)
+	except EnvironmentError:
+		sys.exit(1)
+
+	# Rename font
+	if args.rename:
+		font.familyname += ' for Powerline'
+		font.fullname += ' for Powerline'
+		font.fontname += 'ForPowerline'
+		font.appendSFNTName('English (US)', 'Preferred Family', font.familyname)
+		font.appendSFNTName('English (US)', 'Compatible Full', font.fullname)
+	if args.fixwin:
+		font.fontname = re.sub(r'\W', '', font.familyname)
+
+	# Force the em size to be equal
+	symbols.em = font.em
+
+	# Initial font dimensions
+	font_dim = {
+		'xmin'  :    0,
+		'ymin'  :    -font.descent,
+		'xmax'  :    0,
+		'ymax'  :    font.ascent,
+
+		'width' :    0,
+		'height':    0,
+	}
+
+	# Find the biggest char width and height
+	#
+	# 0x00-0x17f is the Latin Extended-A range
+	# 0x2500-0x2600 is the box drawing range
+	for glyph in range(0x00, 0x17f) + range(0x2500, 0x2600):
+		try:
+			(xmin, ymin, xmax, ymax) = font[glyph].boundingBox()
+		except TypeError:
+			continue
+
+		if font_dim['width'] == 0:
+			font_dim['width'] = font[glyph].width
+
+		if ymin < font_dim['ymin']: font_dim['ymin'] = ymin
+		if ymax > font_dim['ymax']: font_dim['ymax'] = ymax
+		if xmax > font_dim['xmax']: font_dim['xmax'] = xmax
+
+	# Calculate font height
+	font_dim['height'] = abs(font_dim['ymin']) + font_dim['ymax']
+
+	# Update the font encoding to ensure that the Unicode glyphs are available
+	font.encoding = 'ISO10646'
+
+	# Fetch this property before adding outlines
+	onlybitmaps = font.onlybitmaps
+
+	def get_dim(glyph):
+		bbox = glyph.boundingBox()
+
+		return  {
+			'xmin'  : bbox[0],
+			'ymin'  : bbox[1],
+			'xmax'  : bbox[2],
+			'ymax'  : bbox[3],
+
+			'width' : bbox[2] + (-bbox[0]),
+			'height': bbox[3] + (-bbox[1]),
+		}
+
+	# Create glyphs from symbol font
+	for sym_glyph in symbols.glyphs():
+		sym_attr = SYM_ATTR[sym_glyph.unicode]
+
+		# Prepare symbol glyph dimensions
+		sym_dim = get_dim(sym_glyph)
+
+		# Select and copy symbol from its encoding point
+		symbols.selection.select(sym_glyph.encoding)
+		symbols.copy()
+
+		# Select and paste symbol to its unicode code point
+		font.selection.select(sym_glyph.unicode)
+		font.paste()
+
+		# Now that we have copy/pasted the glyph, it's time to scale and move it
+
+		# Handle glyph stretching
+		if 'x' in sym_attr['stretch']:
+			# Stretch the glyph horizontally
+			scale_ratio = font_dim['width'] / sym_dim['width']
+
+			font.transform(psMat.scale(scale_ratio, 1))
+		if 'y' in sym_attr['stretch']:
+			# Stretch the glyph vertically
+			scale_ratio = font_dim['height'] / sym_dim['height']
+
+			font.transform(psMat.scale(1, scale_ratio))
+
+		# Use the dimensions from the pasted and stretched glyph
+		sym_dim = get_dim(font[sym_glyph.unicode])
+
+		# Center-align the glyph vertically
+		font_ycenter = font_dim['height'] / 2
+		sym_ycenter  = sym_dim['height'] / 2
+
+		# First move it to the ymax (top)
+		font.transform(psMat.translate(0, font_dim['ymax'] - sym_dim['ymax']))
+
+		# Then move it the y center difference
+		font.transform(psMat.translate(0, sym_ycenter - font_ycenter))
+
+		# Ensure that the glyph doesn't extend outside the font's bounding box
+		if sym_dim['width'] > font_dim['width']:
+			# The glyph is too wide, scale it down to fit
+			scale_matrix = psMat.scale(font_dim['width'] / sym_dim['width'], 1)
+
+			font.transform(scale_matrix)
+
+			# Use the dimensions from the stretched glyph
+			sym_dim = get_dim(font[sym_glyph.unicode])
+
+		# Handle glyph alignment
+		if sym_attr['align'] == 'c':
+			# Center align
+			align_matrix = psMat.translate(font_dim['width'] / 2 - sym_dim['width'] / 2 , 0)
+		elif sym_attr['align'] == 'r':
+			# Right align
+			align_matrix = psMat.translate(font_dim['width'] - sym_dim['width'], 0)
+		else:
+			# No alignment (left alignment)
+			align_matrix = psMat.translate(0, 0)
+
+		font.transform(align_matrix)
+
+		if sym_attr['overlap'] is True:
+			overlap_width = font.em / 48
+
+			# Stretch the glyph slightly horizontally if it should overlap
+			font.transform(psMat.scale((sym_dim['width'] + overlap_width) / sym_dim['width'], 1))
+
+			if sym_attr['align'] == 'l':
+				# The glyph should be left-aligned, so it must be moved overlap_width to the left
+				# This only applies to left-aligned glyphs because the glyph is scaled to the right
+				font.transform(psMat.translate(-overlap_width, 0))
+
+		# Ensure the font is considered monospaced on Windows
+		font[sym_glyph.unicode].width = font_dim['width']
+
+	if font.bitmapSizes and not onlybitmaps:
+		# If this is an outline font with bitmaps, regenerate bitmaps for the changed glyphs
+		font.selection.changed()
+
+		for size in font.bitmapSizes:
+			font.regenBitmaps((size, ))
+
+	output_name, extension = os.path.split(font_path)[1].rsplit('.', 1)
+	if extension.lower() not in ['ttf', 'otf']:
+		# Default to OpenType if input is not TrueType/OpenType
+		extension = 'otf'
+	if args.fixmono:
+		for glyph in font.glyphs():
+			if glyph.width == 0: glyph.width = font_dim['width']
+
+	if onlybitmaps:
+		# Generate BDF font
+		font.generate('{0}-Powerline.bdf'.format(output_name, bitmap_type='bdf'))
+	else:
+		# Generate OTF/TTF font
+		font.generate('{0}-Powerline.{1}'.format(output_name, extension))
+


### PR DESCRIPTION
I've added a modified version of vim-powerline's fontpatcher and PowerlineSymbols that uses the new codes from the powerline project.

The advantages are perfect glyph alignement and compatibility with all
the utilities that use the glyph codes from the new powerline project.
