### PR TITLE
Problem: CtrlSpace 5.0 integration (statusline + tabline)

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -150,7 +150,7 @@ function! airline#extensions#load()
     call airline#extensions#ctrlp#init(s:ext)
   endif
 
-  if get(g:, 'ctrlspace_loaded', 0)
+  if get(g:, 'CtrlSpaceLoaded', 0)
     call airline#extensions#ctrlspace#init(s:ext)
   endif
 

--- a/autoload/airline/extensions/ctrlspace.vim
+++ b/autoload/airline/extensions/ctrlspace.vim
@@ -6,13 +6,12 @@ let s:padding = s:spc . s:spc . s:spc
 
 function! airline#extensions#ctrlspace#statusline(...)
   let b = airline#builder#new({ 'active': 1 })
-  call b.add_section('airline_a', s:padding . g:ctrlspace_symbols.cs . s:padding)
-  call b.add_section('airline_b', s:padding . ctrlspace#statusline_mode_segment(s:padding))
+  call b.add_section('airline_b', '⌗' . s:padding . ctrlspace#api#StatuslineModeSegment(s:padding))
   call b.split()
-  call b.add_section('airline_x', s:spc . ctrlspace#statusline_tab_segment() . s:spc)
+  call b.add_section('airline_x', s:spc . ctrlspace#api#StatuslineTabSegment() . s:spc)
   return b.build()
 endfunction
 
 function! airline#extensions#ctrlspace#init(ext)
-  let g:ctrlspace_statusline_function = 'airline#extensions#ctrlspace#statusline()'
+  let g:CtrlSpaceStatuslineFunction = "airline#extensions#ctrlspace#statusline()"
 endfunction

--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -10,6 +10,7 @@ if s:taboo
   let g:taboo_tabline = 0
 endif
 
+let s:ctrlspace = get(g:, 'CtrlSpaceLoaded', 0)
 
 function! airline#extensions#tabline#init(ext)
   if has('gui_running')
@@ -27,12 +28,14 @@ function! s:toggle_off()
   call airline#extensions#tabline#autoshow#off()
   call airline#extensions#tabline#tabs#off()
   call airline#extensions#tabline#buffers#off()
+  call airline#extensions#tabline#ctrlspace#off()
 endfunction
 
 function! s:toggle_on()
   call airline#extensions#tabline#autoshow#on()
   call airline#extensions#tabline#tabs#on()
   call airline#extensions#tabline#buffers#on()
+  call airline#extensions#tabline#ctrlspace#on()
 
   set tabline=%!airline#extensions#tabline#get()
 endfunction
@@ -60,19 +63,19 @@ endfunction
 
 function! airline#extensions#tabline#load_theme(palette)
   let colors    = get(a:palette, 'tabline', {})
+  " Theme for tabs on the left
   let l:tab     = get(colors, 'airline_tab', a:palette.normal.airline_b)
   let l:tabsel  = get(colors, 'airline_tabsel', a:palette.normal.airline_a)
   let l:tabtype = get(colors, 'airline_tabtype', a:palette.visual.airline_a)
   let l:tabfill = get(colors, 'airline_tabfill', a:palette.normal.airline_c)
   let l:tabmod  = get(colors, 'airline_tabmod', a:palette.insert.airline_a)
+  let l:tabhid  = get(colors, 'airline_tabhid', a:palette.normal.airline_c)
   if has_key(a:palette, 'normal_modified') && has_key(a:palette.normal_modified, 'airline_c')
     let l:tabmodu = get(colors, 'airline_tabmod_unsel', a:palette.normal_modified.airline_c)
   else
     "Fall back to normal airline_c if modified airline_c isn't present
     let l:tabmodu = get(colors, 'airline_tabmod_unsel', a:palette.normal.airline_c)
   endif
-
-  let l:tabhid  = get(colors, 'airline_tabhid', a:palette.normal.airline_c)
   call airline#highlighter#exec('airline_tab', l:tab)
   call airline#highlighter#exec('airline_tabsel', l:tabsel)
   call airline#highlighter#exec('airline_tabtype', l:tabtype)
@@ -80,6 +83,21 @@ function! airline#extensions#tabline#load_theme(palette)
   call airline#highlighter#exec('airline_tabmod', l:tabmod)
   call airline#highlighter#exec('airline_tabmod_unsel', l:tabmodu)
   call airline#highlighter#exec('airline_tabhid', l:tabhid)
+
+  " Theme for tabs on the right
+  let l:tabsel_right  = get(colors, 'airline_tabsel_right', a:palette.normal.airline_a)
+  let l:tabmod_right  = get(colors, 'airline_tabmod_right', a:palette.insert.airline_a)
+  let l:tabhid_right  = get(colors, 'airline_tabhid_right', a:palette.normal.airline_c)
+  if has_key(a:palette, 'normal_modified') && has_key(a:palette.normal_modified, 'airline_c')
+    let l:tabmodu_right = get(colors, 'airline_tabmod_unsel_right', a:palette.normal_modified.airline_c)
+  else
+    "Fall back to normal airline_c if modified airline_c isn't present
+    let l:tabmodu_right = get(colors, 'airline_tabmod_unsel_right', a:palette.normal.airline_c)
+  endif
+  call airline#highlighter#exec('airline_tabsel_right', l:tabsel_right)
+  call airline#highlighter#exec('airline_tabmod_right', l:tabmod_right)
+  call airline#highlighter#exec('airline_tabhid_right', l:tabhid_right)
+  call airline#highlighter#exec('airline_tabmod_unsel_right', l:tabmodu_right)
 endfunction
 
 let s:current_tabcnt = -1
@@ -89,12 +107,15 @@ function! airline#extensions#tabline#get()
     let s:current_tabcnt = curtabcnt
     call airline#extensions#tabline#tabs#invalidate()
     call airline#extensions#tabline#buffers#invalidate()
+    call airline#extensions#tabline#ctrlspace#invalidate()
   endif
 
   if !exists('#airline#BufAdd#*')
     autocmd airline BufAdd * call <sid>update_tabline()
   endif
-  if s:show_buffers && curtabcnt == 1 || !s:show_tabs
+  if s:ctrlspace
+    return airline#extensions#tabline#ctrlspace#get()
+  elseif s:show_buffers && curtabcnt == 1 || !s:show_tabs
     return airline#extensions#tabline#buffers#get()
   else
     return airline#extensions#tabline#tabs#get()

--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -1,0 +1,97 @@
+" MIT License. Copyright (c) 2016 Kevin Sapper
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+let s:current_bufnr = -1
+let s:current_tabnr = -1
+let s:current_tabline = ''
+
+function! airline#extensions#tabline#ctrlspace#off()
+  augroup airline_tabline_ctrlspace
+    autocmd!
+  augroup END
+endfunction
+
+function! airline#extensions#tabline#ctrlspace#on()
+  augroup airline_tabline_ctrlspace
+    autocmd!
+    autocmd BufDelete * call airline#extensions#tabline#ctrlspace#invalidate()
+  augroup END
+endfunction
+
+function! airline#extensions#tabline#ctrlspace#invalidate()
+  let s:current_bufnr = -1
+  let s:current_tabnr = -1
+endfunction
+
+function! airline#extensions#tabline#ctrlspace#get()
+  let cur_buf = bufnr('%')
+
+  let s:tab_list = ctrlspace#api#TabList()
+  for tab in s:tab_list
+    if tab.current
+      let cur_tab = tab.index
+    endif
+  endfor
+
+  if cur_buf == s:current_bufnr && cur_tab == s:current_tabnr
+    return s:current_tabline
+  endif
+
+  let b = airline#extensions#tabline#new_builder()
+
+  call b.add_section_spaced('airline_tabtype', 'buffers')
+
+  let s:buffer_list = ctrlspace#api#BufferList(cur_tab)
+  for buffer in s:buffer_list
+      if cur_buf == buffer.index
+        if buffer.modified
+          let group = 'airline_tabmod'
+        else
+          let group = 'airline_tabsel'
+        endif
+      else
+        if buffer.modified
+          let group = 'airline_tabmod_unsel'
+        elseif buffer.visible
+          let group = 'airline_tab'
+        else
+          let group = 'airline_tabhid'
+        endif
+      endif
+
+      let buf_name = '%(%{airline#extensions#tabline#get_buffer_name('.buffer.index.')}%)'
+      call b.add_section_spaced(group, buf_name)
+  endfor
+
+
+  call b.add_section('airline_tabfill', '')
+  call b.split()
+  call b.add_section('airline_tabfill', '')
+
+  for tab in s:tab_list
+    if tab.current
+      if tab.modified
+        let group = 'airline_tabmod_right'
+      else
+        let group = 'airline_tabsel_right'
+      endif
+    else
+      if tab.modified
+        let group = 'airline_tabmod_unsel_right'
+      else
+        let group = 'airline_tabhid_right'
+      endif
+    endif
+
+    call b.add_section_spaced(group, tab.title.ctrlspace#api#TabBuffersNumber(tab.index))
+  endfor
+
+  call b.add_section_spaced('airline_tabtype', 'tabs')
+
+  let s:current_bufnr = cur_buf
+  let s:current_tabnr = cur_tab
+  let s:current_tabline = b.build()
+  return s:current_tabline
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -512,6 +512,10 @@ eclim <https://eclim.org>
 
 * enable/disable displaying index of the buffer.
 
+  Note: If you're using ctrlspace the tabline shows your tabs on the right and
+  buffer on the left. Also none of the tabline switches is currently
+  supported!
+
 When enabled, numbers will be displayed in the tabline and mappings will be
 exposed to allow you to select a buffer directly.  Up to 9 mappings will be
 exposed.
@@ -677,6 +681,12 @@ vim-ctrlspace <https://github.com/szw/vim-ctrlspace>
 
 * enable/disable vim-ctrlspace integration >
   let g:airline#extensions#ctrlspace#enabled = 1
+
+  To make the vim-ctrlspace integration work you will need to make the
+  ctrlspace statusline function call the correct airline function. Therefore
+  add the following line into your .vimrc:
+
+  let g:CtrlSpaceStatuslineFunction = "airline#extensions#ctrlspace#statusline()"
 <
 -------------------------------------                    *airline-ycm*
 YouCompleteMe <https://github.com/Valloric/YouCompleteMe>


### PR DESCRIPTION
The PR fixes the CtrlSpace integration for version 5.0 and adds CtrlSpace integration for the tabline.

If you're a user of CtrlSpace both buffers and tabs are shown as suggest in #639.



