### PR TITLE
fix: tabline doesn't update when close buffer(one except the current)

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -148,7 +148,10 @@ function! airline#extensions#tabline#title(n)
 endfunction
 
 function! airline#extensions#tabline#get_buffer_name(nr, ...)
-  let buffers = a:0 ? a:1 : airline#extensions#tabline#buflist#list()
+  let buffers = a:0 ? a:1
+        \ : exists('s:current_buffer_list')
+        \ ? s:current_buffer_list
+        \ : airline#extensions#tabline#buflist#list()
   return airline#extensions#tabline#formatters#{s:formatter}#format(a:nr, buffers)
 endfunction
 

--- a/autoload/airline/extensions/tabline/buflist.vim
+++ b/autoload/airline/extensions/tabline/buflist.vim
@@ -9,10 +9,6 @@ function! airline#extensions#tabline#buflist#invalidate()
 endfunction
 
 function! airline#extensions#tabline#buflist#list()
-  if exists('s:current_buffer_list')
-    return s:current_buffer_list
-  endif
-
   let list = (exists('g:did_bufmru') && g:did_bufmru) ? BufMRUList() : range(1, bufnr("$"))
 
   let buffers = []


### PR DESCRIPTION
if you open more than one buffer,
buffer line won't update if you close one buffer(except the current one),
eg: 
the current buffer is No.2, 
if you close No.3,
the tab line won't update.