### PR TITLE
Add Go to the list of C-like languages.

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -15,7 +15,7 @@ let s:indent_algo = get(g:, 'airline#extensions#whitespace#mixed_indent_algo', 0
 let s:skip_check_ft = {'make': ['indent', 'mixed-indent-file'] }
 let s:max_lines = get(g:, 'airline#extensions#whitespace#max_lines', 20000)
 let s:enabled = get(g:, 'airline#extensions#whitespace#enabled', 1)
-let s:c_like_langs = get(g:, 'airline#extensions#c_like_langs', [ 'c', 'cpp', 'cuda', 'javascript', 'ld', 'php' ])
+let s:c_like_langs = get(g:, 'airline#extensions#c_like_langs', [ 'c', 'cpp', 'cuda', 'go', 'javascript', 'ld', 'php' ])
 
 function! s:check_mixed_indent()
   if s:indent_algo == 1

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -500,7 +500,7 @@ eclim <https://eclim.org>
 
 * configure, which filetypes have special treatment of /* */ comments,
   matters for mix-indent-file algorithm: >
-  let airline#extensions#c_like_langs = ['c', 'cpp', 'cuda', 'javascript', 'ld', 'php']
+  let airline#extensions#c_like_langs = ['c', 'cpp', 'cuda', 'go', 'javascript', 'ld', 'php']
 <
 * disable whitespace checking for an individual buffer >
   " Checking is enabled by default because b:airline_whitespace_disabled


### PR DESCRIPTION
Go files trigger the mixed indent warning, since they don't get treated like a C-like language. Adding them to the list fixes the warnings.