### PR TITLE
Add `readonly` indicator also for &nomodifiable

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -156,7 +156,7 @@ function! airline#check_mode(winnr)
     call add(l:mode, 'paste')
   endif
 
-  if &readonly
+  if &readonly || ! &modifiable
     call add(l:mode, 'readonly')
   endif
 


### PR DESCRIPTION
While typically both are set (e.g. with `:help`), I am using the
modifiable setting alone to prevent editing of some files via an
autocommand (`*.css`, if `*.scss` exists).

I can also set `readonly` for this buffer, but that gets reset when
reloading the buffer, which is not the case for `modifiable`.
