### PR TITLE
tabline#formatters#unique_tail_improved: handle fugitive

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/unique_tail_improved.vim
+++ b/autoload/airline/extensions/tabline/formatters/unique_tail_improved.vim
@@ -10,12 +10,20 @@ function! airline#extensions#tabline#formatters#unique_tail_improved#format(bufn
     return airline#extensions#tabline#formatters#default#format(a:bufnr, a:buffers)
   endif
 
-  let curbuf_tail = fnamemodify(bufname(a:bufnr), ':t')
+  let curbuf_name = bufname(a:bufnr)
+  let curbuf_tail = fnamemodify(curbuf_name, ':t')
   let do_deduplicate = 0
   let path_tokens = {}
 
+  let has_fugitive = exists('*fugitive#buffer')
+  if has_fugitive && getbufvar(a:bufnr, 'fugitive_type', '') != ''
+    let curbuf_name = fugitive#buffer(a:bufnr).path()
+  endif
   for nr in a:buffers
     let name = bufname(nr)
+    if has_fugitive && getbufvar(nr, 'fugitive_type', '') != ''
+      let name = fugitive#buffer(nr).path()
+    endif
     if !empty(name) && nr != a:bufnr && fnamemodify(name, ':t') == curbuf_tail " only perform actions if curbuf_tail isn't unique
       let do_deduplicate = 1
       let tokens = reverse(split(substitute(fnamemodify(name, ':p:h'), '\\', '/', 'g'), '/'))

--- a/autoload/airline/extensions/tabline/formatters/unique_tail_improved.vim
+++ b/autoload/airline/extensions/tabline/formatters/unique_tail_improved.vim
@@ -17,12 +17,14 @@ function! airline#extensions#tabline#formatters#unique_tail_improved#format(bufn
 
   let has_fugitive = exists('*fugitive#buffer')
   if has_fugitive && getbufvar(a:bufnr, 'fugitive_type', '') != ''
-    let curbuf_name = fugitive#buffer(a:bufnr).path()
+    let fug_buffer = fugitive#buffer(a:bufnr)
+    let curbuf_name = fug_buffer.repo().tree(fug_buffer.path())
   endif
   for nr in a:buffers
     let name = bufname(nr)
     if has_fugitive && getbufvar(nr, 'fugitive_type', '') != ''
-      let name = fugitive#buffer(nr).path()
+      let fug_buffer = fugitive#buffer(nr)
+      let name = fug_buffer.repo().tree(fug_buffer.path())
     endif
     if !empty(name) && nr != a:bufnr && fnamemodify(name, ':t') == curbuf_tail " only perform actions if curbuf_tail isn't unique
       let do_deduplicate = 1


### PR DESCRIPTION
This tries to improve the display with fugitive buffers:

Currently:

     1  a   "autoload/grepper.vim"         line 1
     2  a   "plugin/grepper.vim"           line 0
     7 %a-  "fugitive:///home/user/.dotfiles/vim/neobundles/grepper/.git//57f7669bc3a4b3d8a647d7645f0fb1fb064b7418/autoload/grepper.vim" line 479
    10  a-  "fugitive:///home/user/.dotfiles/vim/neobundles/grepper/.git//57f7669bc3a4b3d8a647d7645f0fb1fb064b7418/plugin/grepper.vim" line 0

is displayed as:

     1: home/user/.dotfiles/vim/neobundles/grepper/autoload/grepper.vim
     2: home/user/.dotfiles/vim/neobundles/grepper/plugin/grepper.vim
     7: …//57f7669bc3a4b3d8a647d7645f0fb1fb064b7418/autoload/grepper.vim
    10: …//57f7669bc3a4b3d8a647d7645f0fb1fb064b7418/plugin/grepper.vim

With this patch:

     1: …/autoload/grepper.vim
     2: …/plugin/grepper.vim
     7: …/57f7669bc3a4b3d8a647d7645f0fb1fb064b7418/autoload/grepper.vim
    10: …/57f7669bc3a4b3d8a647d7645f0fb1fb064b7418/plugin/grepper.vim

In both cases it's a bit confusing with:

     1 #a   "autoload/grepper.vim"         line 1
    10 %a-  "fugitive:///home/user/.dotfiles/vim/neobundles/grepper/.git//57f7669bc3a4b3d8a647d7645f0fb1fb064b7418/plugin/grepper.vim" line 1

    …/autoload/grepper.vim
    …/plugin/grepper.vim

It should not look like they are from the same type (real file vs. git/fugitive).

I may have mixed up something in the last example, but spent too much
time on this already.. ;)

/cc @zdm 