### PR TITLE
Allow to customize the trailing whitespace regexp

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -49,7 +49,14 @@ function! airline#extensions#whitespace#check()
 
     let trailing = 0
     if index(checks, 'trailing') > -1
-      let trailing = search('\s$', 'nw')
+      try
+        let regexp = get(g:, 'airline#extensions#whitespace#trailing_regexp', '\s$')
+        let trailing = search(regexp, 'nw')
+      catch
+        echomsg 'airline#whitespace: error occured evaluating '. regexp
+        echomsg v:exception
+        return ''
+      endtry
     endif
 
     let mixed = 0

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -449,6 +449,9 @@ eclim <https://eclim.org>
   let g:airline#extensions#whitespace#trailing_format = 'trailing[%s]'
   let g:airline#extensions#whitespace#mixed_indent_format = 'mixed-indent[%s]'
   let g:airline#extensions#whitespace#long_format = 'long[%s]'
+
+* configure custom trailing whitespace regexp rule >
+  let g:airline#extensions#whitespace#trailing_regexp = '\s$'
 <
 -------------------------------------                      *airline-tabline*
 * enable/disable enhanced tabline. >


### PR DESCRIPTION
Currently, vim-airline uses hard-coded '\s$' to check for trailing
whitespace. However you might want to check for different values.
Therefore, set the variable
`:let g:airline#extensions#whitespace#trailing_regexp` to the required regexp
value.

closes #663