### PR TITLE
Add bang to function definitions

### DIFF
--- a/autoload/airline/extensions/default.vim
+++ b/autoload/airline/extensions/default.vim
@@ -40,7 +40,7 @@ endfunction
 " deactivate it, until this is properly fixed:
 " https://groups.google.com/d/msg/vim_dev/sb1jmVirXPU/mPhvDnZ-CwAJ
 if s:section_use_groups && (v:version >= 704 || (v:version >= 703 && has('patch81')))
-  function s:add_section(builder, context, key)
+  function! s:add_section(builder, context, key)
     " i have no idea why the warning section needs special treatment, but it's
     " needed to prevent separators from showing up
     if ((a:key == 'error' || a:key == 'warning') && empty(s:get_section(a:context.winnr, a:key)))
@@ -56,7 +56,7 @@ if s:section_use_groups && (v:version >= 704 || (v:version >= 703 && has('patch8
   endfunction
 else
   " older version don't like the use of %(%)
-  function s:add_section(builder, context, key)
+  function! s:add_section(builder, context, key)
     if ((a:key == 'error' || a:key == 'warning') && empty(s:get_section(a:context.winnr, a:key)))
       return
     endif

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -180,7 +180,7 @@ function! s:jump_to_tab(offset)
     endif
 endfunction
 
-function s:map_keys()
+function! s:map_keys()
   if s:buffer_idx_mode
     noremap <silent> <Plug>AirlineSelectTab1 :call <SID>select_tab(0)<CR>
     noremap <silent> <Plug>AirlineSelectTab2 :call <SID>select_tab(1)<CR>
@@ -196,7 +196,7 @@ function s:map_keys()
   endif
 endfunction
 
-function airline#extensions#tabline#buffers#clickbuf(minwid, clicks, button, modifiers) abort
+function! airline#extensions#tabline#buffers#clickbuf(minwid, clicks, button, modifiers) abort
     " Clickable buffers
     " works only in recent NeoVim with has('tablineat')
 

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -94,7 +94,7 @@ function! airline#extensions#tabline#tabs#get()
   return s:current_tabline
 endfunction
 
-function s:map_keys()
+function! s:map_keys()
   noremap <silent> <Plug>AirlineSelectTab1 :1tabn<CR>
   noremap <silent> <Plug>AirlineSelectTab2 :2tabn<CR>
   noremap <silent> <Plug>AirlineSelectTab3 :3tabn<CR>

--- a/autoload/airline/extensions/wordcount/formatters/default.vim
+++ b/autoload/airline/extensions/wordcount/formatters/default.vim
@@ -48,7 +48,7 @@ function! s:wordcount()
   endif
 endfunction
 
-function s:get_decimal_group()
+function! s:get_decimal_group()
   if match(v:lang, '\v\cC|en') > -1
     return ','
   elseif match(v:lang, '\v\cde|dk|fr|pt') > -1

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -52,7 +52,7 @@ function! s:on_colorscheme_changed()
   call airline#load_theme()
 endfunction
 
-function airline#cmdwinenter(...)
+function! airline#cmdwinenter(...)
   call airline#extensions#apply_left_override('Command Line', '')
 endfunction
 


### PR DESCRIPTION
This makes it easier to reload the files, e.g. via vim-scriptease's
`:Runtime`.