### PR TITLE
windowswap: use new tab-aware API if WS is up to date

### DIFF
--- a/autoload/airline/extensions/windowswap.vim
+++ b/autoload/airline/extensions/windowswap.vim
@@ -15,7 +15,11 @@ function! airline#extensions#windowswap#init(ext)
 endfunction
 
 function! airline#extensions#windowswap#get_status()
-  if WindowSwap#HasMarkedWindow() && WindowSwap#GetMarkedWindowNum() == winnr()
+  " use new tab-aware api if WS is up to date
+  let s:mark = exists('*WindowSwap#IsCurrentWindowMarked') ?
+    \WindowSwap#IsCurrentWindowMarked() :
+    \(WindowSwap#HasMarkedWindow() && WindowSwap#GetMarkedWindowNum() == winnr())
+  if s:mark
     return g:airline#extensions#windowswap#indicator_text.s:spc
   endif
   return ''


### PR DESCRIPTION
I'm about to add support for window swapping across tabs. I've added a new API that's tab-aware and kept the existing one for backwards compatibility. This extension will work with both new and old versions.