### PR TITLE
Add simple virtualenv fallback when vim-virtualenv is not presented

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -178,7 +178,7 @@ function! airline#extensions#load()
     call airline#extensions#bufferline#init(s:ext)
   endif
 
-  if get(g:, 'virtualenv_loaded', 0) && get(g:, 'airline#extensions#virtualenv#enabled', 1)
+  if isdirectory($VIRTUAL_ENV) && get(g:, 'airline#extensions#virtualenv#enabled', 1)
     call airline#extensions#virtualenv#init(s:ext)
   endif
 

--- a/autoload/airline/extensions/virtualenv.vim
+++ b/autoload/airline/extensions/virtualenv.vim
@@ -1,7 +1,7 @@
 " MIT License. Copyright (c) 2013-2014 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
-if !get(g:, 'virtualenv_loaded', 0)
+if !isdirectory($VIRTUAL_ENV)
   finish
 endif
 
@@ -13,8 +13,13 @@ endfunction
 
 function! airline#extensions#virtualenv#apply(...)
   if &filetype =~ "python"
+    if get(g:, 'virtualenv_loaded', 0)
+      let statusline = virtualenv#statusline()
+    else
+      let statusline = fnamemodify($VIRTUAL_ENV, ':t')
+    endif
     call airline#extensions#append_to_section('x',
-          \ s:spc.g:airline_right_alt_sep.s:spc.'%{virtualenv#statusline()}')
+          \ s:spc.g:airline_right_alt_sep.s:spc.statusline)
   endif
 endfunction
 


### PR DESCRIPTION
Installing an extra plugin shouldn't be mandatory to simply display the current virtualenv. Referencing to vim-virtualenv, I made a fallback that makes use of the $VIRTUAL_ENV environmental variable when vim-virtualenv is not activated.
