### PR TITLE
Detect inconsistent mixed indentation in a file

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -467,7 +467,11 @@ eclim <https://eclim.org>
   let g:airline#extensions#whitespace#symbol = '!'
 <
 * configure which whitespace checks to enable. >
-  let g:airline#extensions#whitespace#checks = [ 'indent', 'trailing', 'long' ]
+  " indent: mixed indent within a line
+  " long:   overlong lines
+  " trailing: trailing whitespace
+  " mixed-indent-file: different indentation in different lines
+  let g:airline#extensions#whitespace#checks = [ 'indent', 'trailing', 'long', 'mixed-indent-file' ]
 <
 * configure the maximum number of lines where whitespace checking is enabled. >
   let g:airline#extensions#whitespace#max_lines = 20000
@@ -479,6 +483,7 @@ eclim <https://eclim.org>
   let g:airline#extensions#whitespace#trailing_format = 'trailing[%s]'
   let g:airline#extensions#whitespace#mixed_indent_format = 'mixed-indent[%s]'
   let g:airline#extensions#whitespace#long_format = 'long[%s]'
+  let g:airline#extensions#whitespace#mixed_indent_file_format = 'mix-indent-file[%s]'
 
 * configure custom trailing whitespace regexp rule >
   let g:airline#extensions#whitespace#trailing_regexp = '\s$'


### PR DESCRIPTION
This is an extension to the whitespace extension.
It can now detect, if there is mixed indentation used within a file,
e.g. (using space for indentation on some lines and using tabs on other
lines.

This fixes #560