### PR TITLE
Change Solarized insert mode color to blue

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -55,7 +55,7 @@ function! airline#themes#solarized#refresh()
   endif
 
   " Insert mode
-  let s:I1 = [s:N1[0], s:yellow, 'bold']
+  let s:I1 = [s:N1[0], s:blue, 'bold']
   let s:I2 = s:N2
   let s:I3 = s:N3
   let s:IF = s:NF


### PR DESCRIPTION
It mimics the `showmode` color (at least on the iterm.app and terminal.app colorschemes)
https://www.dropbox.com/s/o4epotzpv9ilgbl/Screenshot%202014-03-12%2009.00.55.png
