### PR TITLE
Display warnings only when there are no errors messages.

### DIFF
--- a/autoload/airline/extensions/eclim.vim
+++ b/autoload/airline/extensions/eclim.vim
@@ -20,12 +20,24 @@ function! airline#extensions#eclim#get_warnings()
 
   if !empty(eclimList)
     " Remove any non-eclim signs (see eclim#display#signs#Update)
-      call filter(eclimList, 'v:val.name =~ "^\\(qf_\\)\\?\\(error\\|info\\|warning\\)$"')
+    " First check for just errors since they are more important.
+    " If there are no errors, then check for warnings.
+    let errorList = filter(copy(eclimList), 'v:val.name =~ "^\\(qf_\\)\\?\\(error\\)$"')
+
+    if (empty(errorList))
+      " use the warnings
+      call filter(eclimList, 'v:val.name =~ "^\\(qf_\\)\\?\\(info\\|warning\\)$"')
+      let type = 'W'
+    else
+      " Use the errors
+      let eclimList = errorList
+      let type = 'E'
+    endif
 
     if !empty(eclimList)
       let errorsLine = eclimList[0]['line']
       let errorsNumber = len(eclimList)
-      let errors = "[Eclim: line:".string(errorsLine)." (".string(errorsNumber).")]"
+      let errors = "[Eclim:" . type . " line:".string(errorsLine)." (".string(errorsNumber).")]"
       if !exists(':SyntasticCheck') || SyntasticStatuslineFlag() == ''
         return errors.(g:airline_symbols.space)
       endif


### PR DESCRIPTION
In large code base, typically there will lot of warnings because the
file has been changed by many people and not everyone bothered to follow
coding conventions. So its more useful to show the errors first. Once
all errors have been fixed, we can focus on warnings.
