### PR TITLE
Show/hide setting for close button in tabline

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -7,6 +7,7 @@ let s:tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
 let s:show_buffers = get(g:, 'airline#extensions#tabline#show_buffers', 1)
 let s:show_tab_nr = get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
 let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
+let s:show_close_button = get(g:, 'airline#extensions#tabline#show_close_button', 1)
 let s:close_symbol = get(g:, 'airline#extensions#tabline#close_symbol', 'X')
 
 let s:builder_context = {
@@ -272,7 +273,9 @@ function! s:get_tabs()
   call b.add_raw('%T')
   call b.add_section('airline_tabfill', '')
   call b.split()
-  call b.add_section('airline_tab', ' %999X'.s:close_symbol.' ')
+  if s:show_close_button
+    call b.add_section('airline_tab', ' %999X'.s:close_symbol.' ')
+  endif
   if s:show_tab_type
     call b.add_section('airline_tabtype', ' tabs ')
   endif

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -453,6 +453,9 @@ eclim <https://eclim.org>
   let g:airline#extensions#tabline#right_sep = ''
   let g:airline#extensions#tabline#right_alt_sep = ''
 
+* configure whether close button should be shown
+  let g:airline#extensions#tabline#show_close_button = 1
+
 * configure symbol used to represent close button
   let g:airline#extensions#tabline#close_symbol = 'X'
 


### PR DESCRIPTION
I use console version of vim and close button in tabline is useless for me. This setting allows users to hide a close button.
