### PR TITLE
Airline error improvements.

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -138,7 +138,9 @@ function! airline#extensions#load()
     call airline#extensions#netrw#init(s:ext)
   endif
 
-  call airline#extensions#ycm#init(s:ext)
+  if exists(':YcmDiag')
+    call airline#extensions#ycm#init(s:ext)
+  endif
 
   if get(g:, 'loaded_vimfiler', 0)
     let g:vimfiler_force_overwrite_statusline = 0

--- a/autoload/airline/extensions/default.vim
+++ b/autoload/airline/extensions/default.vim
@@ -37,6 +37,9 @@ if v:version >= 704 || (v:version >= 703 && has('patch81'))
   function s:add_section(builder, context, key)
     " i have no idea why the warning section needs special treatment, but it's
     " needed to prevent separators from showing up
+    if ((a:key == 'error' || a:key == 'warning') && empty(s:get_section(a:context.winnr, a:key)))
+      return
+    endif
     if (a:key == 'warning' || a:key == 'error')
       call a:builder.add_raw('%(')
     endif

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -84,7 +84,8 @@ function! airline#init#bootstrap()
         \ 'raw': '%{g:airline_symbols.linenr}%#__accent_bold#%4l%#__restore__#',
         \ 'accent': 'bold'})
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
-  call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic', 'eclim', 'whitespace','windowswap'])
+  call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic',
+        \ 'eclim', 'whitespace','windowswap', 'ycm_error_count', 'ycm_warning_count'])
   call airline#parts#define_text('capslock', '')
 
   unlet g:airline#init#bootstrapping


### PR DESCRIPTION
Okay, I haven't tested the YCM stuff completly, mostly because the diff looked straight-forward and I personally found it too much hassle to set up YCM. But here is a thing I noticed, which I don't really like:
If the trailing whitespace extension becomes active, you'll notice a red separator from the warning section. I really don't like this and I don't think this should be like that.
So here is a patch, that tries to prevent that. Note, I am not yet understanding all the complicated sections/parts and builders so I am not sure this is the correct solution (and I don't even know, if YCM still works). But I think it should ;) So please review carefully.