### PR TITLE
Do not unconditionally modify airline_c_inactive

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -188,7 +188,7 @@ function! airline#check_mode(winnr)
   let mode_string = join(l:mode)
   if get(w:, 'airline_lastmode', '') != mode_string
     call airline#highlighter#highlight_modified_inactive(context.bufnr)
-    call airline#highlighter#highlight(l:mode)
+    call airline#highlighter#highlight(l:mode, context.bufnr)
     let w:airline_lastmode = mode_string
   endif
 

--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -47,6 +47,9 @@ function! s:prototype.build()
     let contents = section[1]
     let pgroup = prev_group
     let prev_group = s:get_prev_group(self._sections, i)
+    if group ==# 'airline_c' && !self._context.active
+      let group = 'airline_c'. self._context.bufnr
+    endif
     if is_empty
       let prev_group = pgroup
     endif
@@ -87,6 +90,7 @@ function! s:prototype.build()
   endwhile
 
   if !self._context.active
+    "let line = substitute(line, '%#airline_c#', '%#airline_c'.self._context.bufnr.'#', '')
     let line = substitute(line, '%#.\{-}\ze#', '\0_inactive', 'g')
   endif
   return line

--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -136,7 +136,8 @@ function! airline#highlighter#highlight_modified_inactive(bufnr)
   endif
 endfunction
 
-function! airline#highlighter#highlight(modes)
+function! airline#highlighter#highlight(modes, ...)
+  let bufnr = a:0 ? a:1 : ''
   let p = g:airline#themes#{g:airline_theme}#palette
 
   " draw the base mode, followed by any overrides
@@ -147,7 +148,11 @@ function! airline#highlighter#highlight(modes)
       let dict = g:airline#themes#{g:airline_theme}#palette[mode]
       for kvp in items(dict)
         let mode_colors = kvp[1]
-        call airline#highlighter#exec(kvp[0].suffix, mode_colors)
+        let name = kvp[0]
+        if name is# 'airline_c' && !empty(bufnr) && suffix is# '_inactive'
+          let name = 'airline_c'.bufnr
+        endif
+        call airline#highlighter#exec(name.suffix, mode_colors)
 
         for accent in keys(s:accents)
           if !has_key(p.accents, accent)
@@ -165,7 +170,7 @@ function! airline#highlighter#highlight(modes)
           else
             call add(colors, get(p.accents[accent], 4, ''))
           endif
-          call airline#highlighter#exec(kvp[0].suffix.'_'.accent, colors)
+          call airline#highlighter#exec(name.suffix.'_'.accent, colors)
         endfor
       endfor
 


### PR DESCRIPTION
consider a window with these splits:
,----
| file1
| ---
| file2
| ---
| file1
`----

If the top buffer is the active one and you start modifying this buffer,
this will also reset the highlighting for the inactive buffer2, since
the highlighting group 'airline_c_inactive' is used for both windows
(one having the unmodified buffer 'file2' and one having the modified
'file1').

This lead to the incorrect highlighting of the buffer name of file2.

Airline basically already created different airline_c<bufnr>_inactive
highlighting groups, but unfortunately did not use them.

Therefore, make the builder aware of this and always append the buffer
number to the group 'airline_c' if it is in an inactive window.

2) we need to make sure, the highlighting won't get overwritten, so
make the highlighter aware of this situation as well, by appending the
buffer number to the group name, if it creates the 'inactive' mode
groups and a buffer number has been given.

this fixes #1233