### PR TITLE
Support for Neomake

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -214,6 +214,10 @@ function! airline#extensions#load()
     call airline#extensions#whitespace#init(s:ext)
   endif
 
+  if (get(g:, 'airline#extensions#neomake#enabled', 1) && exists(':Neomake'))
+    call airline#extensions#neomake#init(s:ext)
+  endif
+
   if get(g:, 'airline#extensions#po#enabled', 1) && executable('msgfmt')
     call airline#extensions#po#init(s:ext)
   endif

--- a/autoload/airline/extensions/neomake.vim
+++ b/autoload/airline/extensions/neomake.vim
@@ -1,0 +1,25 @@
+" vim: et ts=2 sts=2 sw=2
+
+if !exists(':Neomake')
+  finish
+endif
+
+let s:error_symbol = get(g:, 'airline#extensions#neomake#error_symbol', 'E:')
+let s:warning_symbol = get(g:, 'airline#extensions#neomake#warning_symbol', 'W:')
+
+function! airline#extensions#neomake#get_warnings()
+  let counts = neomake#statusline#LoclistCounts()
+  let warnings = get(counts, 'W', 0)
+  return warnings ? s:warning_symbol.warnings : ''
+endfunction
+
+function! airline#extensions#neomake#get_errors()
+  let counts = neomake#statusline#LoclistCounts()
+  let errors = get(counts, 'E', 0)
+  return errors ? s:error_symbol.errors : ''
+endfunction
+
+function! airline#extensions#neomake#init(ext)
+  call airline#parts#define_function('neomake_warning_count', 'airline#extensions#neomake#get_warnings')
+  call airline#parts#define_function('neomake_error_count', 'airline#extensions#neomake#get_errors')
+endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -94,7 +94,8 @@ function! airline#init#bootstrap()
         \ 'accent': 'bold'})
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
   call airline#parts#define_empty(['hunks', 'branch', 'obsession', 'tagbar', 'syntastic',
-        \ 'eclim', 'whitespace','windowswap', 'ycm_error_count', 'ycm_warning_count'])
+        \ 'eclim', 'whitespace','windowswap', 'ycm_error_count', 'ycm_warning_count',
+        \ 'neomake_error_count', 'neomake_warning_count'])
   call airline#parts#define_text('capslock', '')
 
   unlet g:airline#init#bootstrapping
@@ -138,10 +139,10 @@ function! airline#init#sections()
     endif
   endif
   if !exists('g:airline_section_error')
-    let g:airline_section_error = airline#section#create(['ycm_error_count', 'syntastic', 'eclim'])
+    let g:airline_section_error = airline#section#create(['ycm_error_count', 'syntastic', 'eclim', 'neomake_error_count'])
   endif
   if !exists('g:airline_section_warning')
-    let g:airline_section_warning = airline#section#create(['ycm_warning_count', 'whitespace'])
+    let g:airline_section_warning = airline#section#create(['ycm_warning_count',  'neomake_warning_count', 'whitespace'])
   endif
 endfunction
 


### PR DESCRIPTION
Added support for neomake plugin; similar to syntastic.
Shows warning and error counts in the airline statusbar.

```
:version
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Apr 28 2016 11:34:02)
MacOS X (unix) version
Included patches: 1-1795
Compiled by Homebrew
Huge version without GUI.  Features included (+) or not (-):
+acl             +clipboard       +dialog_con      +file_in_path    +job             +menu            -mouse_sysmouse  +persistent_undo +scrollbind      -tcl             +virtualedit     -xfontset
+arabic          +cmdline_compl   +diff            +find_in_path    +jumplist        +mksession       +mouse_urxvt     +postscript      +signs           +terminfo        +visual          -xim
+autocmd         +cmdline_hist    +digraphs        +float           +keymap          +modify_fname    +mouse_xterm     +printer         +smartindent     +termresponse    +visualextra     -xsmp
-balloon_eval    +cmdline_info    -dnd             +folding         +langmap         +mouse           +multi_byte      +profile         +startuptime     +termtruecolor   +viminfo         -xterm_clipboard
-browse          +comments        -ebcdic          -footer          +libcall         -mouseshape      +multi_lang      +python          +statusline      +textobjects     +vreplace        -xterm_save
++builtin_terms  +conceal         +emacs_tags      +fork()          +linebreak       +mouse_dec       -mzscheme        -python3         -sun_workshop    +timers          +wildignore      -xpm
+byte_offset     +cryptv          +eval            -gettext         +lispindent      -mouse_gpm       +netbeans_intg   +quickfix        +syntax          +title           +wildmenu
+channel         +cscope          +ex_extra        -hangul_input    +listcmds        -mouse_jsbterm   +packages        +reltime         +tag_binary      -toolbar         +windows
+cindent         +cursorbind      +extra_search    +iconv           +localmap        +mouse_netterm   +path_extra      +rightleft       +tag_old_static  +user_commands   +writebackup
-clientserver    +cursorshape     +farsi           +insert_expand   -lua             +mouse_sgr       +perl            +ruby            -tag_any_white   +vertsplit       -X11
   system vimrc file: "$VIM/vimrc"
     user vimrc file: "$HOME/.vimrc"
 2nd user vimrc file: "~/.vim/vimrc"
      user exrc file: "$HOME/.exrc"
  fall-back for $VIM: "/usr/local/share/vim"
Compilation: /usr/bin/clang -c -I. -Iproto -DHAVE_CONFIG_H   -DMACOS_X_UNIX  -Os -w -pipe -march=native -mmacosx-version-min=10.11 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
Linking: /usr/bin/clang   -L. -L/usr/local/lib -L/usr/local/lib -Wl,-headerpad_max_install_names -o vim        -lm  -lncurses -liconv -framework Cocoa   -fstack-protector  -L/System/Library/Perl/5.18/darw
in-thread-multi-2level/CORE -lperl -framework Python   -lruby.2.0.0 -lobjc
```