### PR TITLE
Added fontpatcher.

### DIFF
--- a/fontpatcher/PowerlineSymbols.sfd
+++ b/fontpatcher/PowerlineSymbols.sfd
@@ -1,0 +1,247 @@
+SplineFontDB: 3.0
+FontName: PowerlineSymbols
+FullName: PowerlineSymbols
+FamilyName: PowerlineSymbols
+Weight: Medium
+Copyright: 
+UComments: "2011-11-21: Created." 
+Version: 001.000
+ItalicAngle: 0
+UnderlinePosition: -98.6328
+UnderlineWidth: 48.8281
+Ascent: 800
+Descent: 200
+LayerCount: 2
+Layer: 0 0 "Back"  1
+Layer: 1 0 "Fore"  0
+XUID: [1021 211 26716215 11021609]
+FSType: 0
+OS2Version: 0
+OS2_WeightWidthSlopeOnly: 0
+OS2_UseTypoMetrics: 1
+CreationTime: 1321867751
+ModificationTime: 1390495496
+OS2TypoAscent: 0
+OS2TypoAOffset: 1
+OS2TypoDescent: 0
+OS2TypoDOffset: 1
+OS2TypoLinegap: 90
+OS2WinAscent: 0
+OS2WinAOffset: 1
+OS2WinDescent: 0
+OS2WinDOffset: 1
+HheadAscent: 0
+HheadAOffset: 1
+HheadDescent: 0
+HheadDOffset: 1
+OS2Vendor: 'PfEd'
+MarkAttachClasses: 1
+DEI: 91125
+Encoding: UnicodeFull
+Compacted: 1
+UnicodeInterp: none
+NameList: Adobe Glyph List
+DisplaySize: -24
+AntiAlias: 1
+FitToEm: 1
+WinInfo: 0 31 18
+BeginPrivate: 0
+EndPrivate
+BeginChars: 1114112 7
+
+StartChar: uni2B80
+Encoding: 57522 57522 0
+Width: 601
+Flags: HMW
+LayerCount: 2
+Fore
+SplineSet
+621 1000 m 5
+ 621 -243 l 5
+ 0 379 l 5
+ 621 1000 l 5
+EndSplineSet
+EndChar
+
+StartChar: uni2B81
+Encoding: 57523 57523 1
+Width: 621
+Flags: HMW
+LayerCount: 2
+Fore
+SplineSet
+612 991 m 4
+ 618 985 621 979 621 970 c 4
+ 621 961 619 954 613 948 c 6
+ 74 379 l 5
+ 613 -190 l 6
+ 619 -196 621 -203 621 -212 c 4
+ 621 -221 618 -228 612 -234 c 4
+ 606 -240 598 -242 589 -242 c 4
+ 580 -242 574 -239 568 -233 c 6
+ 8 357 l 6
+ 3 362 0 370 0 378 c 4
+ 0 386 3 394 8 400 c 6
+ 568 990 l 6
+ 574 996 580 1000 589 1000 c 4
+ 598 1000 606 997 612 991 c 4
+EndSplineSet
+EndChar
+
+StartChar: uni2B61
+Encoding: 57505 57505 2
+Width: 555
+VWidth: 0
+Flags: HMW
+LayerCount: 2
+Fore
+SplineSet
+0 800 m 5
+ 92 800 l 5
+ 92 513 l 5
+ 253 513 l 5
+ 253 444 l 5
+ 0 444 l 5
+ 0 800 l 5
+236 312 m 5
+ 339 312 l 5
+ 468 67 l 5
+ 468 312 l 5
+ 555 312 l 5
+ 555 -44 l 5
+ 453 -44 l 5
+ 323 200 l 5
+ 323 -44 l 5
+ 236 -44 l 5
+ 236 312 l 5
+EndSplineSet
+EndChar
+
+StartChar: uni2B60
+Encoding: 57504 57504 3
+Width: 676
+Flags: HMW
+LayerCount: 2
+Fore
+SplineSet
+0 197 m 1
+ 94 207 419 279 419 384 c 2
+ 419 537 l 1
+ 278 501 l 1
+ 478 794 l 1
+ 677 501 l 1
+ 536 537 l 1
+ 536 384 l 2
+ 536 196 208 126 208 21 c 2
+ 208 -244 l 1
+ 0 -244 l 1
+ 0 197 l 1
+0 288 m 1
+ 0 944 l 1
+ 208 944 l 1
+ 208 944 208 451 208 334 c 1
+ 185 311 12 288 0 288 c 1
+EndSplineSet
+EndChar
+
+StartChar: uni2B62
+Encoding: 57506 57506 4
+Width: 546
+VWidth: 0
+Flags: HMW
+LayerCount: 2
+Fore
+SplineSet
+273 733 m 4
+ 429 733 430 538 430 538 c 5
+ 430 420 l 5
+ 547 420 l 5
+ 547 303 l 5
+ 547 303 546 -9 273 -9 c 4
+ 0 -9 0 303 0 303 c 5
+ 0 420 l 5
+ 117 420 l 5
+ 117 538 l 5
+ 117 538 117 733 273 733 c 4
+273 655 m 4
+ 195 655 195 576 195 420 c 5
+ 352 420 l 5
+ 352 576 351 655 273 655 c 4
+273 342 m 4
+ 195 342 195 147 273 147 c 4
+ 351 147 351 342 273 342 c 4
+EndSplineSet
+EndChar
+
+StartChar: uni2B63
+Encoding: 57520 57520 5
+Width: 621
+Flags: HMW
+LayerCount: 2
+Fore
+SplineSet
+-20 1000 m 1
+ 601 379 l 1
+ -20 -243 l 1
+ -20 1000 l 1
+EndSplineSet
+EndChar
+
+StartChar: uni2B64
+Encoding: 57521 57521 6
+Width: 621
+Flags: HMW
+LayerCount: 2
+Fore
+SplineSet
+10 991 m 0
+ 16 997 23 1000 32 1000 c 0
+ 41 1000 48 996 54 990 c 2
+ 613 400 l 2
+ 619 394 621 386 621 378 c 0
+ 621 370 618 362 613 357 c 2
+ 54 -233 l 2
+ 48 -239 41 -242 32 -242 c 0
+ 23 -242 16 -240 10 -234 c 0
+ 4 -228 0 -221 0 -212 c 0
+ 0 -203 3 -196 8 -190 c 2
+ 547 379 l 1
+ 8 948 l 2
+ 3 954 0 961 0 970 c 0
+ 0 979 4 985 10 991 c 0
+EndSplineSet
+EndChar
+EndChars
+BitmapFont: 10 8 8 2 1 
+BDFChar: 0 57522 6 1 5 -2 7
+#T,OGq"T(n(^L*A
+BDFChar: 1 57523 6 1 5 -2 7
+#S8+DJ:Km-&-r79
+BDFChar: 2 57505 6 1 4 -1 7
+J:N1>!0GR3O8o7\
+BDFChar: 3 57504 7 0 5 -2 7
+^rY<PaN2`d^q]pM
+BDFChar: 4 57506 5 0 5 0 6
+0M"b4bku\c
+BDFChar: 5 57520 6 0 4 -2 7
+JAC+4q"X@:^jlCb
+BDFChar: 6 57521 6 0 4 -2 7
+J3Y4g#RCta5_&h7
+EndBitmapFont
+BitmapFont: 12 8 10 2 1 
+BDFChar: 0 57522 7 0 5 -2 9
+":Q84I/Nni4<+b4
+BDFChar: 1 57523 7 0 5 -2 9
+":,P]5_+AM+:ne]
+BDFChar: 2 57505 7 0 5 0 8
+J:N1>!$jBP,QIfE
+BDFChar: 3 57504 8 0 5 -2 9
+^qe%HaN2HLi5!.D
+BDFChar: 4 57506 7 0 5 0 8
+0M"`*r63C_GQ7^D
+BDFChar: 5 57520 7 0 5 -2 9
+JAC+4q#('bnDM*4
+BDFChar: 6 57521 7 0 5 -2 9
+J3Y4g#Qt89&0O5g
+EndBitmapFont
+EndSplineFont

