### PR TITLE
put file path in quotes when call "system()"

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -73,7 +73,7 @@ function! s:get_git_untracked(file)
   if has_key(s:untracked_git, a:file)
     let untracked = s:untracked_git[a:file]
   else
-    let output    = system('git status --porcelain -- '. a:file)
+    let output    = system('git status --porcelain -- '. shellescape(a:file))
     if output[0:1] is# '??' && output[3:-2] is? a:file
       let untracked = get(g:, 'airline#extensions#branch#notexists', g:airline_symbols.notexists)
     endif
@@ -92,7 +92,7 @@ function! s:get_hg_untracked(file)
     if has_key(s:untracked_hg, a:file)
       let untracked = s:untracked_hg[a:file]
     else
-      let untracked = (system('hg status -u -- '. a:file)[0] is# '?'  ?
+      let untracked = (system('hg status -u -- '. shellescape(a:file))[0] is# '?'  ?
             \ get(g:, 'airline#extensions#branch#notexists', g:airline_symbols.notexists) : '')
       let s:untracked_hg[a:file] = untracked
     endif


### PR DESCRIPTION
"system()" called by "get_git_untrack" and "get_hg_untrack" fails. It report error "Can't open file /tmp/***".
The root cause is that the file path for system() contains some unordinary character and lacks quotes.

The bug happens in both windows and linux:

![bug2](https://cloud.githubusercontent.com/assets/2666324/14856953/da3245ba-0ccc-11e6-9fb5-573f92ef8806.PNG)
![bug0](https://cloud.githubusercontent.com/assets/2666324/14857690/ceeeca04-0ccf-11e6-9e7b-eccf287f203b.PNG)

