### PR TITLE
Make c_like_langs variable customisable in VIMRC

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -18,7 +18,7 @@ let s:max_lines = get(g:, 'airline#extensions#whitespace#max_lines', 20000)
 
 let s:enabled = get(g:, 'airline#extensions#whitespace#enabled', 1)
 
-let s:c_like_langs = ['c', 'cpp', 'javascript', 'ld']
+let s:c_like_langs = get(g:, 'airline#extensions#c_like_langs', [ 'c', 'cpp', 'javascript', 'ld' ])
 
 function! s:check_mixed_indent()
   if s:indent_algo == 1


### PR DESCRIPTION
I keep getting mix-indent-file in PHP files when I use multi-line comments ('/** */'). Being able to customise this would be very handy for me.