### PR TITLE
Fix matching of themes to color names

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -71,7 +71,7 @@ endfunction
 
 function! airline#switch_matching_theme()
   if exists('g:colors_name')
-    let existing = g:airline_theme
+    let existing = substitute(g:airline_theme, '-', '_', 'g')
     try
       let palette = g:airline#themes#{g:colors_name}#palette
       call airline#switch_theme(g:colors_name)

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -47,13 +47,12 @@ function! airline#init#bootstrap()
 
   call s:check_defined('g:airline_theme_map', {})
   call extend(g:airline_theme_map, {
-        \ 'Tomorrow.*': 'tomorrow',
-        \ 'base16.*': 'base16',
-        \ 'bubblegum': 'bubblegum',
+        \ '\CTomorrow': 'tomorrow',
+        \ 'base16': 'base16',
         \ 'mo[l|n]okai': 'molokai',
-        \ 'wombat.*': 'wombat',
-        \ '.*zenburn.*': 'zenburn',
-        \ '.*solarized.*': 'solarized',
+        \ 'wombat': 'wombat',
+        \ 'zenburn': 'zenburn',
+        \ 'solarized': 'solarized',
         \ }, 'keep')
 
   call s:check_defined('g:airline_symbols', {})


### PR DESCRIPTION
theme usually use '_' instead of '-', so replace that first before
trying to match.

Second, make the patterns easier to match.

Third, make sure, match for Tomorrow happens with matching case

fixes #1056