### PR TITLE
Always display buffer list in tabline

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -5,6 +5,7 @@ let s:formatter = get(g:, 'airline#extensions#tabline#formatter', 'default')
 let s:show_buffers = get(g:, 'airline#extensions#tabline#show_buffers', 1)
 let s:show_tabs = get(g:, 'airline#extensions#tabline#show_tabs', 1)
 let s:ignore_bufadd_pat = get(g:, 'airline#extensions#tabline#ignore_bufadd_pat', '\c\vgundo|undotree|vimfiler|tagbar|nerd_tree')
+
 let s:taboo = get(g:, 'airline#extensions#taboo#enabled', 1) && get(g:, 'loaded_taboo', 0)
 if s:taboo
   let g:taboo_tabline = 0
@@ -47,7 +48,7 @@ function! s:update_tabline()
   elseif !get(g:, 'airline#extensions#tabline#enabled', 0)
     return
   " return, if buffer matches ignore pattern or is directory (netrw)
-  elseif empty(match) 
+  elseif empty(match)
         \ || match(match, s:ignore_bufadd_pat) > -1
         \ || isdirectory(expand("<afile>"))
     return
@@ -91,6 +92,7 @@ function! airline#extensions#tabline#load_theme(palette)
   call airline#highlighter#exec('airline_tabhid', l:tabhid)
 
   " Theme for tabs on the right
+  let l:tab_right     = get(colors, 'airline_tab_right',    a:palette.normal.airline_b)
   let l:tabsel_right  = get(colors, 'airline_tabsel_right', a:palette.normal.airline_a)
   let l:tabmod_right  = get(colors, 'airline_tabmod_right', a:palette.insert.airline_a)
   let l:tabhid_right  = get(colors, 'airline_tabhid_right', a:palette.normal.airline_c)
@@ -100,6 +102,7 @@ function! airline#extensions#tabline#load_theme(palette)
     "Fall back to normal airline_c if modified airline_c isn't present
     let l:tabmodu_right = get(colors, 'airline_tabmod_unsel_right', a:palette.normal.airline_c)
   endif
+  call airline#highlighter#exec('airline_tab_right',    l:tab_right)
   call airline#highlighter#exec('airline_tabsel_right', l:tabsel_right)
   call airline#highlighter#exec('airline_tabmod_right', l:tabmod_right)
   call airline#highlighter#exec('airline_tabhid_right', l:tabhid_right)
@@ -162,4 +165,25 @@ function! airline#extensions#tabline#new_builder()
   endif
 
   return airline#builder#new(builder_context)
+endfunction
+
+function! airline#extensions#tabline#group_of_bufnr(tab_bufs, bufnr)
+  let cur = bufnr('%')
+  if cur == a:bufnr
+    if g:airline_detect_modified && getbufvar(a:bufnr, '&modified')
+      let group = 'airline_tabmod'
+    else
+      let group = 'airline_tabsel'
+    endif
+    let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
+  else
+    if g:airline_detect_modified && getbufvar(a:bufnr, '&modified')
+      let group = 'airline_tabmod_unsel'
+    elseif index(a:tab_bufs, a:bufnr) > -1
+      let group = 'airline_tab'
+    else
+      let group = 'airline_tabhid'
+    endif
+  endif
+  return group
 endfunction

--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -58,11 +58,6 @@ function! s:update_tabline()
   endif
   call feedkeys("\<Plug>AirlineTablineRefresh")
   call feedkeys("\<Plug>AirlineTablineRefresh")
-  "call feedkeys(',,', 't')
-  "call feedkeys(':unmap ,,')
-  " force re-evaluation of tabline setting
-  " disable explicit redraw, may cause E315
-  "redraw
 endfunction
 
 function! airline#extensions#tabline#load_theme(palette)
@@ -92,8 +87,8 @@ function! airline#extensions#tabline#load_theme(palette)
   call airline#highlighter#exec('airline_tabhid', l:tabhid)
 
   " Theme for tabs on the right
-  let l:tab_right     = get(colors, 'airline_tab_right',    a:palette.normal.airline_b)
   let l:tabsel_right  = get(colors, 'airline_tabsel_right', a:palette.normal.airline_a)
+  let l:tab_right     = get(colors, 'airline_tab_right',    a:palette.inactive.airline_c)
   let l:tabmod_right  = get(colors, 'airline_tabmod_right', a:palette.insert.airline_a)
   let l:tabhid_right  = get(colors, 'airline_tabhid_right', a:palette.normal.airline_c)
   if has_key(a:palette, 'normal_modified') && has_key(a:palette.normal_modified, 'airline_c')

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -62,23 +62,7 @@ function! airline#extensions#tabline#buffers#get()
       continue
     endif
 
