### PR TITLE
Make FAQ URL reflect new Org

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -917,7 +917,7 @@ A. Certain themes are derived from the active colorscheme by extracting colors
 
 
 Solutions to other common problems can be found in the Wiki:
-<https://github.com/bling/vim-airline/wiki/FAQ>
+<https://github.com/vim-airline/vim-airline/wiki/FAQ>
 
 ==============================================================================
 CONTRIBUTIONS                                        *airline-contributions*


### PR DESCRIPTION
While the URL redirect properly, having all URLs reflect the final
destination is best to present a unified message.

I know know this is not a high-priority, but I thought I'd try to help where I could.