### PR TITLE
Fix "Cannot use empty key for Dictionary" error

### DIFF
--- a/autoload/airline/extensions/tabline/unique_tail_improved.vim
+++ b/autoload/airline/extensions/tabline/unique_tail_improved.vim
@@ -19,6 +19,7 @@ function! airline#extensions#tabline#unique_tail_improved#format(bufnr, buffers)
       let tokens = reverse(split(substitute(fnamemodify(name, ':p:.:h'), '\\', '/', 'g'), '/'))
       let token_index = 0
       for token in tokens
+        if token == '' | continue | endif
         if token == '.' | break | endif
         if !has_key(path_tokens, token_index)
           let path_tokens[token_index] = {}


### PR DESCRIPTION
This pull request resolves a compatibility issue with [fugitive](https://github.com/tpope/vim-fugitive) plugin. When using "Gdiff" command on some file, fugitive attempts to open the current and the index version of the file.  For example, if the file is

```
/home/taketwo/path/to/the/project/README.md
```

then fugitive will use the following path to open the index version:

```
fugitive:///home/taketwo/path/to/the/project/.git//0/README.md
```

Opening this file leads to a cascade of errors like this:

```
Error detected while processing function
airline#extensions#tabline#get..<SNR>162_get_buffers..<SNR>162_get_visible_buffers..airline#extensions#tabline#get_buffer_name..airline#extensions#tabline#unique_tail_improved#format:
line   20:
E713: Cannot use empty key for Dictionary
```

The problem is that when a filename like this is being tokenized, there appear empty "" tokens, and an error occurs when using them as keys in `path_tokens[token_index]` dictionary. This fix simply skips empty tokens.
