### PR TITLE
branch: limit length of head/branch to 7 chars

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -39,7 +39,7 @@ function! airline#extensions#branch#head()
 
   return empty(head) || !s:check_in_path()
         \ ? ''
-        \ : head
+        \ : len(head) > 7 ? head[0:5].'…' : head
 endfunction
 
 function! airline#extensions#branch#get_head()


### PR DESCRIPTION
This does not make it configurable, but uses a maxlength of 7, which covers `master` and `develop`.

Fixes https://github.com/bling/vim-airline/issues/462
