### PR TITLE
Problem: Cannot rename the labels for buffers and tabs

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -5,6 +5,7 @@ let s:formatter = get(g:, 'airline#extensions#tabline#formatter', 'default')
 let s:show_buffers = get(g:, 'airline#extensions#tabline#show_buffers', 1)
 let s:show_tabs = get(g:, 'airline#extensions#tabline#show_tabs', 1)
 let s:ignore_bufadd_pat = get(g:, 'airline#extensions#tabline#ignore_bufadd_pat', '\c\vgundo|undotree|vimfiler|tagbar|nerd_tree')
+
 let s:taboo = get(g:, 'airline#extensions#taboo#enabled', 1) && get(g:, 'loaded_taboo', 0)
 if s:taboo
   let g:taboo_tabline = 0
@@ -47,7 +48,7 @@ function! s:update_tabline()
   elseif !get(g:, 'airline#extensions#tabline#enabled', 0)
     return
   " return, if buffer matches ignore pattern or is directory (netrw)
-  elseif empty(match) 
+  elseif empty(match)
         \ || match(match, s:ignore_bufadd_pat) > -1
         \ || isdirectory(expand("<afile>"))
     return
@@ -57,11 +58,6 @@ function! s:update_tabline()
   endif
   call feedkeys("\<Plug>AirlineTablineRefresh")
   call feedkeys("\<Plug>AirlineTablineRefresh")
-  "call feedkeys(',,', 't')
-  "call feedkeys(':unmap ,,')
-  " force re-evaluation of tabline setting
-  " disable explicit redraw, may cause E315
-  "redraw
 endfunction
 
 function! airline#extensions#tabline#load_theme(palette)
@@ -92,6 +88,7 @@ function! airline#extensions#tabline#load_theme(palette)
 
   " Theme for tabs on the right
   let l:tabsel_right  = get(colors, 'airline_tabsel_right', a:palette.normal.airline_a)
+  let l:tab_right     = get(colors, 'airline_tab_right',    a:palette.inactive.airline_c)
   let l:tabmod_right  = get(colors, 'airline_tabmod_right', a:palette.insert.airline_a)
   let l:tabhid_right  = get(colors, 'airline_tabhid_right', a:palette.normal.airline_c)
   if has_key(a:palette, 'normal_modified') && has_key(a:palette.normal_modified, 'airline_c')
@@ -100,6 +97,7 @@ function! airline#extensions#tabline#load_theme(palette)
     "Fall back to normal airline_c if modified airline_c isn't present
     let l:tabmodu_right = get(colors, 'airline_tabmod_unsel_right', a:palette.normal.airline_c)
   endif
+  call airline#highlighter#exec('airline_tab_right',    l:tab_right)
   call airline#highlighter#exec('airline_tabsel_right', l:tabsel_right)
   call airline#highlighter#exec('airline_tabmod_right', l:tabmod_right)
   call airline#highlighter#exec('airline_tabhid_right', l:tabhid_right)
@@ -162,4 +160,25 @@ function! airline#extensions#tabline#new_builder()
   endif
 
   return airline#builder#new(builder_context)
+endfunction
+
+function! airline#extensions#tabline#group_of_bufnr(tab_bufs, bufnr)
+  let cur = bufnr('%')
+  if cur == a:bufnr
+    if g:airline_detect_modified && getbufvar(a:bufnr, '&modified')
+      let group = 'airline_tabmod'
+    else
+      let group = 'airline_tabsel'
+    endif
+    let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
+  else
+    if g:airline_detect_modified && getbufvar(a:bufnr, '&modified')
+      let group = 'airline_tabmod_unsel'
+    elseif index(a:tab_bufs, a:bufnr) > -1
+      let group = 'airline_tab'
+    else
+      let group = 'airline_tabhid'
+    endif
+  endif
+  return group
 endfunction

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -5,6 +5,7 @@ scriptencoding utf-8
 
 let s:buffer_idx_mode = get(g:, 'airline#extensions#tabline#buffer_idx_mode', 0)
 let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
+let s:buffers_label = get(g:, 'airline#extensions#tabline#buffers_label', 'buffers')
 let s:spc = g:airline_symbols.space
 
 let s:current_bufnr = -1
@@ -64,23 +65,7 @@ function! airline#extensions#tabline#buffers#get()
       continue
     endif
 
-    if cur == nr
-      if g:airline_detect_modified && getbufvar(nr, '&modified')
-        let group = 'airline_tabmod'
-      else
-        let group = 'airline_tabsel'
-      endif
-      let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
-    else
-      if g:airline_detect_modified && getbufvar(nr, '&modified')
-        let group = 'airline_tabmod_unsel'
-      elseif index(tab_bufs, nr) > -1
-        let group = 'airline_tab'
-      else
-        let group = 'airline_tabhid'
-      endif
-    endif
-
+    let group = airline#extensions#tabline#group_of_bufnr(tab_bufs, nr)
     if s:buffer_idx_mode
       if len(s:number_map) > 0
         call b.add_section(group, s:spc . get(s:number_map, l:index, '') . '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)' . s:spc)
@@ -97,7 +82,7 @@ function! airline#extensions#tabline#buffers#get()
   call b.split()
   call b.add_section('airline_tabfill', '')
   if s:show_tab_type
