### PR TITLE
Fix issue when an airline theme and an external colorscheme have been defined

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -21,7 +21,7 @@ function! s:init()
       let g:airline_theme = 'dark'
       let s:airline_theme_defined = 1
   endif
-  if !airline#switch_matching_theme()
+  if s:airline_theme_defined || !airline#switch_matching_theme()
     try
       let palette = g:airline#themes#{g:airline_theme}#palette
     catch


### PR DESCRIPTION
Defining a theme in vimrc didn't work if a separate colorscheme had been defined. This was due to airline#switch_matching_theme() returning true since g:colors_name exists. 