### PR TITLE
Display warnings only when there are no errors messages.

### DIFF
--- a/autoload/airline/extensions/eclim.vim
+++ b/autoload/airline/extensions/eclim.vim
@@ -26,7 +26,7 @@ function! airline#extensions#eclim#get_warnings()
 
     if (empty(errorList))
       " use the warnings
-      call filter(eclimList, 'v:val.name =~ "^\\(qf_\\)\\?\\(info\\|warning\\)$"')
+      call filter(eclimList, 'v:val.name =~ "^\\(qf_\\)\\?\\(warning\\)$"')
       let type = 'W'
     else
       " Use the errors


### PR DESCRIPTION
In large code base, typically there will lot of warnings because the
file has been changed by many people and not everyone bothered to follow
coding conventions. So its more useful to show the errors first. Once
all errors have been fixed, we can focus on warnings.
