### PR TITLE
more padding options

### DIFF
--- a/autoload/airline/extensions/default.vim
+++ b/autoload/airline/extensions/default.vim
@@ -18,7 +18,7 @@ function! s:get_section(winnr, key, ...)
       return ''
     endif
   endif
-  let spc = g:airline_symbols.space
+  let spc = g:airline_symbols.pad_section
   let text = airline#util#getwinvar(a:winnr, 'airline_section_'.a:key, g:airline_section_{a:key})
   let [prefix, suffix] = [get(a:000, 0, '%('.spc), get(a:000, 1, spc.'%)')]
   return empty(text) ? '' : prefix.text.suffix

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -64,6 +64,9 @@ function! airline#init#bootstrap()
         \ 'modified': '+',
         \ 'space': ' ',
         \ 'crypt': get(g:, 'airline_crypt_symbol', nr2char(0x1F512)),
+        \ 'pad': get(g:airline_symbols, 'space', ' '),
+        \ 'pad_section': get(g:airline_symbols, 'space', ' '),
+        \ 'pad_sep': get(g:airline_symbols, 'space', ' '),
         \ }, 'keep')
 
   call airline#parts#define('mode', {

--- a/autoload/airline/section.vim
+++ b/autoload/airline/section.vim
@@ -2,7 +2,6 @@
 " vim: et ts=2 sts=2 sw=2
 
 call airline#init#bootstrap()
-let s:spc = g:airline_symbols.space
 
 function! s:wrap_accent(part, value)
   if exists('a:part.accent')
@@ -13,6 +12,7 @@ function! s:wrap_accent(part, value)
 endfunction
 
 function! s:create(parts, append)
+  let s:spc = g:airline_symbols.pad_sep
   let _ = ''
   for idx in range(len(a:parts))
     let part = airline#parts#get(a:parts[idx])

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -2,7 +2,6 @@
 " vim: et ts=2 sts=2 sw=2
 
 call airline#init#bootstrap()
-let s:spc = g:airline_symbols.space
 
 function! airline#util#wrap(text, minwidth)
   if a:minwidth > 0 && winwidth(0) < a:minwidth
@@ -12,6 +11,7 @@ function! airline#util#wrap(text, minwidth)
 endfunction
 
 function! airline#util#append(text, minwidth)
+  let s:spc = g:airline_symbols.space
   if a:minwidth > 0 && winwidth(0) < a:minwidth
     return ''
   endif
@@ -20,6 +20,7 @@ function! airline#util#append(text, minwidth)
 endfunction
 
 function! airline#util#prepend(text, minwidth)
+  let s:spc = g:airline_symbols.space
   if a:minwidth > 0 && winwidth(0) < a:minwidth
     return ''
   endif

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -208,6 +208,24 @@ its contents. >
   let g:airline_symbols.linenr = '⭡'
 <
 
+White space and padding:
+
+Some white space variables exist to allow greater control of padding and
+white space.  If these are changed after airline is running you may need to
+:AirlineRefresh to see your changes
+
+Note: You must define the dictionary first before setting values. Also, it's a
+good idea to check whether if it exists as to avoid accidentally overwritting
+its contents. >
+
+
+  variable names                     usage
+  ----------------------------------------------------------------------------
+  let g:airline_symbols.space        normal space
+  let g:airline_symbols.pad          padding that can collapse
+  let g:airline_symbols.pad_section  padding at start and end of a section
+  let g:airline_symbols.pad_sep      padding around a separator
+
 For more intricate customizations, you can replace the predefined sections
 with the usual statusline syntax.
 


### PR DESCRIPTION
This patch provides three new g:airline_symbol options

*    pad - padding that can collapse but is nice to have
*    pad_section - padding at start and end of a section
*   pad_sep - padding around a separator

They default to the value of g:airline_symbols.space so no user configurations should be affected by this patch.

It allows these options to be changed on the fly and take affect after a `:AirlineRefresh`.  It will be helpful for my extension  [vim-budget-airline](https://github.com/tobes/vim-budget-airline) 