### PR TITLE
Neovim true color support

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -77,7 +77,7 @@ function! s:should_change_group(group1, group2)
   endif
   let color1 = airline#highlighter#get_highlight(a:group1)
   let color2 = airline#highlighter#get_highlight(a:group2)
-  if has('gui_running') || (has("termtruecolor") && &guicolors == 1)
+  if has('gui_running') || has('nvim') || (has("termtruecolor") && &guicolors == 1)
     return color1[1] != color2[1] || color1[0] != color2[0]
   else
     return color1[3] != color2[3] || color1[2] != color2[2]

--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -12,7 +12,7 @@ endif
 
 
 function! airline#extensions#tabline#init(ext)
-  if has('gui_running')
+  if has('nvim') || has('gui_running')
     set guioptions-=e
   endif
 

--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -18,13 +18,13 @@ endfunction
 
 function! s:get_syn(group, what)
   " need to pass in mode, known to break on 7.3.547
-  let mode = has('gui_running') || (has("termtruecolor") && &guicolors == 1) ? 'gui' : 'cterm'
+  let mode = has('nvim') || has('gui_running') || (has("termtruecolor") && &guicolors == 1) ? 'gui' : 'cterm'
   let color = synIDattr(synIDtrans(hlID(a:group)), a:what, mode)
   if empty(color) || color == -1
     let color = synIDattr(synIDtrans(hlID('Normal')), a:what, mode)
   endif
   if empty(color) || color == -1
-    if has('gui_running') || (has("termtruecolor") && &guicolors == 1)
+    if has('nvim') || has('gui_running') || (has("termtruecolor") && &guicolors == 1)
       let color = a:what ==# 'fg' ? '#000000' : '#FFFFFF'
     else
       let color = a:what ==# 'fg' ? 0 : 1
@@ -36,7 +36,7 @@ endfunction
 function! s:get_array(fg, bg, opts)
   let fg = a:fg
   let bg = a:bg
-  return has('gui_running') || (has("termtruecolor") && &guicolors == 1)
+  return has('nvim') || has('gui_running') || (has("termtruecolor") && &guicolors == 1)
         \ ? [ fg, bg, '', '', join(a:opts, ',') ]
         \ : [ '', '', fg, bg, join(a:opts, ',') ]
 endfunction
@@ -44,7 +44,7 @@ endfunction
 function! airline#highlighter#get_highlight(group, ...)
   let fg = s:get_syn(a:group, 'fg')
   let bg = s:get_syn(a:group, 'bg')
-  let reverse = has('gui_running') || (has("termtruecolor") && &guicolors == 1)
+  let reverse = has('nvim') || has('gui_running') || (has("termtruecolor") && &guicolors == 1)
         \ ? synIDattr(synIDtrans(hlID(a:group)), 'reverse', 'gui')
         \ : synIDattr(synIDtrans(hlID(a:group)), 'reverse', 'cterm')
         \|| synIDattr(synIDtrans(hlID(a:group)), 'reverse', 'term')


### PR DESCRIPTION
After [this change](https://github.com/neovim/neovim/pull/4155), neovim no longer sets `gui_running` when running in true color mode (via `NVIM_TUI_ENABLE_TRUE_COLOR` env variable).

This results in neovim always running in low color mode on airline.

With this PR, `has('nvim')` checks are added wherever you are checking for true color support. This makes `vim-airline` work as expected on neovim.