### PR TITLE
Added extension for tpope/vim-capslock

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -211,6 +211,10 @@ function! airline#extensions#load()
       call airline#extensions#nrrwrgn#init(s:ext)
   endif
 
+  if (get(g:, 'airline#extensions#capslock#enabled', 1) && exists('*CapsLockStatusline'))
+    call airline#extensions#capslock#init(s:ext)
+  endif
+
   if !get(g:, 'airline#extensions#disable_rtp_load', 0)
     " load all other extensions, which are not part of the default distribution.
     " (autoload/airline/extensions/*.vim outside of our s:script_path).

--- a/autoload/airline/extensions/capslock.vim
+++ b/autoload/airline/extensions/capslock.vim
@@ -1,0 +1,14 @@
+" MIT License. Copyright (c) 2014 Mathias Andersson.
+" vim: et ts=2 sts=2 sw=2
+if !exists('*CapsLockStatusline')
+  finish
+endif
+
+function! airline#extensions#capslock#status()
+  return CapsLockStatusline() == '[caps]' ? 'CAPS' : ''
+endfunction
+
+function! airline#extensions#capslock#init(ext)
+  call airline#parts#define_function('capslock', 'airline#extensions#capslock#status')
+endfunction
+

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -79,6 +79,7 @@ function! airline#init#bootstrap()
   call airline#parts#define_raw('linenr', '%{g:airline_symbols.linenr}%#__accent_bold#%4l%#__restore__#')
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
   call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic', 'eclim', 'whitespace'])
+  call airline#parts#define_text('capslock', '')
 
   unlet g:airline#init#bootstrapping
 endfunction
@@ -86,7 +87,7 @@ endfunction
 function! airline#init#sections()
   let spc = g:airline_symbols.space
   if !exists('g:airline_section_a')
-    let g:airline_section_a = airline#section#create_left(['mode', 'paste', 'iminsert'])
+    let g:airline_section_a = airline#section#create_left(['mode', 'paste', 'capslock', 'iminsert'])
   endif
   if !exists('g:airline_section_b')
     let g:airline_section_b = airline#section#create(['hunks', 'branch'])

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -502,6 +502,12 @@ NrrwRgn <https://github.com/chrisbra/NrrwRgn>
 * enable/disable NrrwRgn integration >
   let g:airline#extensions#nrrwrgn#enabled = 1
 
+-------------------------------------                        *airline-capslock*
+vim-capslock <https://github.com/tpope/vim-capslock>
+
+* enable/disable vim-capslock integration >
+  let g:airline#extensions#capslock#enabled = 1
+<
 ==============================================================================
 ADVANCED CUSTOMIZATION                      *airline-advanced-customization*
 


### PR DESCRIPTION
Hi

I have added support for [vim-capslock](https://github.com/tpope/vim-capslock).
This extension displays CAPS when the soft caps lock is enabled.

I locked at how the other extensions was made and tried to do something similar.
Please let me know if you want something done another way.

I had to use `airline#parts#define_text` and not `airline#parts#define_empty` or else an extra arrow would show when vim-capslock is not present. Not sure if this is correct.
