### PR TITLE
Update each window only once in s:on_window_changed.

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -37,6 +37,13 @@ function! s:on_window_changed()
   if pumvisible() && (!&previewwindow || g:airline_exclude_preview)
     return
   endif
+  " Handle each window only once, since we might come here several times for
+  " different autocommands.
+  let l:key = [bufnr('%'), winnr(), winnr('$')]
+  if get(t:, 'airline_last_window_changed', []) == l:key
+    return
+  endif
+  let t:airline_last_window_changed = l:key
   call s:init()
   call airline#update_statusline()
 endfunction


### PR DESCRIPTION
We might come there several times for different autocommands.

The key uses bufnr/winnr and the number of total windows, and is stored
for the tab.