### PR TITLE
fix load regression errors with recent theme changes

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -71,14 +71,20 @@ endfunction
 
 function! airline#switch_matching_theme()
   if exists('g:colors_name')
+    let existing = g:airline_theme
     try
       let palette = g:airline#themes#{g:colors_name}#palette
-      silent call airline#switch_theme(g:colors_name)
+      call airline#switch_theme(g:colors_name)
       return 1
     catch
       for map in items(g:airline_theme_map)
         if match(g:colors_name, map[0]) > -1
-          silent call airline#switch_theme(map[1])
+          try
+            let palette = g:airline#themes#{map[1]}#palette
+            call airline#switch_theme(map[1])
+          catch
+            call airline#switch_theme(existing)
+          endtry
           return 1
         endif
       endfor

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -8,7 +8,6 @@ let g:loaded_airline = 1
 
 let s:airline_initialized = 0
 function! s:init()
-  let s:airline_theme_defined = exists('g:airline_theme')
   if s:airline_initialized
     return
   endif
@@ -17,18 +16,18 @@ function! s:init()
   call airline#extensions#load()
   call airline#init#sections()
 
-  if !s:airline_theme_defined
-      let g:airline_theme = 'dark'
-      let s:airline_theme_defined = 1
-  endif
-  if s:airline_theme_defined || !airline#switch_matching_theme()
+  let s:theme_in_vimrc = exists('g:airline_theme')
+  if s:theme_in_vimrc
     try
       let palette = g:airline#themes#{g:airline_theme}#palette
     catch
       echom 'Could not resolve airline theme "' . g:airline_theme . '". Themes have been migrated to github.com/vim-airline/vim-airline-themes.'
       let g:airline_theme = 'dark'
     endtry
-    call airline#switch_theme(g:airline_theme)
+    silent call airline#switch_theme(g:airline_theme)
+  else
+    let g:airline_theme = 'dark'
+    silent call s:on_colorscheme_changed()
   endif
 
   silent doautocmd User AirlineAfterInit
@@ -44,10 +43,8 @@ endfunction
 
 function! s:on_colorscheme_changed()
   call s:init()
-  if !s:airline_theme_defined
-    if airline#switch_matching_theme()
-      return
-    endif
+  if !s:theme_in_vimrc
+    call airline#switch_matching_theme()
   endif
 
   " couldn't find a match, or theme was defined, just refresh


### PR DESCRIPTION
@chrisbra i'm getting load errors on HEAD after the latest changes if i have `g:airline_theme` defined, here's a patch that fixes it.  didn't want to commit directly without another set of eyes first.

here are a couple test cases i've thought of that need to work.

- [ ] themes repo not installed, dark theme selected by default, changing colorschemes does nothing.
- [ ] themes repo installed, matching colorscheme selected by default, changing colorschemes also selects matching theme.
- [ ] themes repo not installed, `g:airline_theme` defined, it should get ignored and revert to 'dark'.
- [ ] themes repo installed, `g:airline_theme` trumps everything, if invalid, displays error message about themes repo moved.