### PR TITLE
doesn't assume user has 'set autochdir' set

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -42,7 +42,7 @@ function! airline#extensions#branch#head()
     let b:airline_head = fugitive#head()
 
     if empty(b:airline_head) && !exists('b:git_dir')
-      let b:airline_head = s:get_git_branch(getcwd())
+      let b:airline_head = s:get_git_branch(expand("%:p:h"))
     endif
   endif
 


### PR DESCRIPTION
This fix solves the potential issue scenario:
1) User doesn't have 'set autochdir' in their vimrc
2) They open file1 from branch Master.  Hunks show 'Master'
3) They open file2 which is untracked (or from different branch).  Hunks still show 'Master' as directory from (2) is retained by getcwd()

NB: Also affects vim-signify & vim-gitgutter