--- a/fontpatcher/fontpatcher
+++ b/fontpatcher/fontpatcher
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+
+"""Font patcher for Powerline.
+
+Creates dividers and symbols for use with Powerline. Requires FontForge with Python bindings.
+
+Stores glyphs in the U+E000..U+F8FF Unicode range.
+
+[e0a0] Branch symbol
+[e0a1] LN (line) symbol
+[e0a2] Padlock (closed) symbol
+[e0b0] Hard right arrow
+[e0b1] Soft right arrow
+[e0b2] Hard left arrow
+[e0b3] Soft left arrow
+"""
+
+from __future__ import division
+
+import argparse
+import os
+import sys
+import re
+
+try:
+	import fontforge
+	import psMat
+except ImportError:
+	sys.stderr.write('The required FontForge modules could not be loaded.\n\n')
+
+	if sys.version_info.major > 2:
+		sys.stderr.write('FontForge only supports Python 2. Please run this script with the Python 2 executable - e.g. "python2 {0}"\n'.format(sys.argv[0]))
+	else:
+		sys.stderr.write('You need FontForge with Python bindings for this script to work.\n')
+
+	sys.exit(1)
+
+# Handle command-line arguments
+parser = argparse.ArgumentParser(description='Font patcher for Powerline. Creates dividers and symbols in FontForge-compatible font files. Requires FontForge with Python bindings. Stores glyphs in the U+2B80-U+2BFF range ("Miscellaneous symbols and arrows"). Stores the patched font as a new, renamed font file by default.')
+
+parser.add_argument('fonts', help='font file to patch', metavar='font', nargs='+')
+parser.add_argument('--no-rename', help='don\'t add " for Powerline" to the font name', default=True, action='store_false', dest='rename')
+parser.add_argument('--symbol-font', help='font file with symbols', metavar='font', dest='symbol_font', default='{0}/PowerlineSymbols.sfd'.format(sys.path[0]))
+parser.add_argument('--fix-mono', help='fixes some mono-fonts which have glyphs of 0 widths', default=False, action='store_true', dest='fixmono')
+parser.add_argument('--fix-win', help='modifies font names such that Windows correctly recognizes font families', default=False, action='store_true', dest='fixwin')
+
+args = parser.parse_args()
+
+SYM_ATTR = {
+	# Right/left-aligned glyphs will have their advance width reduced in order to overlap the next glyph slightly
+	0xe0a0: { 'align': 'c', 'stretch': 'y' , 'overlap': False },
+	0xe0a1: { 'align': 'c', 'stretch': ''  , 'overlap': False },
+	0xe0a2: { 'align': 'c', 'stretch': ''  , 'overlap': False },
+	0xe0b0: { 'align': 'l', 'stretch': 'xy', 'overlap': True  },
+	0xe0b1: { 'align': 'l', 'stretch': 'xy', 'overlap': True  },
+	0xe0b2: { 'align': 'r', 'stretch': 'xy', 'overlap': True  },
+	0xe0b3: { 'align': 'r', 'stretch': 'xy', 'overlap': True  },
+}
+
+# Open symbol font
+try:
+	symbols = fontforge.open(args.symbol_font)
+except EnvironmentError:
+	sys.exit(1)
+
+# Patch provided fonts
+for font_path in args.fonts:
+	try:
+		font = fontforge.open(font_path)
+	except EnvironmentError:
+		sys.exit(1)
+
+	# Rename font
+	if args.rename:
+		font.familyname += ' for Powerline'
+		font.fullname += ' for Powerline'
+		font.fontname += 'ForPowerline'
+		font.appendSFNTName('English (US)', 'Preferred Family', font.familyname)
+		font.appendSFNTName('English (US)', 'Compatible Full', font.fullname)
+	if args.fixwin:
+		font.fontname = re.sub(r'\W', '', font.familyname)
+
+	# Force the em size to be equal
+	symbols.em = font.em
+
+	# Initial font dimensions
+	font_dim = {
+		'xmin'  :    0,
+		'ymin'  :    -font.descent,
+		'xmax'  :    0,
+		'ymax'  :    font.ascent,
+
+		'width' :    0,
+		'height':    0,
+	}
+
+	# Find the biggest char width and height
+	#
+	# 0x00-0x17f is the Latin Extended-A range
+	# 0x2500-0x2600 is the box drawing range
+	for glyph in range(0x00, 0x17f) + range(0x2500, 0x2600):
+		try:
+			(xmin, ymin, xmax, ymax) = font[glyph].boundingBox()
+		except TypeError:
+			continue
+
+		if font_dim['width'] == 0:
+			font_dim['width'] = font[glyph].width
+
+		if ymin < font_dim['ymin']: font_dim['ymin'] = ymin
+		if ymax > font_dim['ymax']: font_dim['ymax'] = ymax
+		if xmax > font_dim['xmax']: font_dim['xmax'] = xmax
+
+	# Calculate font height
+	font_dim['height'] = abs(font_dim['ymin']) + font_dim['ymax']
+
+	# Update the font encoding to ensure that the Unicode glyphs are available
+	font.encoding = 'ISO10646'
+
+	# Fetch this property before adding outlines
+	onlybitmaps = font.onlybitmaps
+
+	def get_dim(glyph):
+		bbox = glyph.boundingBox()
+
+		return  {
+			'xmin'  : bbox[0],
+			'ymin'  : bbox[1],
+			'xmax'  : bbox[2],
+			'ymax'  : bbox[3],
+
+			'width' : bbox[2] + (-bbox[0]),
+			'height': bbox[3] + (-bbox[1]),
+		}
+
+	# Create glyphs from symbol font
+	for sym_glyph in symbols.glyphs():
+		sym_attr = SYM_ATTR[sym_glyph.unicode]
+
+		# Prepare symbol glyph dimensions
+		sym_dim = get_dim(sym_glyph)
+
+		# Select and copy symbol from its encoding point
+		symbols.selection.select(sym_glyph.encoding)
+		symbols.copy()
+
+		# Select and paste symbol to its unicode code point
+		font.selection.select(sym_glyph.unicode)
+		font.paste()
+
+		# Now that we have copy/pasted the glyph, it's time to scale and move it
+
+		# Handle glyph stretching
+		if 'x' in sym_attr['stretch']:
+			# Stretch the glyph horizontally
+			scale_ratio = font_dim['width'] / sym_dim['width']
+
+			font.transform(psMat.scale(scale_ratio, 1))
+		if 'y' in sym_attr['stretch']:
+			# Stretch the glyph vertically
+			scale_ratio = font_dim['height'] / sym_dim['height']
+
+			font.transform(psMat.scale(1, scale_ratio))
+
+		# Use the dimensions from the pasted and stretched glyph
+		sym_dim = get_dim(font[sym_glyph.unicode])
+
+		# Center-align the glyph vertically
+		font_ycenter = font_dim['height'] / 2
+		sym_ycenter  = sym_dim['height'] / 2
+
+		# First move it to the ymax (top)
+		font.transform(psMat.translate(0, font_dim['ymax'] - sym_dim['ymax']))
+
+		# Then move it the y center difference
+		font.transform(psMat.translate(0, sym_ycenter - font_ycenter))
+
+		# Ensure that the glyph doesn't extend outside the font's bounding box
+		if sym_dim['width'] > font_dim['width']:
+			# The glyph is too wide, scale it down to fit
+			scale_matrix = psMat.scale(font_dim['width'] / sym_dim['width'], 1)
+
+			font.transform(scale_matrix)
+
+			# Use the dimensions from the stretched glyph
+			sym_dim = get_dim(font[sym_glyph.unicode])
+
+		# Handle glyph alignment
+		if sym_attr['align'] == 'c':
+			# Center align
+			align_matrix = psMat.translate(font_dim['width'] / 2 - sym_dim['width'] / 2 , 0)
+		elif sym_attr['align'] == 'r':
+			# Right align
+			align_matrix = psMat.translate(font_dim['width'] - sym_dim['width'], 0)
+		else:
+			# No alignment (left alignment)
+			align_matrix = psMat.translate(0, 0)
+
+		font.transform(align_matrix)
+
+		if sym_attr['overlap'] is True:
+			overlap_width = font.em / 48
+
+			# Stretch the glyph slightly horizontally if it should overlap
+			font.transform(psMat.scale((sym_dim['width'] + overlap_width) / sym_dim['width'], 1))
+
+			if sym_attr['align'] == 'l':
+				# The glyph should be left-aligned, so it must be moved overlap_width to the left
+				# This only applies to left-aligned glyphs because the glyph is scaled to the right
+				font.transform(psMat.translate(-overlap_width, 0))
+
+		# Ensure the font is considered monospaced on Windows
+		font[sym_glyph.unicode].width = font_dim['width']
+
+	if font.bitmapSizes and not onlybitmaps:
+		# If this is an outline font with bitmaps, regenerate bitmaps for the changed glyphs
+		font.selection.changed()
+
+		for size in font.bitmapSizes:
+			font.regenBitmaps((size, ))
+
+	output_name, extension = os.path.split(font_path)[1].rsplit('.', 1)
+	if extension.lower() not in ['ttf', 'otf']:
+		# Default to OpenType if input is not TrueType/OpenType
+		extension = 'otf'
+	if args.fixmono:
+		for glyph in font.glyphs():
+			if glyph.width == 0: glyph.width = font_dim['width']
+
+	if onlybitmaps:
+		# Generate BDF font
+		font.generate('{0}-Powerline.bdf'.format(output_name, bitmap_type='bdf'))
+	else:
+		# Generate OTF/TTF font
+		font.generate('{0}-Powerline.{1}'.format(output_name, extension))
+

