### PR TITLE
update_tabline() may cause E315

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -50,9 +50,12 @@ function! s:update_tabline()
     return
   endif
   " force re-evaluation of tabline setting
-  set mod!
-  redraw
-  set mod!
+  sil call feedkeys(":set mod!\n")
+  sil call feedkeys(":set mod!\n")
+  " disable explicit redraw, may cause E315
+  " https://groups.google.com/d/msg/vim_dev/fYl4dP1i9fo/rPT5f7h1DAAJ
+  "redraw
+  "set mod!
 endfunction
 
 function! airline#extensions#tabline#load_theme(palette)


### PR DESCRIPTION
This is probably a bug in Vim because redrawing might cause
Vim to actually try to access a line of the buffer, that hasn't
been loaded yet.

Therefore try to update the tabline, by performing a two :set mod!
calls.