### PR TITLE
Add support for getting tab title from t:title

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -131,6 +131,10 @@ function! airline#extensions#tabline#title(n)
     let title = TabooTabTitle(a:n)
   endif
 
+  if empty(title) && exists('*gettabvar')
+    let title = gettabvar(a:n, 'title')
+  endif
+
   if empty(title)
     let buflist = tabpagebuflist(a:n)
     let winnr = tabpagewinnr(a:n)


### PR DESCRIPTION
Uses `gettabvar` to get tab name.