### PR TITLE
Fix highlighting problems with Vim

### DIFF
--- a/autoload/airline/extensions/default.vim
+++ b/autoload/airline/extensions/default.vim
@@ -1,6 +1,7 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+let s:section_use_groups     = get(g:, 'airline#extensions#default#section_use_groupitems', 1)
 let s:section_truncate_width = get(g:, 'airline#extensions#default#section_truncate_width', {
       \ 'b': 79,
       \ 'x': 60,
@@ -35,7 +36,10 @@ function! s:build_sections(builder, context, keys)
   endfor
 endfunction
 
-if v:version >= 704 || (v:version >= 703 && has('patch81'))
+" There still is a highlighting bug when using groups %(%) in the statusline,
+" deactivate it, until this is properly fixed:
+" https://groups.google.com/d/msg/vim_dev/sb1jmVirXPU/mPhvDnZ-CwAJ
+if s:section_use_groups && (v:version >= 704 || (v:version >= 703 && has('patch81')))
   function s:add_section(builder, context, key)
     " i have no idea why the warning section needs special treatment, but it's
     " needed to prevent separators from showing up

--- a/autoload/airline/themes.vim
+++ b/autoload/airline/themes.vim
@@ -40,7 +40,7 @@ function! airline#themes#patch(palette)
       let a:palette[mode]['airline_warning'] = [ '#000000', '#df5f00', 232, 190 ]
     endif
     if !has_key(a:palette[mode], 'airline_error')
-      let a:palette[mode]['airline_error'] = [ '#000000', '#df5f00', 232, 160 ]
+      let a:palette[mode]['airline_error'] = [ '#000000', '#990000', 232, 160 ]
     endif
   endfor
 

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -285,6 +285,10 @@ configuration values that you can use.
       \ [ 'x', 'y', 'z', 'error', 'warning' ]
       \ ]
 <
+* configure the layout to not use %(%) grouping items in the statusline.
+  Try setting this to zero, if you notice bleeding color artifacts >
+  let airline#extensions#default#section_use_groupitems = 1
+<
 -------------------------------------                     *airline-quickfix*
 The quickfix extension is a simple built-in extension which determines
 whether the buffer is a quickfix or location list buffer, and adjusts the


### PR DESCRIPTION
1) Make sure airline_error and airline_warning highlighting are
   different, so that the correct separator will be drawn. This
   fixes #982.

2) allow to deactivate %(%) to workaround a vim bug, that may cause
   leaking of colors from one section to the next and adding additional
   spaces. This needs to be fixed upstream:
   https://groups.google.com/d/msg/vim_dev/sb1jmVirXPU/mPhvDnZ-CwAJ
   Possibly, also related to neovim/neovim#4147
   Use `:let airline#extensions#default#section_use_groupitems = 0`
   to disable grouping of statusline items