### PR TITLE
do not add padding to section name if empty

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -8,7 +8,10 @@ function! s:prototype.split(...)
 endfunction
 
 function! s:prototype.add_section_spaced(group, contents)
-  call self.add_section(a:group, (g:airline_symbols.space).a:contents.(g:airline_symbols.space))
+  if a:contents
+    let a:contents = (g:airline_symbols.space).a:contents.(g:airline_symbols.space)
+  endif
+  call self.add_section(a:group, a:contents)
 endfunction
 
 function! s:prototype.add_section(group, contents)


### PR DESCRIPTION
I would like to disable "buffers" label with the following option by setting it to empty string:
```
let g:airline#extensions#tabline#buffers_label = ''
```
Airline adds one space padding to each side and this is how it looks:
![screenshot](https://www.dropbox.com/s/mfrbb1pexsrfarf/Screenshot%202016-05-08%2004.57.10.png?dl=1)

I would like to hide it completely.

This commit avoids padding of empty section names.