### PR TITLE
check tabpagenr

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -179,10 +179,12 @@ function! airline#check_mode(winnr)
   endif
 
   let mode_string = join(l:mode)
-  if get(w:, 'airline_lastmode', '') != mode_string
+  if get(w:, 'airline_lastmode', '') != mode_string ||
+      \ get(s:, 'airline_lastmode', []) != l:mode
     call airline#highlighter#highlight_modified_inactive(context.bufnr)
     call airline#highlighter#highlight(l:mode)
     let w:airline_lastmode = mode_string
+    let s:airline_lastmode = l:mode
   endif
 
   return ''


### PR DESCRIPTION
Mode is only cached per window. This will break, if one switches tabpage. Therefore, we also need to save the mode per tabpagenr. This fixes #670 