### PR TITLE
themes: allow to customize separators on inactive windows

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -107,10 +107,13 @@ endfunction
 
 function! s:get_transitioned_seperator(self, prev_group, group, side)
   let line = ''
+  let sep = a:side ? a:self._context.left_sep : a:self._context.right_sep
+  if a:self._context.active == 0 &&
+      \ get(get(g:airline#themes#{g:airline_theme}#palette, 'separator', {}), 'inactive_window') ==? 'alt'
+    let sep = a:side ? a:self._context.left_alt_sep : a:self._context.right_alt_sep
+  endif
   call airline#highlighter#add_separator(a:prev_group, a:group, a:side)
-  let line .= '%#'.a:prev_group.'_to_'.a:group.'#'
-  let line .= a:side ? a:self._context.left_sep : a:self._context.right_sep
-  let line .= '%#'.a:group.'#'
+  let line .= '%#'.a:prev_group.'_to_'.a:group.'#'.sep.'%#'.a:group.'#'
   return line
 endfunction
 

--- a/autoload/airline/themes/dark.vim
+++ b/autoload/airline/themes/dark.vim
@@ -66,7 +66,6 @@ let g:airline#themes#dark#palette.visual_modified = {
       \ 'airline_c': [ '#ffffff' , '#5f005f' , 255     , 53      , ''     ] ,
       \ }
 
-
 let s:IA1 = [ '#4e4e4e' , '#1c1c1c' , 239 , 234 , '' ]
 let s:IA2 = [ '#4e4e4e' , '#262626' , 239 , 235 , '' ]
 let s:IA3 = [ '#4e4e4e' , '#303030' , 239 , 236 , '' ]
@@ -87,6 +86,11 @@ let g:airline#themes#dark#palette.accents = {
       \ 'red': [ '#ff0000' , '' , 160 , ''  ]
       \ }
 
+" What kind of separator to use for inactive windows.
+" Possible values: - 'normal' uses the default separators
+"                  - 'alt'    always uses the alternative separators
+" The default is 'normal'
+let g:airline#themes#dark#palette.separator = {'inactive_window': 'alt'}
 
 " Here we define the color map for ctrlp.  We check for the g:loaded_ctrlp
 " variable so that related functionality is loaded iff the user is using


### PR DESCRIPTION
This fixes #1236
and allows theme creators to define, if inactive windows should rather
always been drawn using the alternative separators.

Currently this is just an experimental feature and adds this feature to the dark.vim theme, to be able to try this out easily.

I am currently not happy with how to set this up:
`:let g:airline#themes#dark#palette.separator = {'inactive_window': 'alt'}` 
First of all, it does not seem to fix into the palette at all, second, themes.vim will always add additional highlighting groups 'airline_error' and 'airline_warning' which is kind of useless here. So perhaps an extra setting would be more desireable?

cc @bling for comments
