### PR TITLE
Fix highlighting of current/modified buffer.

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -170,7 +170,6 @@ function! airline#extensions#tabline#group_of_bufnr(tab_bufs, bufnr)
     else
       let group = 'airline_tabsel'
     endif
-    let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
   else
     if g:airline_detect_modified && getbufvar(a:bufnr, '&modified')
       let group = 'airline_tabmod_unsel'

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -66,6 +66,7 @@ function! airline#extensions#tabline#buffers#get()
     endif
 
     let group = airline#extensions#tabline#group_of_bufnr(tab_bufs, nr)
+    let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
     if s:buffer_idx_mode
       if len(s:number_map) > 0
         call b.add_section(group, s:spc . get(s:number_map, l:index, '') . '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)' . s:spc)


### PR DESCRIPTION
Fixes broken variable reference caused by e4ef624 (#952).

See https://github.com/vim-airline/vim-airline-themes/issues/16.  This fixes a bug that caused the buffer to incorrectly appear modified (blue in the dark theme) after 1) opening the file from within vim, or 2) modifying and then saving the buffer.