### PR TITLE
airline#highlighter: s:get_syn: fallback to 'NONE'

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -25,11 +25,7 @@ function! s:get_syn(group, what)
     let color = synIDattr(synIDtrans(hlID('Normal')), a:what, g:airline_gui_mode)
   endif
   if empty(color) || color == -1
-    if g:airline_gui_mode ==# 'gui'
-      let color = a:what ==# 'fg' ? '#000000' : '#FFFFFF'
-    else
-      let color = a:what ==# 'fg' ? 0 : 1
-    endif
+    let color = 'NONE'
   endif
   return color
 endfunction

--- a/t/themes.vim
+++ b/t/themes.vim
@@ -28,10 +28,10 @@ describe 'themes'
 
   it 'should pass args through correctly'
     let hl = airline#themes#get_highlight('Foo', 'bold', 'italic')
-    Expect hl == ['', '', 0, 1, 'bold,italic']
+    Expect hl == ['', '', 'NONE', 'NONE', 'bold,italic']
 
     let hl = airline#themes#get_highlight2(['Foo','bg'], ['Foo','fg'], 'italic', 'bold')
-    Expect hl == ['', '', 1, 0, 'italic,bold']
+    Expect hl == ['', '', 'NONE', 'NONE', 'italic,bold']
   end
 
   it 'should generate color map with mirroring'


### PR DESCRIPTION
This is required when used with 'Normal' with a transparent background.
Falling back to 1 here results in "red" for "ctermbg"!

I think it's important to keep the 'NONE' color property here, instead
of hardcoding the fallbacks (even if white would be used instead of
red).