### PR TITLE
cmd.exe: Check for NONE/fg/bg of color value

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -9,6 +9,8 @@ let s:accents = {}
 function! s:gui2cui(rgb, fallback)
   if a:rgb == ''
     return a:fallback
+  elseif match(a:rgb, 'NONE\|[fb]g')
+    return a:rgb
   endif
   let rgb = map(matchlist(a:rgb, '#\(..\)\(..\)\(..\)')[1:3], '0 + ("0x".v:val)')
   let rgb = [rgb[0] > 127 ? 4 : 0, rgb[1] > 127 ? 2 : 0, rgb[2] > 127 ? 1 : 0]


### PR DESCRIPTION
Color values can have NONE/fg/bg values as well, and this would
error out.