### PR TITLE
Use non-broken default for whitespace detection

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -16,7 +16,7 @@ let s:default_checks = ['indent', 'trailing']
 let s:trailing_format = get(g:, 'airline#extensions#whitespace#trailing_format', 'trailing[%s]')
 let s:mixed_indent_format = get(g:, 'airline#extensions#whitespace#mixed_indent_format', 'mixed-indent[%s]')
 let s:long_format = get(g:, 'airline#extensions#whitespace#long_format', 'long[%s]')
-let s:indent_algo = get(g:, 'airline#extensions#whitespace#mixed_indent_algo', 0)
+let s:indent_algo = get(g:, 'airline#extensions#whitespace#mixed_indent_algo', 1)
 
 let s:max_lines = get(g:, 'airline#extensions#whitespace#max_lines', 20000)
 


### PR DESCRIPTION
When editing a file with mixed tabs/spaces, the whitespace plugin's
default algorithm reports mixed indent.

I recommend switching the default for
`g:airline#extensions#whitespace#mixed_indent_algo` to 1 so that it uses
the non-broken algorithm by default.

... or just completely getting rid of the broken algorithm but that
might break some peoples' vims.

Steps to reproduce:

1. Edit this file with `tabstop=8`, `shiftwidth=4` and `noexpandtab`:

    #!/bin/sh
    \# vi: ts=8 sw=4 noet

    foo() {
            bar() {
                    baz() {
                            qux() {
                            }
                    }
            }
    }

2. Indent all lines using `gg=G`

3. Save and re-open file so that the whitespace plugin scans it.