### PR TITLE
Set script encoding to avoid script parsing problem in non UTF-8 VIM

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let g:airline_statusline_funcrefs = get(g:, 'airline_statusline_funcrefs', [])
 
 let s:sections = ['a','b','c','gutter','x','y','z', 'error', 'warning']

--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:prototype = {}
 
 function! s:prototype.split(...)
@@ -58,7 +60,7 @@ function! s:prototype.build()
     if is_empty
       " need to fix highlighting groups, since we
       " have skipped a section, we actually need
-      " the previous previous group and so the 
+      " the previous previous group and so the
       " seperator goes from the previous previous group
       " to the current group
       let pgroup = group

--- a/autoload/airline/debug.vim
+++ b/autoload/airline/debug.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 function! airline#debug#profile1()
   profile start airline-profile-switch.log
   profile func *

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:ext = {}
 let s:ext._theme_funcrefs = []
 

--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:has_fugitive = exists('*fugitive#head')
 let s:has_lawrencium = exists('*lawrencium#statusline')
 let s:has_vcscommand = get(g:, 'airline#extensions#branch#use_vcscommand', 0) && exists('*VCSCommandGetStatusLine')

--- a/autoload/airline/extensions/bufferline.vim
+++ b/autoload/airline/extensions/bufferline.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists('*bufferline#get_status_string')
   finish
 endif

--- a/autoload/airline/extensions/capslock.vim
+++ b/autoload/airline/extensions/capslock.vim
@@ -1,5 +1,8 @@
 " MIT License. Copyright (c) 2014 Mathias Andersson.
 " vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
 if !exists('*CapsLockStatusline')
   finish
 endif

--- a/autoload/airline/extensions/commandt.vim
+++ b/autoload/airline/extensions/commandt.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !get(g:, 'command_t_loaded', 0)
   finish
 endif

--- a/autoload/airline/extensions/csv.vim
+++ b/autoload/airline/extensions/csv.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !get(g:, 'loaded_csv', 0) && !exists(':Table')
   finish
 endif

--- a/autoload/airline/extensions/ctrlp.vim
+++ b/autoload/airline/extensions/ctrlp.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !get(g:, 'loaded_ctrlp', 0)
   finish
 endif

--- a/autoload/airline/extensions/ctrlspace.vim
+++ b/autoload/airline/extensions/ctrlspace.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:spc = g:airline_symbols.space
 let s:padding = s:spc . s:spc . s:spc
 

