### PR TITLE
Added extension for wesQ3/vim-windowswap

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -215,6 +215,10 @@ function! airline#extensions#load()
     call airline#extensions#capslock#init(s:ext)
   endif
 
+  if (get(g:, 'airline#extensions#windowswap#enabled', 1) && get(g:, 'loaded_windowswap', 0))
+    call airline#extensions#windowswap#init(s:ext)
+  endif
+
   if !get(g:, 'airline#extensions#disable_rtp_load', 0)
     " load all other extensions, which are not part of the default distribution.
     " (autoload/airline/extensions/*.vim outside of our s:script_path).

--- a/autoload/airline/extensions/windowswap.vim
+++ b/autoload/airline/extensions/windowswap.vim
@@ -1,0 +1,23 @@
+" vim: et ts=2 sts=2 sw=2
+
+if !exists('g:loaded_windowswap')
+  finish
+endif
+
+let s:spc = g:airline_symbols.space
+
+if !exists('g:airline#extensions#windowswap#indicator_text')
+  let g:airline#extensions#windowswap#indicator_text = 'WS'
+endif
+
+function! airline#extensions#windowswap#init(ext)
+  call airline#parts#define_function('windowswap', 'airline#extensions#windowswap#get_status')
+endfunction
+
+function! airline#extensions#windowswap#get_status()
+  if WindowSwap#HasMarkedWindow() && WindowSwap#GetMarkedWindowNum() == winnr()
+    return g:airline#extensions#windowswap#indicator_text.s:spc
+  endif
+  return ''
+endfunction
+

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -78,7 +78,7 @@ function! airline#init#bootstrap()
   call airline#parts#define_raw('file', '%f%m')
   call airline#parts#define_raw('linenr', '%{g:airline_symbols.linenr}%#__accent_bold#%4l%#__restore__#')
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
-  call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic', 'eclim', 'whitespace'])
+  call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic', 'eclim', 'whitespace','windowswap'])
   call airline#parts#define_text('capslock', '')
 
   unlet g:airline#init#bootstrapping
@@ -105,7 +105,7 @@ function! airline#init#sections()
     let g:airline_section_y = airline#section#create_right(['ffenc'])
   endif
   if !exists('g:airline_section_z')
-    let g:airline_section_z = airline#section#create(['%3p%%'.spc, 'linenr', ':%3c '])
+    let g:airline_section_z = airline#section#create(['windowswap', '%3p%%'.spc, 'linenr', ':%3c '])
   endif
   if !exists('g:airline_section_warning')
     let g:airline_section_warning = airline#section#create(['syntastic', 'eclim', 'whitespace'])

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -510,6 +510,15 @@ vim-capslock <https://github.com/tpope/vim-capslock>
 
 * enable/disable vim-capslock integration >
   let g:airline#extensions#capslock#enabled = 1
+
+-------------------------------------                       *airline-windowswap*
+vim-windowswap <https://github.com/wesQ3/vim-windowswap>
+
+* enable/disable vim-windowswap integration >
+  let g:airline#extensions#windowswap#enabled = 1
+
+* set marked window indicator string >
+  let g:airline#extensions#windowswap#indicator_text = 'WS'
 <
 ==============================================================================
 ADVANCED CUSTOMIZATION                      *airline-advanced-customization*


### PR DESCRIPTION
Hi, I've added an extension to integrate with [my WindowSwap plugin](https://github.com/wesQ3/vim-windowswap).

The extension shows an airline indicator of which window has been marked for swapping. I followed as an example one of the other extensions, but please let me know if I made any mistakes or if you'd like me to change something.

Thanks for your work maintainting airline; I really enjoy it.
