### PR TITLE
Do not draw separators for empty sections

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -37,12 +37,28 @@ function! s:prototype.build()
   let i = 0
   let length = len(self._sections)
   let split = 0
+  let is_empty = 0
+  let prev_group = ''
 
   while i < length
     let section = self._sections[i]
     let group = section[0]
     let contents = section[1]
+    let pgroup = prev_group
     let prev_group = s:get_prev_group(self._sections, i)
+    if is_empty
+      let prev_group = pgroup
+    endif
+    let is_empty = s:section_is_empty(self, contents)
+
+    if is_empty
+      " need to fix highlighting groups, since we
+      " have skipped a section, we actually need
+      " the previous previous group and so the 
+      " seperator goes from the previous previous group
+      " to the current group
+      let pgroup = group
+    endif
 
     if group == ''
       let line .= contents
@@ -54,12 +70,16 @@ function! s:prototype.build()
       if prev_group == ''
         let line .= '%#'.group.'#'
       elseif split
-        let line .= s:get_transitioned_seperator(self, prev_group, group, side)
+        if !is_empty
+          let line .= s:get_transitioned_seperator(self, prev_group, group, side)
+        endif
         let split = 0
       else
-        let line .= s:get_seperator(self, prev_group, group, side)
+        if !is_empty
+          let line .= s:get_seperator(self, prev_group, group, side)
+        endif
       endif
-      let line .= s:get_accented_line(self, group, contents)
+      let line .= is_empty ? '' : s:get_accented_line(self, group, contents)
     endif
 
     let i = i + 1
@@ -116,6 +136,43 @@ function! s:get_accented_line(self, group, contents)
     let line = substitute(line, '%#__restore__#', '', 'g')
   endif
   return line
+endfunction
+
+function! s:section_is_empty(self, content)
+  let start=1
+
+  " do not check for inactive windows
+  if a:self._context.active == 0
+    return 0
+  endif
+
+  " only check, if airline#skip_empty_sections == 1
+  if get(g:, 'airline_skip_empty_sections', 0) == 0
+    return 0
+  endif
+  " assume accents sections to be never empty
+  " (avoides, that on startup the mode message becomes empty)
+  if match(a:content, '%#__accent_[^#]*#.*__restore__#') > -1
+    return 0
+  endif
+  let list=matchlist(a:content, '%{\zs.\{-}\ze}', 1, start)
+  if empty(list)
+    return 0 " no function in statusline text
+  endif
+  while len(list) > 0
+    let expr = list[0]
+    try
+      " catch all exceptions, just in case
+      if !empty(eval(expr))
+        return 0
+      endif
+    catch
+      return 0
+    endtry
+    let start += 1
+    let list=matchlist(a:content, '%{\zs.\{-}\ze}', 1, start)
+  endw
+  return 1
 endfunction
 
 function! airline#builder#new(context)

--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -139,7 +139,13 @@ function! airline#extensions#whitespace#init(...)
   unlet! b:airline_whitespace_check
   augroup airline_whitespace
     autocmd!
-    autocmd CursorHold,BufWritePost * unlet! b:airline_whitespace_check
+    autocmd CursorHold,BufWritePost * call <sid>ws_refresh()
   augroup END
 endfunction
 
+function! s:ws_refresh()
+  unlet! b:airline_whitespace_check
+  if get(g:, 'airline_skip_empty_sections', 0)
+    exe ':AirlineRefresh'
+  endif
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -140,6 +140,10 @@ values):
 * disable the Airline customization for selective windows (this is a
   window-local variable so you can disable it for only some windows) >
   let w:airline_disabled = 1
+
+* Do not draw separators for empty sections (only for the active window)
+ >
+  let g:airline_skip_empty_sections = 1
 <
 
 ==============================================================================


### PR DESCRIPTION
This is a little bit a hack, because by the time the separators are
added, it is not clear, if the following section is empty, therefore
we need to parse the content of the following section and eval the
expressions to find out, if this is empty

Remarks:
- catch all exceptions when eval'ing statusline

- make sure, that the seperators are highlighted
  even when skipping empty regions (highlight group
  names need to be adjusted)

fixes #157