### PR TITLE
don't throw error if bufferline is not installed

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -123,7 +123,11 @@ function! airline#extensions#load()
 
   if exists('g:airline_extensions')
     for ext in g:airline_extensions
-      call airline#extensions#{ext}#init(s:ext)
+      try
+        call airline#extensions#{ext}#init(s:ext)
+      catch /^Vim\%((\a\+)\)\=:E117/	" E117, function does not exist
+        call airline#util#warning("Extension '".ext."' not installed, ignoring!")
+      endtry
     endfor
     return
   endif

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -19,6 +19,12 @@ function! airline#util#append(text, minwidth)
   return empty(a:text) ? '' : prefix.g:airline_left_alt_sep.s:spc.a:text
 endfunction
 
+function! airline#util#warning(msg)
+  echohl WarningMsg
+  echomsg "airline: ".a:msg
+  echohl Normal
+endfunction
+
 function! airline#util#prepend(text, minwidth)
   if a:minwidth > 0 && winwidth(0) < a:minwidth
     return ''


### PR DESCRIPTION
airline#extensions#load() tries to load all extensions,
the user has specified in g:airline_extensions.
However, if e.g. bufferline is requested to be loaded, but
is not installed, it will throw an error
E117: Unknown function: airline#extensions#bufferline#init

Therefore, catch E117 and show a warning.

closes #1127