### PR TITLE
tabline: do not change the signature of get_buffer_name

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -147,8 +147,9 @@ function! airline#extensions#tabline#title(n)
   return title
 endfunction
 
-function! airline#extensions#tabline#get_buffer_name(nr, buffers)
-  return airline#extensions#tabline#formatters#{s:formatter}#format(a:nr, a:buffers)
+function! airline#extensions#tabline#get_buffer_name(nr, ...)
+  let buffers = a:0 ? a:1 : airline#extensions#tabline#buflist#list()
+  return airline#extensions#tabline#formatters#{s:formatter}#format(a:nr, buffers)
 endfunction
 
 function! airline#extensions#tabline#new_builder()


### PR DESCRIPTION
Thanks to @wsdjeg about notifying me in
https://github.com/vim-airline/vim-airline/commit/e1f7bf#commitcomment-18104843.

Fixes: https://github.com/vim-airline/vim-airline/issues/1204.