### PR TITLE
Improve Quickfix window detection

### DIFF
--- a/autoload/airline/extensions/quickfix.vim
+++ b/autoload/airline/extensions/quickfix.vim
@@ -25,7 +25,7 @@ function! s:get_text()
   let nr = bufnr('%')
   for buf in split(buffers, '\n')
     if match(buf, '\v^\s*'.nr) > -1
-      if match(buf, '\[Quickfix List\]') > -1
+      if match(buf, '\cQuickfix') > -1
         return g:airline#extensions#quickfix#quickfix_text
       else
         return g:airline#extensions#quickfix#location_text


### PR DESCRIPTION
When using a non-english locale, the name of the Quickfix window can change, making the detection of Quickfix vs Location list fail.
E.g., my locale is set to italian and the Quickfix window's name is `[Lista Quickfix]` rather than `[Quickfix List]`.
This change generalizes the pattern used to detect the Quickfix window.
