### PR TITLE
Fix #456 Status line text color too dim for inactive windows

### DIFF
--- a/autoload/airline/themes/bubblegum.vim
+++ b/autoload/airline/themes/bubblegum.vim
@@ -54,7 +54,7 @@ let g:airline#themes#bubblegum#palette.visual = airline#themes#generate_color_ma
 let g:airline#themes#bubblegum#palette.visual_modified = copy(g:airline#themes#bubblegum#palette.insert_modified)
 
 " Inactive window
-let s:IA = [s:gui_dark_gray, s:gui_med_gray_hi, s:cterm_dark_gray, s:cterm_med_gray_hi, '']
+let s:IA = [s:gui_light_gray, s:gui_med_gray_hi, s:cterm_light_gray, s:cterm_med_gray_hi, '']
 let g:airline#themes#bubblegum#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
 let g:airline#themes#bubblegum#palette.inactive_modified = {
       \ 'airline_c': [s:gui_orange, '', s:cterm_orange, '', ''],


### PR DESCRIPTION
Fix for #456. Status line text color too dim for inactive windows. Fixed for both terminal and gui.
