### PR TITLE
filter() result error

### DIFF
--- a/autoload/airline/extensions/eclim.vim
+++ b/autoload/airline/extensions/eclim.vim
@@ -20,8 +20,7 @@ function! airline#extensions#eclim#get_warnings()
 
   if !empty(eclimList)
     " Remove any non-eclim signs (see eclim#display#signs#Update)
-    " :help filter() ---- `the result **is zero** remove the item from the |List| or |Dictionary|.`
-    call filter(eclimList, "v:val.name != '^\(qf_\)\?\(error\|info\|warning\)$'")
+      call filter(eclimList, 'v:val.name =~ "^\\(qf_\\)\\?\\(error\\|info\\|warning\\)$"')
 
     if !empty(eclimList)
       let errorsLine = eclimList[0]['line']


### PR DESCRIPTION
`:help filter()`

The `v:val.name` String `^\(qf_\)\?\(error\|info\|warning\)$` **IS ZERO** mean remove the intem from the list or dictionary.

So it's would be `!=`.

Thanks :+1: 
