### PR TITLE
Problem: Cannot rename the labels for buffers and tabs

### DIFF
--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -5,6 +5,7 @@ scriptencoding utf-8
 
 let s:buffer_idx_mode = get(g:, 'airline#extensions#tabline#buffer_idx_mode', 0)
 let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
+let s:buffers_label = get(g:, 'airline#extensions#tabline#buffers_label', 'buffers')
 let s:spc = g:airline_symbols.space
 
 let s:current_bufnr = -1
@@ -81,7 +82,7 @@ function! airline#extensions#tabline#buffers#get()
   call b.split()
   call b.add_section('airline_tabfill', '')
   if s:show_tab_type
-    call b.add_section('airline_tabtype', ' buffers ')
+    call b.add_section_spaced('airline_tabtype', s:buffers_label)
   endif
 
   let s:current_bufnr = cur

--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -7,6 +7,9 @@ let s:current_bufnr = -1
 let s:current_tabnr = -1
 let s:current_tabline = ''
 
+let s:buffers_label = get(g:, 'airline#extensions#tabline#buffers_label', 'buffers')
+let s:tabs_label = get(g:, 'airline#extensions#tabline#tabs_label', 'tabs')
+
 function! airline#extensions#tabline#ctrlspace#off()
   augroup airline_tabline_ctrlspace
     autocmd!
@@ -41,7 +44,7 @@ function! airline#extensions#tabline#ctrlspace#get()
 
   let b = airline#extensions#tabline#new_builder()
 
-  call b.add_section_spaced('airline_tabtype', 'buffers')
+  call b.add_section_spaced('airline_tabtype', s:buffers_label)
 
   let s:buffer_list = ctrlspace#api#BufferList(cur_tab)
   for buffer in s:buffer_list
@@ -88,7 +91,7 @@ function! airline#extensions#tabline#ctrlspace#get()
     call b.add_section_spaced(group, tab.title.ctrlspace#api#TabBuffersNumber(tab.index))
   endfor
 
-  call b.add_section_spaced('airline_tabtype', 'tabs')
+  call b.add_section_spaced('airline_tabtype', s:tabs_label)
 
   let s:current_bufnr = cur_buf
   let s:current_tabnr = cur_tab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -6,6 +6,7 @@ let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
 let s:show_tab_nr = get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
 let s:tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
 let s:close_symbol = get(g:, 'airline#extensions#tabline#close_symbol', 'X')
+let s:tabs_label = get(g:, 'airline#extensions#tabline#tabs_label', 'tabs')
 let s:show_splits = get(g:, 'airline#extensions#tabline#show_splits', 1)
 let s:spc = g:airline_symbols.space
 
@@ -84,7 +85,7 @@ function! airline#extensions#tabline#tabs#get()
       call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
     endfor
   elseif s:show_tab_type == 1
-    call b.add_section('airline_tabtype', ' tabs ')
+    call b.add_section_spaced('airline_tabtype', s:tabs_label)
   endif
 
   let s:current_bufnr = curbuf

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -518,8 +518,14 @@ eclim <https://eclim.org>
 * enable/disable displaying index of the buffer.
 
   Note: If you're using ctrlspace the tabline shows your tabs on the right and
-  buffer on the left. Also none of the tabline switches is currently
+  buffer on the left. Also none of the above tabline switches is currently
   supported!
+
+* rename label for buffers (default: 'buffers')
+  let g:airline#extensions#tabline#buffers_label = 'b'
+
+* rename label for tabs (default: 'tabs')
+  let g:airline#extensions#tabline#tabs_label = 't'
 
   When enabled, numbers will be displayed in the tabline and mappings will be
   exposed to allow you to select a buffer directly.  Up to 9 mappings will be


### PR DESCRIPTION
Solution: Add an option for the user to configure those labels and make
the current values the default ones.