### PR TITLE
Make the virtualenv extension work better

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -189,7 +189,7 @@ function! airline#extensions#load()
     call airline#extensions#bufferline#init(s:ext)
   endif
 
-  if isdirectory($VIRTUAL_ENV) && get(g:, 'airline#extensions#virtualenv#enabled', 1)
+  if (get(g:, 'airline#extensions#virtualenv#enabled', 1) && exists(':VirtualEnvList'))
     call airline#extensions#virtualenv#init(s:ext)
   endif
 

--- a/autoload/airline/extensions/virtualenv.vim
+++ b/autoload/airline/extensions/virtualenv.vim
@@ -1,10 +1,6 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
-if !isdirectory($VIRTUAL_ENV)
-  finish
-endif
-
 let s:spc = g:airline_symbols.space
 
 function! airline#extensions#virtualenv#init(ext)
@@ -12,14 +8,22 @@ function! airline#extensions#virtualenv#init(ext)
 endfunction
 
 function! airline#extensions#virtualenv#apply(...)
-  if &filetype =~ "python"
+  if &filetype =~# "python"
     if get(g:, 'virtualenv_loaded', 0)
       let statusline = virtualenv#statusline()
     else
       let statusline = fnamemodify($VIRTUAL_ENV, ':t')
     endif
-    call airline#extensions#append_to_section('x',
-          \ s:spc.g:airline_right_alt_sep.s:spc.statusline)
+    if !empty(statusline)
+      call airline#extensions#append_to_section('x',
+            \ s:spc.g:airline_right_alt_sep.s:spc.statusline)
+    endif
   endif
 endfunction
 
+function! airline#extensions#virtualenv#update()
+  if &filetype =~# "python"
+    call airline#extensions#virtualenv#apply()
+    call airline#update_statusline()
+  endif
+endfunction


### PR DESCRIPTION
This fixes #511

It allows the virtualenv plugin to call back and tell the airline plugin
to update the statusline. Therefore, the new function
airline#extensions#virtualenv#update() is provided. However, to properly
fix this issue, the virtualenv plugin needs to call this function.

Second, depending on $VIRTUAL_ENV is not safe, since the virtualenv
plugin might define it itsself when calling :VirtualEnvActivate
Therefore skip this test and just test for existance of he
:VirtualEnvList command.