### PR TITLE
do not skip empty sections for the tabline

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -150,8 +150,10 @@ endfunction
 function! s:section_is_empty(self, content)
   let start=1
 
-  " do not check for inactive windows
+  " do not check for inactive windows or the tabline
   if a:self._context.active == 0
+    return 0
+  elseif get(a:self._context, 'tabline', 0)
     return 0
   endif
 

--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -157,6 +157,7 @@ endfunction
 function! airline#extensions#tabline#new_builder()
   let builder_context = {
         \ 'active'        : 1,
+        \ 'tabline'       : 1,
         \ 'right_sep'     : get(g:, 'airline#extensions#tabline#right_sep'    , g:airline_right_sep),
         \ 'right_alt_sep' : get(g:, 'airline#extensions#tabline#right_alt_sep', g:airline_right_alt_sep),
         \ }


### PR DESCRIPTION
commit 3d667c32d3ac04 fixed a bug, that a section was not considered
empty for the statusline, also g:airline_skip_empty was set.

However unfortunately, this lead to a regression, makeing the tabline
ugly, because sections, that contained a single highlighting group would
be considered empty and would therefore be skipped. Since this is not
what is expected, make s:section_is_empty() return zero, when it notices
we are looking at a tabline.

fixes #1273