### PR TITLE
Fix runtime error when g:airline_theme is not defined

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -22,7 +22,7 @@ function! s:init()
     try
       let palette = g:airline#themes#{g:airline_theme}#palette
     catch
-      echom 'Could not resolve airline theme "' . g:airline_theme . '". Themes have been migrated to github.com/vim-airline/vim-airline-themes.'
+      echom "Could not resolve g:airline_theme. Themes have been migrated to github.com/vim-airline/vim-airline-themes."
       let g:airline_theme = 'dark'
     endtry
     call airline#switch_theme(g:airline_theme)


### PR DESCRIPTION
I'm getting the following after updating vim-airline:

```
Error detected while processing function <SNR>65_on_window_changed[4]..<SNR>65_init:
line   14:
E121: Undefined variable: g:airline_theme
E15: Invalid expression: 'Could not resolve airline theme "' . g:airline_theme . '". T
hemes have been migrated to github.com/vim-airline/vim-airline-themes.'
```

The patch fixes the issue -- not referencing `g:airline_theme` when it's not defined.