### PR TITLE
do not cache status of statusline per tabpage

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -39,12 +39,12 @@ function! s:on_window_changed()
   endif
   " Handle each window only once, since we might come here several times for
   " different autocommands.
-  let l:key = [bufnr('%'), winnr(), winnr('$')]
-  if get(t:, 'airline_last_window_changed', []) == l:key
+  let l:key = [bufnr('%'), winnr(), winnr('$'), tabpagenr()]
+  if get(g:, 'airline_last_window_changed', []) == l:key
         \ && &stl is# '%!airline#statusline('.winnr().')'
     return
   endif
-  let t:airline_last_window_changed = l:key
+  let g:airline_last_window_changed = l:key
   call s:init()
   call airline#update_statusline()
 endfunction


### PR DESCRIPTION
When cacheing the values of buffer number, window number per tabpage, we
might forget to update the statusline when it is actually needed, e.g.
on `:tab help h | norm! gt` which would then still display "Help" also
we are not in a help window anymore.

Therefore cache those values (including current tabpage number)
globally.

fixes #1253