### PR TITLE
`:AirlineRefresh` not work correctly

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -106,8 +106,11 @@ function! airline#highlighter#load_theme()
   for winnr in filter(range(1, winnr('$')), 'v:val != winnr()')
     call airline#highlighter#highlight_modified_inactive(winbufnr(winnr))
   endfor
-  call airline#highlighter#highlight(['inactive'])
-  call airline#highlighter#highlight(['normal'])
+  if getbufvar( bufnr('%'), '&modified'  )
+    call airline#highlighter#highlight(['normal', 'modified'])
+  else
+    call airline#highlighter#highlight(['normal'])
+  endif
 endfunction
 
 function! airline#highlighter#add_separator(from, to, inverse)


### PR DESCRIPTION
If active buffer is modified, `:AirlineRefresh` apply `normal` highlight
instead of `normal_modified` highlight.

No particular config is requiered to reproduce this bug.

I see this bug with option `g:airline_skip_empty_sections` set.
Add any modification at the active buffer return to normal mode,
**do not save** and wait a few seconds, you can see highlight change to
normal but file is still modified.

Without option `g:airline_skip_empty_sections`, add any modification at
the active buffer return to normal mode and type `:AirlineRefresh` you
can see change to bad highlight .