### PR TITLE
Update raven.vim

### DIFF
--- a/autoload/airline/themes/raven.vim
+++ b/autoload/airline/themes/raven.vim
@@ -50,7 +50,7 @@ let g:airline#themes#raven#palette.tabline = {
       \ 'airline_tabmod':   ['#2e2e2e' , '#a4c639' , 235 , 149 , '' ],
       \ }
 
-let s:WI = [ '#ff0000', '#2e2e2e', 196, 188 ]
+let s:WI = [ '#ff0000', '#2e2e2e', 196, 235 ]
 let g:airline#themes#raven#palette.normal.airline_warning = [
      \ s:WI[0], s:WI[1], s:WI[2], s:WI[3]
      \ ]


### PR DESCRIPTION
- Fixed the incorrect cterm background value for `airline_warning`

---

@bling 

Sorry about this ! (That one value seem to have esacped me ! :sweat_smile: )
