### PR TITLE
[RFC] Add g:airline_extensions_add setting

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -128,6 +128,12 @@ function! airline#extensions#load()
     return
   endif
 
+  if exists('g:airline_extensions_add')
+    for ext in g:airline_extensions_add
+      call airline#extensions#{ext}#init(s:ext)
+    endfor
+  endif
+
   call airline#extensions#quickfix#init(s:ext)
 
   if get(g:, 'loaded_unite', 0)


### PR DESCRIPTION
This is useful if you want to specify some extension(s) to load, but
without providing/generating the whole list (as with
`g:airline_extensions`).

This is especially useful with `g:airline#extensions#disable_rtp_load = 1`,
which I am using mostly for performance reasons.

TODO:

 - [ ] documentation