### PR TITLE
Revert term highlighting of airline_warning to orange

### DIFF
--- a/autoload/airline/themes.vim
+++ b/autoload/airline/themes.vim
@@ -37,7 +37,7 @@ endfunction
 function! airline#themes#patch(palette)
   for mode in keys(a:palette)
     if !has_key(a:palette[mode], 'airline_warning')
-      let a:palette[mode]['airline_warning'] = [ '#000000', '#df5f00', 232, 190 ]
+      let a:palette[mode]['airline_warning'] = [ '#000000', '#df5f00', 232, 166 ]
     endif
     if !has_key(a:palette[mode], 'airline_error')
       let a:palette[mode]['airline_error'] = [ '#000000', '#990000', 232, 160 ]


### PR DESCRIPTION
Highlighting was changed with commit 06f2cb5a89931284ac0a8
Revert it to the old colors.