### PR TITLE
call YCM function only if they are defined

### DIFF
--- a/autoload/airline/extensions/ycm.vim
+++ b/autoload/airline/extensions/ycm.vim
@@ -11,7 +11,7 @@ function! airline#extensions#ycm#init(ext)
 endfunction
 
 function! airline#extensions#ycm#get_error_count()
-  if exists(':YcmDiag')
+  if exists(':YcmDiag') && exists("*youcompleteme#GetErrorCount")
     let cnt = youcompleteme#GetErrorCount()
 
     if cnt != 0
@@ -23,7 +23,7 @@ function! airline#extensions#ycm#get_error_count()
 endfunction
 
 function! airline#extensions#ycm#get_warning_count()
-  if exists(':YcmDiag')
+  if exists(':YcmDiag') && exists("*youcompleteme#GetWarningCount")
     let cnt = youcompleteme#GetWarningCount()
 
     if cnt != 0


### PR DESCRIPTION
fixes #1187 by making sure, we only call functions, that actually exist.

Should make vim-airline work with lady loaded YCM, e.g. using vim-plug:

```viml
" Code to execute when the plugin is loaded on demand
Plug 'Valloric/YouCompleteMe', { 'for': 'cpp' }
autocmd! User YouCompleteMe if !has('vim_starting') | call youcompleteme#Enable() | endif
```