### PR TITLE
Git and hg are friends

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -310,6 +310,10 @@ vcscommand   <http://www.vim.org/scripts/script.php?script_id=90>
 * change the text for when no branch is detected >
   let g:airline#extensions#branch#empty_message = ''
 <
+* define the order in which the branches of different vcs systems will be
+  displayed on the statusline (currently only for fugitive and lawrencium) >
+  let g:airline#extensions#branch#vcs_priority = ["git", "mercurial"]
+<
 * use vcscommand.vim if available >
   let g:airline#extensions#branch#use_vcscommand = 0
 <


### PR DESCRIPTION
So, I have both fugitive and lawrencium plugins. My home folder is under mercurial revision. Whenever I open a project under git revision that is somewhere in my home, fugitive would get overpowered by lawrencium, and I would get a useless mercurial default branch, instead of the git branch I was working on. I thought there might be many other setups where one will have a project under both VCS, and showing both branches might be useful, so this is my take on that. I didn't touch the VCSCommand stuff, cause I don't use that plugin, and don't know how it functions.
There was also this found_fugitive_head variable, which would disable check_in_path() check if you had fugitive plugin, even if you are not working with git, so I changed it to work as its name suggest. I don't really understand why the check_in_path() check is needed, but I figured disabling it like that was not good, and the behavior of the variable did not correspond to the message in the commit, where it was added.