### PR TITLE
Optional Angle brackets

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -19,14 +19,14 @@ function! airline#init#bootstrap()
   call s:check_defined('g:airline_left_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b0":">")
   " call s:check_defined('g:airline_left_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b1":">")
   if (g:airline_left_sep == '')
-    call s:check_defined('g:airline_left_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"|":">")
+    call s:check_defined('g:airline_left_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"|":"|")
   else
     call s:check_defined('g:airline_left_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b1":">")
   endif
   call s:check_defined('g:airline_right_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b2":"<")
   " call s:check_defined('g:airline_right_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b3":"<")
   if (g:airline_right_sep == '')
-    call s:check_defined('g:airline_right_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"|":"<")
+    call s:check_defined('g:airline_right_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"|":"|")
   else
     call s:check_defined('g:airline_right_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b3":"<")
   endif


### PR DESCRIPTION
- This commit provides a bit of cleanliness,
  where, if the user has made the `alt_sep` for either
  right or left (or more usually both) as '' (null values),
  Then put in a pipe symbol, instead of an angle bracket,
  which looks out of place.

(That was the longer part of the commit message, but here's the explanation)

---

Here's what happens: 

If the user has this situation

``` viml
let g:airline_left_sep=''
let g:airline_right_sep=''
let g:airline_powerline_fonts = 1
```

this happens 
![annoy1](https://f.cloud.github.com/assets/1803997/2503706/1dbe33e6-b385-11e3-879f-e85831940cef.png)

Which is kinda ... uh ... slightly annoying :sweat_smile:  (Since, that angle bracket looks out of place)

With this commit, it changes to this 

![soln1](https://f.cloud.github.com/assets/1803997/2503824/6aa311b2-b386-11e3-9e18-f3367034b4a4.png)

Since it looks slightly better and more cleaner. 

Mind you these are useful if the users sets the custom  `AirlineInit()` something like this : 

``` viml
fucntion! AirlineInit()
    let g:airline_section_y = airline#section#create_right(['branch', 'ffenc'])
endfunction
autocmd VimEnter * call AirlineInit()
```
## 

Another look and feel, with a different font (Menlo for powerline)

![mnlo_perp1](https://f.cloud.github.com/assets/1803997/2504316/d3f00152-b38b-11e3-99b8-39330f777452.png)

---

Also, While making this patch, I came across this bug where : 

``` viml
fucntion! AirlineInit()
    let g:airline_section_b = airline#section#create_right(['hunks', 'branch'])
endfunction
autocmd VimEnter * call AirlineInit()
```

Mind you, That's the **airline_section_b**, and the angle bracket still persists. It doesn't get replaced with the pipe one 

![bug1](https://f.cloud.github.com/assets/1803997/2504236/c711c336-b38a-11e3-8480-b4def33b18c7.png)

So, Perhaps you might sort this bug out, and hopefully merge this commit ! :wink: 
