### PR TITLE
Add new Powerline-inspired theme powerlineish2.vim

### DIFF
--- a/autoload/airline/themes/powerlineish2.vim
+++ b/autoload/airline/themes/powerlineish2.vim
@@ -16,9 +16,6 @@ let s:V1 = [ '#080808' , '#ffaf00' , 232 , 214 ]
 " Replace mode
 let s:RE = [ '#ffffff' , '#d70000' , 231 , 160 ]
 
-" Inactive
-let s:IA = [ s:N2[1] , s:N3[1] , s:N2[3] , s:N3[3] , '' ]
-
 let g:airline#themes#powerlineish2#palette = {}
 
 let g:airline#themes#powerlineish2#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
@@ -29,7 +26,7 @@ let g:airline#themes#powerlineish2#palette.visual = airline#themes#generate_colo
 
 let g:airline#themes#powerlineish2#palette.replace = airline#themes#generate_color_map(s:RE, s:I2, s:I3)
 
-let g:airline#themes#powerlineish2#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
+let g:airline#themes#powerlineish2#palette.inactive = airline#themes#generate_color_map(s:N3, s:N3, s:N3)
 
 " Tabline
 let g:airline#themes#powerlineish2#palette.tabline = {


### PR DESCRIPTION
Hello,
Powerlineish is a nice theme but I think it can be improved. So I tried to make it a little more readable and consistent.

Changed a few colors and made the rightmost section always match the mode indicator's color, while the middle is blue when writing (insert and replace modes) and gray otherwise.

Created as a new theme because I figured you wouldn't want big changes in existing ones.
