### PR TITLE
Fix neovim true color support

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -101,7 +101,7 @@ function! airline#init#bootstrap()
 endfunction
 
 function! airline#init#gui_mode()
-  return ((has('nvim') && exists('$NVIM_TUI_ENABLE_TRUE_COLOR'))
+  return ((has('nvim') && exists('$NVIM_TUI_ENABLE_TRUE_COLOR') && !exists("+termguicolors"))
         \ || has('gui_running') || (has("termtruecolor") && &guicolors == 1) || (has("termguicolors") && &termguicolors == 1)) ?
         \ 'gui' : 'cterm'
 endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -102,7 +102,7 @@ endfunction
 
 function! airline#init#gui_mode()
   return ((has('nvim') && exists('$NVIM_TUI_ENABLE_TRUE_COLOR'))
-        \ || has('gui_running') || (has("termtruecolor") && &guicolors == 1)) ?
+        \ || has('gui_running') || (has("termtruecolor") && &guicolors == 1) || (has("termguicolors") && &termguicolors == 1)) ?
         \ 'gui' : 'cterm'
 endfunction
 


### PR DESCRIPTION
now both vim and neovim use `set termguicolors` to enable true colors. and neovim master do not support `let $NVIM_TUI_ENABLE_TRUE_COLOR=1`