-    if cur == nr
-      if g:airline_detect_modified && getbufvar(nr, '&modified')
-        let group = 'airline_tabmod'
-      else
-        let group = 'airline_tabsel'
-      endif
-      let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
-    else
-      if g:airline_detect_modified && getbufvar(nr, '&modified')
-        let group = 'airline_tabmod_unsel'
-      elseif index(tab_bufs, nr) > -1
-        let group = 'airline_tab'
-      else
-        let group = 'airline_tabhid'
-      endif
-    endif
-
+    let group = airline#extensions#tabline#group_of_bufnr(tab_bufs, nr)
     if s:buffer_idx_mode
       if len(s:number_map) > 0
         call b.add_section(group, s:spc . get(s:number_map, l:index, '') . '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)' . s:spc)

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -63,7 +63,7 @@ function! airline#extensions#tabline#tabs#get()
     else
       let group = 'airline_tab_right'
     endif
-    call b.add_section(group, '%'.i.'Ttab '.i)
+    call b.add_section_spaced(group, '%'.i.'Ttab '.i)
   endfor
   call b.add_raw('%<')
 

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -1,11 +1,9 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
-let s:show_tab_nr = get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
-let s:tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
 let s:show_close_button = get(g:, 'airline#extensions#tabline#show_close_button', 1)
-let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
 let s:close_symbol = get(g:, 'airline#extensions#tabline#close_symbol', 'X')
+let s:spc = g:airline_symbols.space
 
 let s:current_bufnr = -1
 let s:current_tabnr = -1
@@ -39,42 +37,39 @@ function! airline#extensions#tabline#tabs#get()
   endif
 
   let b = airline#extensions#tabline#new_builder()
+
+  let buffers = tabpagebuflist(curtab)
+  for nr in buffers
+    let group = airline#extensions#tabline#group_of_bufnr(buffers, nr)
+    call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
+  endfor
+  " truncate
+  call b.add_raw('%<')
+  call b.add_section('airline_tabfill', '')
+  call b.split()
+  call b.add_section('airline_tabfill', '')
+
   for i in range(1, tabpagenr('$'))
     if i == curtab
-      let group = 'airline_tabsel'
+      let group = 'airline_tabsel_right'
       if g:airline_detect_modified
         for bi in tabpagebuflist(i)
           if getbufvar(bi, '&modified')
-            let group = 'airline_tabmod'
+            let group = 'airline_tabmod_right'
           endif
         endfor
       endif
-      let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
+      let s:current_modified = (group == 'airline_tabmod_right') ? 1 : 0
     else
-      let group = 'airline_tab'
+      let group = 'airline_tab_right'
     endif
-    let val = '%('
-    if s:show_tab_nr
-      if s:tab_nr_type == 0
-        let val .= (g:airline_symbols.space).'%{len(tabpagebuflist('.i.'))}'
-      elseif s:tab_nr_type == 1
-        let val .= (g:airline_symbols.space).i
-      else "== 2
-        let val .= (g:airline_symbols.space).i.'.%{len(tabpagebuflist('.i.'))}'
-      endif
-    endif
-    call b.add_section(group, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)')
+    call b.add_section(group, '%'.i.'Ttab '.i)
   endfor
+  call b.add_raw('%<')
 
-  call b.add_raw('%T')
-  call b.add_section('airline_tabfill', '')
-  call b.split()
-  if s:show_close_button
-    call b.add_section('airline_tab', ' %999X'.s:close_symbol.' ')
-  endif
-  if s:show_tab_type
-    call b.add_section('airline_tabtype', ' tabs ')
-  endif
+   if s:show_close_button
+     call b.add_section('airline_tab_right', ' %999X'.s:close_symbol.' ')
+   endif
 
   let s:current_bufnr = curbuf
   let s:current_tabnr = curtab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -2,6 +2,8 @@
 " vim: et ts=2 sts=2 sw=2
 
 let s:show_close_button = get(g:, 'airline#extensions#tabline#show_close_button', 1)
+let s:show_tab_nr = get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
+let s:tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
 let s:close_symbol = get(g:, 'airline#extensions#tabline#close_symbol', 'X')
 let s:spc = g:airline_symbols.space
 
@@ -63,7 +65,17 @@ function! airline#extensions#tabline#tabs#get()
     else
       let group = 'airline_tab_right'
     endif
-    call b.add_section_spaced(group, '%'.i.'Ttab '.i)
+    let val = '%('
+    if s:show_tab_nr
+      if s:tab_nr_type == 0
+        let val .= (g:airline_symbols.space).'%{len(tabpagebuflist('.i.'))}'
+      elseif s:tab_nr_type == 1
+        let val .= (g:airline_symbols.space).i
+      else "== 2
+        let val .= (g:airline_symbols.space).i.'.%{len(tabpagebuflist('.i.'))}'
+      endif
+    endif
+    call b.add_section(group, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)')
   endfor
   call b.add_raw('%<')
 


### PR DESCRIPTION
regardless of how many tabs are open.
fixes #639

Simply set `:let g:airline#extensions#tabline#show_buffers=2`