### PR TITLE
Add support for flattened and NeoSolarized themes

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -56,6 +56,8 @@ function! airline#init#bootstrap()
         \ 'wombat': 'wombat',
         \ 'zenburn': 'zenburn',
         \ 'solarized': 'solarized',
+        \ 'flattened': 'solarized',
+        \ '\CNeoSolarized': 'solarized',
         \ }, 'keep')
 
   call s:check_defined('g:airline_symbols', {})


### PR DESCRIPTION
These are forks/alternate versions of Solarized, without many of the dynamic elements or the extensive terminal support.

[flattened](https://github.com/romainl/flattened) is a basic, totally static version of Solarized with only ansi and GUI support.

[NeoSolarized](https://github.com/iCyMind/NeoSolarized) is a version focusing on true/24-bit color support and NeoVim support, with limited dynamic options.

[solarized8](https://github.com/lifepillar/vim-solarized8) is a version focusing on vim/neovim true color support and limited dynamics. It is already supported (`match()` matches it), but it is at least worth noting.

Many users, including myself, use these themes over the original Solarized for performance or technical reasons. Many users believe they are incompatible with airline because automatic theming no longer functions. While they can manually override the theme, most people seem to miss this option in the documentation and give up.

It would be a nice quality of live improvement if airline detected these themes and enabled its own Solarized theme automatically to match.