### PR TITLE
tagbar: only lookup tag once every second

### DIFF
--- a/autoload/airline/extensions/tagbar.vim
+++ b/autoload/airline/extensions/tagbar.vim
@@ -23,9 +23,15 @@ function! airline#extensions#tagbar#inactive_apply(...)
   endif
 endfunction
 
+let s:airline_tagbar_last_lookup_time = 0
+let s:airline_tagbar_last_lookup_val = ''
 function! airline#extensions#tagbar#currenttag()
   if get(w:, 'airline_active', 0)
-    return tagbar#currenttag('%s', '', s:flags)
+    if s:airline_tagbar_last_lookup_time != localtime()
+      let s:airline_tagbar_last_lookup_val = tagbar#currenttag('%s', '', s:flags)
+      let s:airline_tagbar_last_lookup_time = localtime()
+    endif
+    return s:airline_tagbar_last_lookup_val
   endif
   return ''
 endfunction


### PR DESCRIPTION
This makes scrolling (holding done j/k) much smoother, and the current
tag gets pulled in via CursorHold anyway.

Fixes https://github.com/bling/vim-airline/issues/387
