### PR TITLE
Simplify logic on if statement

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -27,8 +27,7 @@ function! s:init()
 endfunction
 
 function! s:on_window_changed()
-  if pumvisible() && (!&previewwindow ||
-        \ (g:airline_exclude_preview && &previewwindow))
+  if pumvisible() && (!&previewwindow || g:airline_exclude_preview)
     return
   endif
   call s:init()


### PR DESCRIPTION
Referencing the same boolean multiple times in a logical statement is
probably not what was intended.

Here's the truth table for this if statement, which isn't altered:

    pumvisible()|&previewwindow|g:...  |is true
    0           |0             |0      |no
    0           |0             |1      |no
    0           |1             |0      |no
    0           |1             |1      |no
    1           |0             |0      |yes
    1           |0             |1      |yes
    1           |1             |0      |no
    1           |1             |1      |yes