### PR TITLE
Don't wipe out b:airline_head if fugitive finds the head

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -42,9 +42,11 @@ function! airline#extensions#branch#head()
   endif
 
   let b:airline_head = ''
+  let found_fugitive_head = 0
 
   if s:has_fugitive && !exists('b:mercurial_dir')
     let b:airline_head = fugitive#head(7)
+    let found_fugitive_head = 1
 
     if empty(b:airline_head) && !exists('b:git_dir')
       let b:airline_head = s:get_git_branch(expand("%:p:h"))
@@ -66,7 +68,7 @@ function! airline#extensions#branch#head()
     endif
   endif
 
-  if empty(b:airline_head) || !s:check_in_path()
+  if empty(b:airline_head) || !found_fugitive_head && !s:check_in_path()
     let b:airline_head = ''
   endif
 


### PR DESCRIPTION
- Fugitive can edit virtual files that represent objects in git; while
  editing these files, it still reports on the HEAD of the relevant
  repo, which should be displayed as the branch (rather than having the
  branch section disappear)
