### PR TITLE
Save branch head to a buffer variable

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -84,4 +84,5 @@ function! airline#extensions#branch#init(ext)
   call airline#parts#define_function('branch', 'airline#extensions#branch#get_head')
 
   autocmd BufReadPost * unlet! b:airline_file_in_root
+  autocmd CursorHold * unlet! b:airline_head
 endfunction


### PR DESCRIPTION
Save branch head to a buffer-local variable to prevent looking up the head for every status line refresh.

I'm inexperienced with Vimscript so this might not do what I intend but after switching to airline I noticed my vim sessions are very slow on network filesystems. Profiling shows hundreds of calls to fugitive#is_git_dir (via airline#extensions#branch#get_head) are taking several seconds of time and it seems like doing this once when the buffer is loaded should be enough.

This fixes my slow session problem and still seems to function properly.
