### PR TITLE
Added tag for '(Untracked File)' next to 'branch head' info

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -73,9 +73,16 @@ function! airline#extensions#branch#get_head()
   let empty_message = get(g:, 'airline#extensions#branch#empty_message',
       \ get(g:, 'airline_branch_empty_message', ''))
   let symbol = get(g:, 'airline#extensions#branch#symbol', g:airline_symbols.branch)
+  let tracked = s:check_file_tracked() ? '' : ' (UNTRACKED FILE)'
   return empty(head)
         \ ? empty_message
-        \ : printf('%s%s', empty(symbol) ? '' : symbol.(g:airline_symbols.space), head)
+        \ : printf('%s%s%s', empty(symbol) ? '' : symbol.(g:airline_symbols.space), head, tracked)
+endfunction
+
+function! s:check_file_tracked()
+  let file = expand("%")
+  let is_tracked = (system('git status ' . file) =~ 'Untracked') ? 0 : 1
+  return is_tracked
 endfunction
 
 function! s:check_in_path()


### PR DESCRIPTION
For files in a git directory that's untracked, adding an '(UNTRACKED FILE)' tag next to the branch head info.

Result should look something like this:
http://imgur.com/Lq1m9tg

Feel free to replace '(UNTRACKED FILE)" with something more aesthetically pleasing / takes up less space