### PR TITLE
base16-theme: Revert changes for active statusline

### DIFF
--- a/autoload/airline/themes/base16.vim
+++ b/autoload/airline/themes/base16.vim
@@ -79,7 +79,7 @@ else
           \ }
 
     let s:I1 = airline#themes#get_highlight2(['DiffText', 'bg'], ['DiffAdded', 'fg'], 'bold')
-    let s:I2 = airline#themes#get_highlight2(['DiffAdded', 'fg'], ['Visual', 'bg'])
+    let s:I2 = airline#themes#get_highlight2(['DiffAdded', 'fg'], ['Normal', 'bg'])
     let s:I3 = s:N3
     let g:airline#themes#base16#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
     let g:airline#themes#base16#palette.insert_modified = g:airline#themes#base16#palette.normal_modified
@@ -91,7 +91,7 @@ else
     let g:airline#themes#base16#palette.replace_modified = g:airline#themes#base16#palette.normal_modified
 
     let s:V1 = airline#themes#get_highlight2(['DiffText', 'bg'], ['Constant', 'fg'], 'bold')
-    let s:V2 = airline#themes#get_highlight2(['Constant', 'fg'], ['Visual', 'bg'])
+    let s:V2 = airline#themes#get_highlight2(['Constant', 'fg'], ['Normal', 'bg'])
     let s:V3 = s:N3
     let g:airline#themes#base16#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
     let g:airline#themes#base16#palette.visual_modified = g:airline#themes#base16#palette.normal_modified


### PR DESCRIPTION
Hello, https://github.com/vim-airline/vim-airline/pull/893 improved statusline visibility when inactive and that's cool, but it also changed the color of the section when it is active.
Would it be possible to revert those back?