### PR TITLE
Make middle clickable buffers (only Neovim)

### DIFF
--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -73,7 +73,7 @@ function! airline#extensions#tabline#buffers#get()
 
     " Neovim feature: Have clickable buffers
     if has("tablineat")
-      call b.add_raw('%'.nr.'@airline#extensions#tabline#buffers#switchbuf@')
+      call b.add_raw('%'.nr.'@airline#extensions#tabline#buffers#clickbuf@')
     endif
     if s:buffer_idx_mode
       if len(s:number_map) > 0
@@ -196,10 +196,18 @@ function s:map_keys()
   endif
 endfunction
 
-function airline#extensions#tabline#buffers#switchbuf(minwid, clicks, button, modifiers) abort
-    " Run the following code only on a single left mouse button click without modifiers pressed
+function airline#extensions#tabline#buffers#clickbuf(minwid, clicks, button, modifiers) abort
+    " Clickable buffers
     " works only in recent NeoVim with has('tablineat')
-    if a:clicks == 1 && a:button is# 'l' && a:modifiers !~# '[^ ]'
-        sil execute 'buffer' a:minwid
+
+    " single mouse button click without modifiers pressed
+    if a:clicks == 1 && a:modifiers !~# '[^ ]'
+      if a:button is# 'l'
+        " left button - switch to buffer
+        silent execute 'buffer' a:minwid
+      elseif a:button is# 'm'
+        " middle button - delete buffer
+        silent execute 'bdelete' a:minwid
+      endif
     endif
 endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -508,6 +508,11 @@ are supported!
 * enable/disable displaying buffers with a single tab. (c)
   let g:airline#extensions#tabline#show_buffers = 1
 <
+
+Note: If you are using neovim (has('tablineat') = 1), then you can click
+on the tabline with the left mouse button to switch to that buffer, and
+with the middle mouse button to delete that buffer.
+
 * enable/disable displaying tabs, regardless of number. (c)
   let g:airline#extensions#tabline#show_tabs = 1
 <


### PR DESCRIPTION
Extended the work done in https://github.com/vim-airline/vim-airline/pull/1020 to also support middle click to delete the buffer.