### PR TITLE
Always use absolute file path when comparing buffers names

### DIFF
--- a/autoload/airline/extensions/tabline/unique_tail_improved.vim
+++ b/autoload/airline/extensions/tabline/unique_tail_improved.vim
@@ -14,9 +14,9 @@ function! airline#extensions#tabline#unique_tail_improved#format(bufnr, buffers)
 
   for nr in a:buffers
     let name = bufname(nr)
-    if !empty(name) && nr != a:bufnr && fnamemodify(name, ':t') == curbuf_tail
+    if !empty(name) && nr != a:bufnr && fnamemodify(name, ':t') == curbuf_tail " only perform actions if curbuf_tail isn't unique
       let do_deduplicate = 1
-      let tokens = reverse(split(substitute(fnamemodify(name, ':p:.:h'), '\\', '/', 'g'), '/'))
+      let tokens = reverse(split(substitute(fnamemodify(name, ':p:h'), '\\', '/', 'g'), '/'))
       let token_index = 0
       for token in tokens
         if token == '' | continue | endif
@@ -33,7 +33,7 @@ function! airline#extensions#tabline#unique_tail_improved#format(bufnr, buffers)
   if do_deduplicate == 1
     let path = []
     let token_index = 0
-    for token in reverse(split(substitute(fnamemodify(bufname(a:bufnr), ':p:.:h'), '\\', '/', 'g'), '/'))
+    for token in reverse(split(substitute(fnamemodify(bufname(a:bufnr), ':p:h'), '\\', '/', 'g'), '/'))
       if token == '.' | break | endif
       let duplicated = 0
       let uniq = 1


### PR DESCRIPTION
Hello again.

When some buffer has it's own root directory (:lcd) unique paths in tabline displayed incorrectly. 
The solution is to always use absolute paths instead of shorten them to relative to buffer cwd.
