### PR TITLE
Improve loading and allow accent change/removal

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -80,6 +80,8 @@ function! airline#init#bootstrap()
         \ })
   call airline#parts#define_raw('file', '%f%m')
   call airline#parts#define_raw('linenr', '%{g:airline_symbols.linenr}%#__accent_bold#%4l%#__restore__#')
+  " we need to make sure bold accent exists
+  call airline#highlighter#add_accent('bold')
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
   call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic', 'eclim', 'whitespace','windowswap'])
   call airline#parts#define_text('capslock', '')

--- a/autoload/airline/section.vim
+++ b/autoload/airline/section.vim
@@ -5,8 +5,9 @@ call airline#init#bootstrap()
 let s:spc = g:airline_symbols.space
 
 function! s:wrap_accent(part, value)
-  if exists('a:part.accent')
+  if exists('a:part.accent') && !empty(a:part.accent)
     call airline#highlighter#add_accent(a:part.accent)
+
     return '%#__accent_'.(a:part.accent).'#'.a:value.'%#__restore__#'
   endif
   return a:value

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -24,6 +24,7 @@ function! s:init()
   endif
 
   silent doautocmd User AirlineAfterInit
+  call s:on_window_changed()
 endfunction
 
 function! s:on_window_changed()

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -30,13 +30,13 @@ function! s:on_window_changed()
   if pumvisible()
     return
   endif
-  call s:init()
-  call airline#update_statusline()
+  if s:airline_initialized
+    call airline#update_statusline()
+  endif
 endfunction
 
 function! s:on_colorscheme_changed()
-  call s:init()
-  if !s:airline_theme_defined
+  if s:airline_initialized && !s:airline_theme_defined
     if airline#switch_matching_theme()
       return
     endif
@@ -73,8 +73,9 @@ function! s:airline_toggle()
       autocmd CmdwinLeave * call airline#remove_statusline_func('airline#cmdwinenter')
 
       autocmd ColorScheme * call <sid>on_colorscheme_changed()
-      autocmd VimEnter,WinEnter,BufWinEnter,FileType,BufUnload,VimResized *
+      autocmd WinEnter,BufWinEnter,FileType,BufUnload,VimResized *
             \ call <sid>on_window_changed()
+      autocmd VimEnter * call <sid>init()
 
       autocmd BufWritePost */autoload/airline/themes/*.vim
             \ exec 'source '.split(globpath(&rtp, 'autoload/airline/themes/'.g:airline_theme.'.vim', 1), "\n")[0]


### PR DESCRIPTION
inspired by *Add null accent, to allow accents to be removed #385*

`call airline#parts#define_accent('mode', 'red')`
`call airline#parts#define_accent('mode', '')`

can be directly in `.vimrc` or called via `autocmd vimEnter *`