### PR TITLE
Cache hunk values, shorten for small windows

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -166,7 +166,8 @@ function! airline#extensions#branch#head()
   if empty(b:airline_head) || !found_fugitive_head && !s:check_in_path()
     let b:airline_head = ''
   endif
-  let b:airline_head = airline#util#shorten(b:airline_head, 120, 9)
+  let minwidth = empty(get(b:, 'airline_hunks', '')) ? 14 : 7
+  let b:airline_head = airline#util#shorten(b:airline_head, 120, minwidth)
   return b:airline_head
 endfunction
 

--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -65,19 +65,27 @@ function! airline#extensions#hunks#get_hunks()
   if !get(w:, 'airline_active', 0)
     return ''
   endif
+  " Cache vavlues, so that it isn't called too often
+  if exists("b:airline_hunks") &&
+    \  get(b:,  'airline_changenr', 0) == changenr() &&
+    \ winwidth(0) == get(s:, 'airline_winwidth', 0)
+    return b:airline_hunks
+  endif
   let hunks = s:get_hunks()
   let string = ''
   if !empty(hunks)
     for i in [0, 1, 2]
-      if s:non_zero_only == 0 || hunks[i] > 0
+      if (s:non_zero_only == 0 && winwidth(0) > 100) || hunks[i] > 0
         let string .= printf('%s%s ', s:hunk_symbols[i], hunks[i])
       endif
     endfor
   endif
+  let b:airline_hunks = string
+  let b:airline_changenr = changenr()
+  let s:airline_winwidth = winwidth(0)
   return string
 endfunction
 
 function! airline#extensions#hunks#init(ext)
   call airline#parts#define_function('hunks', 'airline#extensions#hunks#get_hunks')
 endfunction
-

--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -82,10 +82,9 @@ function! airline#parts#readonly()
 endfunction
 
 function! airline#parts#filetype()
-  return &filetype
+  return winwidth(0) < 100 && strlen(&filetype) > 3 ? matchstr(&filetype, '...'). '…' : &filetype
 endfunction
 
 function! airline#parts#ffenc()
   return printf('%s%s%s', &fenc, &l:bomb ? '[BOM]' : '', strlen(&ff) > 0 ? '['.&ff.']' : '')
 endfunction
-


### PR DESCRIPTION
Cache the hunk values. In case of short windows, shorten the hunk string
a little bit and make the branch extension take the hunk value into
account when deciding how much to shorten it.