### PR TITLE
limit whitespace check output for smaller screens

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -106,7 +106,12 @@ function! airline#extensions#whitespace#check()
       endif
     endif
   endif
-  return b:airline_whitespace_check
+  if winwidth(0) < 120 && len(split(b:airline_whitespace_check, '\zs')) > 9
+    return matchstr(b:airline_whitespace_check, '^.\{9\}').'…'
+  else
+    return b:airline_whitespace_check
+  endif
+
 endfunction
 
 function! airline#extensions#whitespace#toggle()


### PR DESCRIPTION
Sometimes, if a buffer triggers many whitespace check warnings,
and the Vim window size is too small, other parts of the statusline
might become unreadable.

Therefore, if the window size is smaller than say 120 characters
and the whitespace warning > 9 chars, limit it to 10 characters
and inidicate, that there is more to come