### PR TITLE
fixed bug with excludes for buffers

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -135,15 +135,19 @@ function! s:get_buffer_list()
   let cur = bufnr('%')
   for nr in range(1, bufnr('$'))
     if buflisted(nr) && bufexists(nr)
+      let toadd = 1
       for ex in s:excludes
-        if match(bufname(nr), ex)
-          continue
+        if match(bufname(nr), ex) >= 0
+          let toadd = 0
+          break
         endif
       endfor
       if getbufvar(nr, 'current_syntax') == 'qf'
-        continue
+        let toadd = 0
       endif
-      call add(buffers, nr)
+      if toadd
+        call add(buffers, nr)
+      endif
     endif
   endfor
 


### PR DESCRIPTION
The original match call doesn't do the thing intended - `continue` only takes it to the next loop for checking of the buffer names. Furthermore, from `he match()`, `match` can return 0 when the match is at the beginning; the correct way should be comparing with `-1` - which is the value returned when there is no match found
