### PR TITLE
Customizes tabline appearance: type, close button

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -6,6 +6,8 @@ let s:excludes = get(g:, 'airline#extensions#tabline#excludes', [])
 let s:tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
 let s:show_buffers = get(g:, 'airline#extensions#tabline#show_buffers', 1)
 let s:show_tab_nr = get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
+let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
+let s:close_symbol = get(g:, 'airline#extensions#tabline#close_symbol', 'X')
 
 let s:builder_context = {
       \ 'active'        : 1,
@@ -264,8 +266,10 @@ function! s:get_tabs()
   call b.add_raw('%T')
   call b.add_section('airline_tabfill', '')
   call b.split()
-  call b.add_section('airline_tab', ' %999XX ')
-  call b.add_section('airline_tabtype', ' tabs ')
+  call b.add_section('airline_tab', ' %999X'.s:close_symbol.' ')
+  if s:show_tab_type
+    call b.add_section('airline_tabtype', ' tabs ')
+  endif
 
   let s:current_bufnr = curbuf
   let s:current_tabnr = curtab

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -382,6 +382,9 @@ eclim <https://eclim.org>
 * enable/disable displaying tab number in tabs mode. >
   let g:airline#extensions#tabline#show_tab_nr = 1
 
+* enable/disable displaying tab type (far right)
+  let g:airline#extensions#tabline#show_tab_type = 1
+
 * defines the name of a formatter for how buffer names are displayed. >
   let g:airline#extensions#tabline#formatter = 'default'
 
@@ -430,6 +433,10 @@ eclim <https://eclim.org>
   let g:airline#extensions#tabline#left_alt_sep = ''
   let g:airline#extensions#tabline#right_sep = ''
   let g:airline#extensions#tabline#right_alt_sep = ''
+
+* configure symbol used to represent close button
+  let g:airline#extensions#tabline#close_symbol = 'X'
+
 <
 Note: Enabling this extension will modify 'showtabline' and 'guioptions'.
 


### PR DESCRIPTION
This commit adds a couple of new settings so that it's possible to hide
the tab type (all the way to the right) and the symbol which represents
the close button.

The settings and their defaults:

```
let g:airline#extensions#tabline#show_tab_type = 1
let g:airline#extensions#tabline#close_symbol = 'X'
```

This pull request lets me customize the way the tab bar looks to pull off an appearance like this:

<img src="http://drop.emily.st/s/Screen%20Shot%202014-03-19%20at%2013.31.11.png" />
