### PR TITLE
Better fallback for invalid colors

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -26,7 +26,7 @@ function! s:get_syn(group, what)
     if has('gui_running') || (has("termtruecolor") && &guicolors == 1)
       let color = a:what ==# 'fg' ? '#000000' : '#FFFFFF'
     else
-      let color = a:what ==# 'fg' ? 0 : 1
+      let color = a:what ==# 'fg' ? 0 : &t_Co == 256 ? 235 : 8
     endif
   endif
   return color

--- a/t/themes.vim
+++ b/t/themes.vim
@@ -27,11 +27,19 @@ describe 'themes'
   end
 
   it 'should pass args through correctly'
-    let hl = airline#themes#get_highlight('Foo', 'bold', 'italic')
-    Expect hl == ['', '', 0, 1, 'bold,italic']
-
+    set t_Co=8
     let hl = airline#themes#get_highlight2(['Foo','bg'], ['Foo','fg'], 'italic', 'bold')
-    Expect hl == ['', '', 1, 0, 'italic,bold']
+    Expect hl == ['', '', 8, 0, 'italic,bold']
+
+    let hl = airline#themes#get_highlight('Foo', 'bold', 'italic')
+    Expect hl == ['', '', 0, 8, 'bold,italic']
+
+    set t_Co=256
+    let hl = airline#themes#get_highlight2(['Foo','bg'], ['Foo','fg'], 'italic', 'bold')
+    Expect hl == ['', '', 235, 0, 'italic,bold']
+
+    let hl = airline#themes#get_highlight('Foo', 'bold', 'italic')
+    Expect hl == ['', '', 0, 235, 'bold,italic']
   end
 
   it 'should generate color map with mirroring'


### PR DESCRIPTION
I have `hi Normal ctermbg=None` in my .vimrc to achieve a transparent background, but it turns the status line in a bloody mess (quite literally, some foreground colors become red and disgusting). This aims to address that issue.

Please note that I just recently started using Vim and that I am completely clueless when it comes to Vimscript, so this solution may not be the preferred one. Please improve it!