--- a/fontpatcher/usage.txt
+++ b/fontpatcher/usage.txt
@@ -1,0 +1,33 @@
+Introduction
+=============
+
+This fontpatcher is a modified version of the original patcher from the vim-powerline project so all credit goes to the creator of the vim-powerline plugin Kim Silkebækken (kim.silkebaekken+vim@gmail.com).
+
+I can only take credit for modifying the script and symbol file so that it uses the new glyph codes in the range U+E000..U+F8FF, in other words the glyph codes that the new powerline project uses.
+
+This script produces font that are both compatible with vim-airline and the new powerline plugin and all other related tools that use the new powerline glyphs.
+
+Usage
+=====
+
+1. To use this script and patch the fonts you have to install fontforge built with python support: 
+
+ - on Ubuntu and Debian this is: apt-get install python-fontforge
+ - on ArchLinux: pacman -S fontforge
+
+You should search Google for other supported distros and installation methods.
+
+2. After installing the required software now we get to step 2, chosing and aquring the fonts to be patched. Once you have the fonts just create a temporary working folder and place the fonts inside. Copy the two included files "fontpatcher" and "PowerlineSymbols.sfd" without the quotes :) and paste them inside the working directory, the one that contains the fonts to be patched, now you are ready to patch the fonts.
+
+3. To patch the fonts you just have to run the script from console
+
+  - ./fontpatcher TheNameofTheFont.ttf 
+
+The above command will produce a new font file ex: TheNameofTheFont-Powerline.ttf, that is the patched font.
+
+4. After patchhing the fonts copy them to ~/.fonts and run fc-cache -vf to recache the fonts.
+
+5. Set the patched font as the default inside your terminal emulator of choice and you are good to go.
+
+Enjoy.
+


### PR DESCRIPTION
I've added a modified version of the font patcher from the original vim-powerline project. This version uses the new glyph codes for patching the fonts. In other words this version of the script creates patched fonts that use the new glyph codes so that the fonts are compatible with vim-airline the new python based powerline and all other utilities that use the new powerline glyps. I've never managed to get the glyps align properly using the fontconfig method, but using this I get almost perfect glyph alignement.