-    call b.add_section('airline_tabtype', ' buffers ')
+    call b.add_section_spaced('airline_tabtype', s:buffers_label)
   endif
 
   let s:current_bufnr = cur

--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -7,6 +7,9 @@ let s:current_bufnr = -1
 let s:current_tabnr = -1
 let s:current_tabline = ''
 
+let s:buffers_label = get(g:, 'airline#extensions#tabline#buffers_label', 'buffers')
+let s:tabs_label = get(g:, 'airline#extensions#tabline#tabs_label', 'tabs')
+
 function! airline#extensions#tabline#ctrlspace#off()
   augroup airline_tabline_ctrlspace
     autocmd!
@@ -41,7 +44,7 @@ function! airline#extensions#tabline#ctrlspace#get()
 
   let b = airline#extensions#tabline#new_builder()
 
-  call b.add_section_spaced('airline_tabtype', 'buffers')
+  call b.add_section_spaced('airline_tabtype', s:buffers_label)
 
   let s:buffer_list = ctrlspace#api#BufferList(cur_tab)
   for buffer in s:buffer_list
@@ -88,7 +91,7 @@ function! airline#extensions#tabline#ctrlspace#get()
     call b.add_section_spaced(group, tab.title.ctrlspace#api#TabBuffersNumber(tab.index))
   endfor
 
-  call b.add_section_spaced('airline_tabtype', 'tabs')
+  call b.add_section_spaced('airline_tabtype', s:tabs_label)
 
   let s:current_bufnr = cur_buf
   let s:current_tabnr = cur_tab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -1,11 +1,14 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
-let s:show_tab_nr = get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
-let s:tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
 let s:show_close_button = get(g:, 'airline#extensions#tabline#show_close_button', 1)
 let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
+let s:show_tab_nr = get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
+let s:tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
 let s:close_symbol = get(g:, 'airline#extensions#tabline#close_symbol', 'X')
+let s:tabs_label = get(g:, 'airline#extensions#tabline#tabs_label', 'tabs')
+let s:show_splits = get(g:, 'airline#extensions#tabline#show_splits', 1)
+let s:spc = g:airline_symbols.space
 
 let s:current_bufnr = -1
 let s:current_tabnr = -1
@@ -39,19 +42,20 @@ function! airline#extensions#tabline#tabs#get()
   endif
 
   let b = airline#extensions#tabline#new_builder()
+
   for i in range(1, tabpagenr('$'))
     if i == curtab
-      let group = 'airline_tabsel'
+      let group = 'airline_tabsel_right'
       if g:airline_detect_modified
         for bi in tabpagebuflist(i)
           if getbufvar(bi, '&modified')
-            let group = 'airline_tabmod'
+            let group = 'airline_tabmod_right'
           endif
         endfor
       endif
-      let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
+      let s:current_modified = (group == 'airline_tabmod_right') ? 1 : 0
     else
-      let group = 'airline_tab'
+      let group = 'airline_tab_right'
     endif
     let val = '%('
     if s:show_tab_nr
@@ -66,14 +70,22 @@ function! airline#extensions#tabline#tabs#get()
     call b.add_section(group, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)')
   endfor
 
-  call b.add_raw('%T')
   call b.add_section('airline_tabfill', '')
   call b.split()
+  call b.add_section('airline_tabfill', '')
+
   if s:show_close_button
-    call b.add_section('airline_tab', ' %999X'.s:close_symbol.' ')
+    call b.add_section('airline_tab_right', ' %999X'.s:close_symbol.' ')
   endif
-  if s:show_tab_type
-    call b.add_section('airline_tabtype', ' tabs ')
+
+  if s:show_splits == 1
+    let buffers = tabpagebuflist(curtab)
+    for nr in buffers
+      let group = airline#extensions#tabline#group_of_bufnr(buffers, nr)
+      call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
+    endfor
+  elseif s:show_tab_type == 1
+    call b.add_section_spaced('airline_tabtype', s:tabs_label)
   endif
 
   let s:current_bufnr = curbuf

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -49,6 +49,7 @@ function! airline#init#bootstrap()
   call extend(g:airline_theme_map, {
         \ 'Tomorrow.*': 'tomorrow',
         \ 'base16.*': 'base16',
+        \ 'bubblegum': 'bubblegum',
         \ 'mo[l|n]okai': 'molokai',
         \ 'wombat.*': 'wombat',
         \ '.*zenburn.*': 'zenburn',

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -518,8 +518,14 @@ eclim <https://eclim.org>
 * enable/disable displaying index of the buffer.
 
   Note: If you're using ctrlspace the tabline shows your tabs on the right and
-  buffer on the left. Also none of the tabline switches is currently
+  buffer on the left. Also none of the above tabline switches is currently
   supported!
+
+* rename label for buffers (default: 'buffers')
+  let g:airline#extensions#tabline#buffers_label = 'b'
+
+* rename label for tabs (default: 'tabs')
+  let g:airline#extensions#tabline#tabs_label = 't'
 
   When enabled, numbers will be displayed in the tabline and mappings will be
   exposed to allow you to select a buffer directly.  Up to 9 mappings will be


### PR DESCRIPTION
Solution: Add an option for the user to configure those labels and make
the current values the default ones.