### PR TITLE
Show the byfname toggle in status line of CtrlP

### DIFF
--- a/autoload/airline/extensions/ctrlp.vim
+++ b/autoload/airline/extensions/ctrlp.vim
@@ -36,6 +36,9 @@ endfunction
 " Arguments: focus, byfname, regexp, prv, item, nxt, marked
 function! airline#extensions#ctrlp#ctrlp_airline(...)
   let b = airline#builder#new({'active': 1})
+  if a:2 == 'file'
+    call b.add_section_spaced('CtrlPlight', 'by fname')
+  endif
   if a:3
     call b.add_section_spaced('CtrlPlight', 'regex')
   endif


### PR DESCRIPTION
I added the visualization of the `byfname` toggle (ctrl-d by default) to the status line in CtrlP, with the same presentation as the existing `regex` toggle.

![1416490763](https://cloud.githubusercontent.com/assets/1671603/5125337/fc8f1e88-70fd-11e4-9496-59eb54254c66.png)
