### PR TITLE
Hunks: make s:source_func local to buffer

### DIFF
--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -44,22 +44,21 @@ function! s:get_hunks_empty()
   return ''
 endfunction
 
-let s:source_func = ''
 function! s:get_hunks()
-  if empty(s:source_func)
-    if get(g:, 'loaded_signify', 0)
-      let s:source_func = 's:get_hunks_signify'
+  if !exists('b:source_func')
+    if get(g:, 'loaded_signify') && sy#buffer_is_active()
+      let b:source_func = 's:get_hunks_signify'
     elseif exists('*GitGutterGetHunkSummary')
-      let s:source_func = 's:get_hunks_gitgutter'
+      let b:source_func = 's:get_hunks_gitgutter'
     elseif exists('*changes#GetStats')
-      let s:source_func = 's:get_hunks_changes'
+      let b:source_func = 's:get_hunks_changes'
     elseif exists('*quickfixsigns#vcsdiff#GetHunkSummary')
-      let s:source_func = 'quickfixsigns#vcsdiff#GetHunkSummary'
+      let b:source_func = 'quickfixsigns#vcsdiff#GetHunkSummary'
     else
-      let s:source_func = 's:get_hunks_empty'
+      let b:source_func = 's:get_hunks_empty'
     endif
   endif
-  return {s:source_func}()
+  return {b:source_func}()
 endfunction
 
 function! airline#extensions#hunks#get_hunks()


### PR DESCRIPTION
Prior to this change airline set the function for getting hunks only once,
which works as long as you don't use simlar plugins for different VCS at the
same time.

If that was the case, only one plugin would have won, depending on the first
buffer handled by these plugins. And although the code for the other plugin
was run every time, you would never see the actual line changes, since airline
didn't even bother checking.

Now these plugins can be used side-by-side in the same Vim instance, e.g.
gitgutter for, well, git and signify for the rest.

---

Fixes #898.