--- a/autoload/airline/extensions/default.vim
+++ b/autoload/airline/extensions/default.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:section_use_groups     = get(g:, 'airline#extensions#default#section_use_groupitems', 1)
 let s:section_truncate_width = get(g:, 'airline#extensions#default#section_truncate_width', {
       \ 'b': 79,

--- a/autoload/airline/extensions/eclim.vim
+++ b/autoload/airline/extensions/eclim.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists(':ProjectCreate')
   finish
 endif

--- a/autoload/airline/extensions/example.vim
+++ b/autoload/airline/extensions/example.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 " we don't actually want this loaded :P
 finish
 

--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !get(g:, 'loaded_signify', 0) && !get(g:, 'loaded_gitgutter', 0) && !get(g:, 'loaded_changes', 0) && !get(g:, 'loaded_quickfixsigns', 0)
   finish
 endif

--- a/autoload/airline/extensions/netrw.vim
+++ b/autoload/airline/extensions/netrw.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists(':NetrwSettings')
   finish
 endif

--- a/autoload/airline/extensions/nrrwrgn.vim
+++ b/autoload/airline/extensions/nrrwrgn.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !get(g:, 'loaded_nrrw_rgn', 0)
   finish
 endif

--- a/autoload/airline/extensions/obsession.vim
+++ b/autoload/airline/extensions/obsession.vim
@@ -1,5 +1,7 @@
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists('*ObsessionStatus')
   finish
 endif

--- a/autoload/airline/extensions/po.vim
+++ b/autoload/airline/extensions/po.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 function! airline#extensions#po#apply(...)
   if &ft ==# 'po'
     call airline#extensions#prepend_to_section('z', '%{airline#extensions#po#stats()}')

--- a/autoload/airline/extensions/promptline.vim
+++ b/autoload/airline/extensions/promptline.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists(':PromptlineSnapshot')
   finish
 endif

--- a/autoload/airline/extensions/quickfix.vim
+++ b/autoload/airline/extensions/quickfix.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let g:airline#extensions#quickfix#quickfix_text = 'Quickfix'
 let g:airline#extensions#quickfix#location_text = 'Location'
 

--- a/autoload/airline/extensions/syntastic.vim
+++ b/autoload/airline/extensions/syntastic.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists(':SyntasticCheck')
   finish
 endif

--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:formatter = get(g:, 'airline#extensions#tabline#formatter', 'default')
 let s:show_buffers = get(g:, 'airline#extensions#tabline#show_buffers', 1)
 let s:show_tabs = get(g:, 'airline#extensions#tabline#show_tabs', 1)

--- a/autoload/airline/extensions/tabline/autoshow.vim
+++ b/autoload/airline/extensions/tabline/autoshow.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:show_buffers = get(g:, 'airline#extensions#tabline#show_buffers', 1)
 let s:buf_min_count = get(g:, 'airline#extensions#tabline#buffer_min_count', 0)
 let s:tab_min_count = get(g:, 'airline#extensions#tabline#tab_min_count', 0)

--- a/autoload/airline/extensions/tabline/buflist.vim
+++ b/autoload/airline/extensions/tabline/buflist.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:excludes = get(g:, 'airline#extensions#tabline#excludes', [])
 let s:exclude_preview = get(g:, 'airline#extensions#tabline#exclude_preview', 1)
 

--- a/autoload/airline/extensions/tabline/formatters/default.vim
+++ b/autoload/airline/extensions/tabline/formatters/default.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:fmod = get(g:, 'airline#extensions#tabline#fnamemod', ':~:.')
 let s:fnamecollapse = get(g:, 'airline#extensions#tabline#fnamecollapse', 1)
 let s:fnametruncate = get(g:, 'airline#extensions#tabline#fnametruncate', 0)

--- a/autoload/airline/extensions/tabline/formatters/unique_tail.vim
+++ b/autoload/airline/extensions/tabline/formatters/unique_tail.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 function! airline#extensions#tabline#formatters#unique_tail#format(bufnr, buffers)
   let duplicates = {}
   let tails = {}

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:show_close_button = get(g:, 'airline#extensions#tabline#show_close_button', 1)
 let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
 let s:show_tab_nr = get(g:, 'airline#extensions#tabline#show_tab_nr', 1)

--- a/autoload/airline/extensions/tagbar.vim
+++ b/autoload/airline/extensions/tagbar.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists(':TagbarToggle')
   finish
 endif

--- a/autoload/airline/extensions/tmuxline.vim
+++ b/autoload/airline/extensions/tmuxline.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists(':Tmuxline')
   finish
 endif

--- a/autoload/airline/extensions/undotree.vim
+++ b/autoload/airline/extensions/undotree.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists(':UndotreeToggle')
   finish
 endif

--- a/autoload/airline/extensions/unicode.vim
+++ b/autoload/airline/extensions/unicode.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !get(g:, 'loaded_unicodePlugin', 0)
   finish
 endif

--- a/autoload/airline/extensions/unite.vim
+++ b/autoload/airline/extensions/unite.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !get(g:, 'loaded_unite', 0)
   finish
 endif

--- a/autoload/airline/extensions/virtualenv.vim
+++ b/autoload/airline/extensions/virtualenv.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:spc = g:airline_symbols.space
 
 function! airline#extensions#virtualenv#init(ext)

--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -3,6 +3,8 @@
 
 " http://got-ravings.blogspot.com/2008/10/vim-pr0n-statusline-whitespace-flags.html
 
+scriptencoding utf-8
+
 let s:show_message = get(g:, 'airline#extensions#whitespace#show_message', 1)
 let s:symbol = get(g:, 'airline#extensions#whitespace#symbol', g:airline_symbols.whitespace)
 let s:default_checks = ['indent', 'trailing', 'mixed-indent-file']

--- a/autoload/airline/extensions/windowswap.vim
+++ b/autoload/airline/extensions/windowswap.vim
@@ -1,5 +1,7 @@
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if !exists('g:loaded_windowswap')
   finish
 endif

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:filetypes = get(g:, 'airline#extensions#wordcount#filetypes', '\vhelp|markdown|rst|org|text|asciidoc')
 let s:format = get(g:, 'airline#extensions#wordcount#format', '%d words')
 let s:formatter = get(g:, 'airline#extensions#wordcount#formatter', 'default')

--- a/autoload/airline/extensions/wordcount/formatters/default.vim
+++ b/autoload/airline/extensions/wordcount/formatters/default.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 function! airline#extensions#wordcount#formatters#default#format()
   let words = string(s:wordcount())
   if empty(words)

--- a/autoload/airline/extensions/ycm.vim
+++ b/autoload/airline/extensions/ycm.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2015 Evgeny Firsov.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:spc = g:airline_symbols.space
 let s:error_symbol = get(g:, 'airline#extensions#ycm#error_symbol', 'E:')
 let s:warning_symbol = get(g:, 'airline#extensions#ycm#warning_symbol', 'W:')

--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:is_win32term = (has('win32') || has('win64')) && !has('gui_running') && (empty($CONEMUBUILD) || &term !=? 'xterm')
 
 let s:separators = {}

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 function! s:check_defined(variable, default)
   if !exists(a:variable)
     let {a:variable} = a:default

--- a/autoload/airline/msdos.vim
+++ b/autoload/airline/msdos.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 " basic 16 msdos from MSDOS
 " see output of color, should be
 "     0    Black
@@ -21,7 +23,7 @@
 "     15   White
 
 let s:basic16 = [
-  \ [ 0x00, 0x00, 0x00 ], 
+  \ [ 0x00, 0x00, 0x00 ],
   \ [ 0x00, 0x00, 0x80 ],
   \ [ 0x00, 0x80, 0x00 ],
   \ [ 0x00, 0x80, 0x80 ],

--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 let s:parts = {}
 
 " PUBLIC API {{{

--- a/autoload/airline/section.vim
+++ b/autoload/airline/section.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 call airline#init#bootstrap()
 let s:spc = g:airline_symbols.space
 

--- a/autoload/airline/themes.vim
+++ b/autoload/airline/themes.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 " generates a dictionary which defines the colors for each highlight group
 function! airline#themes#generate_color_map(sect1, sect2, sect3, ...)
   let palette = {

--- a/autoload/airline/themes/dark.vim
+++ b/autoload/airline/themes/dark.vim
@@ -1,3 +1,5 @@
+scriptencoding utf-8
+
 " Each theme is contained in its own file and declares variables scoped to the
 " file.  These variables represent the possible "modes" that airline can
 " detect.  The mode is the return value of mode(), which gets converted to a

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 call airline#init#bootstrap()
 let s:spc = g:airline_symbols.space
 

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -1,6 +1,8 @@
 " MIT License. Copyright (c) 2013-2016 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+scriptencoding utf-8
+
 if &cp || v:version < 702 || (exists('g:loaded_airline') && g:loaded_airline)
   finish
 endif


### PR DESCRIPTION
Just find that :scriptencoding can be used to specify the encoding of current script file.
It can be used to avoid vim parsing script file using incorrect fileencoding.
After this patch, it's ok to use Unicode charaters in non UTF-8 environment.