### PR TITLE
Also draw a nice statusline in the preview window

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -27,7 +27,8 @@ function! s:init()
 endfunction
 
 function! s:on_window_changed()
-  if pumvisible()
+  if pumvisible() && (!&previewwindow ||
+        \ (g:airline_exclude_preview && &previewwindow))
     return
   endif
   call s:init()


### PR DESCRIPTION
This fixes issue #858

previously, the the on_window_changed() function returned early when the
popupmenu was visible, which also means, that a new preview window
created by the popup menu would not be rendered correctly until one
moves into this window.

Therefore, I made it not return early, even if the popup menu was opened
to make sure, it will be rendered. However, since the popup menu is
open, this might have unwanted consequences, if some plugin or other
function from airline calls some normal mode command (e.g. wordcount
which should not be enabled for preview windows). So this might break
subtile in other areas later.

An alternative might be to just document the fact, that airline won't
color preview windows at all. But I don't like that either.

I leave this open for comments.