### PR TITLE
add obsession extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -250,6 +250,10 @@ function! airline#extensions#load()
     call airline#extensions#windowswap#init(s:ext)
   endif
 
+  if (get(g:, 'airline#extensions#obsession#enabled', 1) && exists('*ObsessionStatus'))
+    call airline#extensions#obsession#init(s:ext)
+  endif
+
   if !get(g:, 'airline#extensions#disable_rtp_load', 0)
     " load all other extensions, which are not part of the default distribution.
     " (autoload/airline/extensions/*.vim outside of our s:script_path).

--- a/autoload/airline/extensions/obsession.vim
+++ b/autoload/airline/extensions/obsession.vim
@@ -1,0 +1,20 @@
+" vim: et ts=2 sts=2 sw=2
+
+if !exists('*ObsessionStatus')
+  finish
+endif
+
+let s:spc = g:airline_symbols.space
+
+if !exists('g:airline#extensions#obsession#indicator_text')
+  let g:airline#extensions#obsession#indicator_text = '$'
+endif
+
+function! airline#extensions#obsession#init(ext)
+  call airline#parts#define_function('obsession', 'airline#extensions#obsession#get_status')
+endfunction
+
+function! airline#extensions#obsession#get_status()
+  return ObsessionStatus((g:airline#extensions#obsession#indicator_text . s:spc), '')
+endfunction
+

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -93,7 +93,7 @@ function! airline#init#bootstrap()
         \ 'raw': '%#__accent_bold#/%L%{g:airline_symbols.maxlinenr}%#__restore__#',
         \ 'accent': 'bold'})
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
-  call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic',
+  call airline#parts#define_empty(['hunks', 'branch', 'obsession', 'tagbar', 'syntastic',
         \ 'eclim', 'whitespace','windowswap', 'ycm_error_count', 'ycm_warning_count'])
   call airline#parts#define_text('capslock', '')
 
@@ -131,7 +131,7 @@ function! airline#init#sections()
     let g:airline_section_y = airline#section#create_right(['ffenc'])
   endif
   if !exists('g:airline_section_z')
-    let g:airline_section_z = airline#section#create(['windowswap', '%3p%%'.spc, 'linenr', 'maxlinenr', spc.':%3v'])
+    let g:airline_section_z = airline#section#create(['windowswap', 'obsession', '%3p%%'.spc, 'linenr', 'maxlinenr', spc.':%3v'])
   endif
   if !exists('g:airline_section_error')
     let g:airline_section_error = airline#section#create(['ycm_error_count', 'syntastic', 'eclim'])

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -718,6 +718,15 @@ vim-windowswap <https://github.com/wesQ3/vim-windowswap>
 * set marked window indicator string >
   let g:airline#extensions#windowswap#indicator_text = 'WS'
 <
+-------------------------------------                    *airline-obsession*
+vim-obsession <https://github.com/tpope/vim-obsession>
+
+* enable/disable vim-obsession integration >
+  let g:airline#extensions#obsession#enabled = 1
+
+* set marked window indicator string >
+  let g:airline#extensions#obsession#indicator_text = '$'
+<
 -------------------------------------                        *airline-taboo*
 taboo.vim <https://github.com/gcmt/taboo.vim>
 


### PR DESCRIPTION
simple support of `obsession.vim` for `vim-airline`.

note that i'm aware of solution proposed [here](https://github.com/vim-airline/vim-airline/issues/777#issuecomment-113704356), but i found it pretty weirdo mixing up my status line and hiding some parts.