### PR TITLE
fix minor typo in help text

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -236,7 +236,7 @@ configuration values that you can use.
       \ 'x': 60,
       \ 'y': 88,
       \ 'z': 45,
-      \ })
+      \ }
 
   " Note: set to an empty dictionary to disable truncation.
   let g:airline#extensions#default#section_truncate_width = {}
@@ -246,7 +246,7 @@ configuration values that you can use.
   let g:airline#extensions#default#layout = [
       \ [ 'a', 'b', 'c' ],
       \ [ 'x', 'y', 'z', 'warning' ]
-      \ ])
+      \ ]
 <
 -------------------------------------                     *airline-quickfix*
 The quickfix extension is a simple built-in extension which determines


### PR DESCRIPTION
When I say 'minor', I really do mean 'minor'... :)
