### PR TITLE
check for existance of airline_whitespace autocmd group before undefining it

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -62,8 +62,10 @@ endfunction!
 
 function! airline#extensions#whitespace#toggle()
   if s:enabled
-    autocmd! airline_whitespace CursorHold,BufWritePost
-    augroup! airline_whitespace
+    if exists("#airline_whitespace")
+      autocmd! airline_whitespace CursorHold,BufWritePost
+      augroup! airline_whitespace
+    endif
     let s:enabled = 0
   else
     call airline#extensions#whitespace#init()


### PR DESCRIPTION
Otherwise, :AirlineToggleWhitespace might error out.
