### PR TITLE
Tabline extension: Option to allow middle click close to preserve windows with clicked buffer open

### DIFF
--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -207,7 +207,21 @@ function! airline#extensions#tabline#buffers#clickbuf(minwid, clicks, button, mo
         silent execute 'buffer' a:minwid
       elseif a:button is# 'm'
         " middle button - delete buffer
-        silent execute 'bdelete' a:minwid
+        let current_window = bufwinnr("%")
+        let window_number = bufwinnr(a:minwid)
+        let last_window_visited = -1
+        let buffer_in_window = 0
+        while window_number != -1 && window_number != last_window_visited
+          let buffer_in_window = 1
+          silent execute window_number . 'wincmd w'
+          silent execute 'enew'
+          let last_window_visited = window_number
+          let window_number = bufwinnr(a:minwid)
+        endwhile
+        silent execute current_window . 'wincmd w'
+        if window_number != last_window_visited || buffer_in_window == 0
+          silent execute 'bdelete' a:minwid
+        endif
       endif
     endif
 endfunction

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -6,6 +6,7 @@ scriptencoding utf-8
 let s:buffer_idx_mode = get(g:, 'airline#extensions#tabline#buffer_idx_mode', 0)
 let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
 let s:buffers_label = get(g:, 'airline#extensions#tabline#buffers_label', 'buffers')
+let s:middle_click_preserves_windows = get(g:, 'airline#extensions#tabline#middle_click_preserves_windows', 0)
 let s:spc = g:airline_symbols.space
 
 let s:current_bufnr = -1
@@ -208,7 +209,7 @@ function! airline#extensions#tabline#buffers#clickbuf(minwid, clicks, button, mo
       elseif a:button is# 'm'
         " middle button - delete buffer
 
-        if get(g:, 'airline_middle_click_preserve_windows', 0) == 0
+        if s:middle_click_preserves_windows == 0
           " just simply delete the clicked buffer. This will cause windows 
           " associated with the clicked buffer to be closed.
           silent execute 'bdelete' a:minwid

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -207,20 +207,40 @@ function! airline#extensions#tabline#buffers#clickbuf(minwid, clicks, button, mo
         silent execute 'buffer' a:minwid
       elseif a:button is# 'm'
         " middle button - delete buffer
-        let current_window = bufwinnr("%")
-        let window_number = bufwinnr(a:minwid)
-        let last_window_visited = -1
-        let buffer_in_window = 0
-        while window_number != -1 && window_number != last_window_visited
-          let buffer_in_window = 1
-          silent execute window_number . 'wincmd w'
-          silent execute 'enew'
-          let last_window_visited = window_number
-          let window_number = bufwinnr(a:minwid)
-        endwhile
-        silent execute current_window . 'wincmd w'
-        if window_number != last_window_visited || buffer_in_window == 0
+
+        if get(g:, 'airline_middle_click_preserve_windows', 0) == 0
+          " just simply delete the clicked buffer. This will cause windows 
+          " associated with the clicked buffer to be closed.
           silent execute 'bdelete' a:minwid
+        else
+          " find windows displaying the clicked buffer and open an new 
+          " buffer in them.
+          let current_window = bufwinnr("%")
+          let window_number = bufwinnr(a:minwid)
+          let last_window_visited = -1
+          
+          " Set to 1 if the clicked buffer was open in any windows.
+          let buffer_in_window = 0
+
+          " Find the next window with the clicked buffer open. If bufwinnr() 
+          " returns the same window number, this is because we clicked a new 
+          " buffer, and then tried editing a new buffer. Vim won't create a
+          " new empty buffer for the same window, so we get the same window
+          " number from bufwinnr(). In this case we just give up and don't
+          " delete the buffer.
+          " This could be made cleaner if we could check if the clicked buffer
+          " is a new buffer, but I don't know if there is a way to do that.
+          while window_number != -1 && window_number != last_window_visited
+            let buffer_in_window = 1
+            silent execute window_number . 'wincmd w'
+            silent execute 'enew'
+            let last_window_visited = window_number
+            let window_number = bufwinnr(a:minwid)
+          endwhile
+          silent execute current_window . 'wincmd w'
+          if window_number != last_window_visited || buffer_in_window == 0
+            silent execute 'bdelete' a:minwid
+          endif
         endif
       endif
     endif

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -145,9 +145,6 @@ values):
  >
   let g:airline_skip_empty_sections = 1
 <
-* preserve windows when closing a buffer from the bufferline >
-  let g:airline_middle_click_preserve_windows=1
-<
 ==============================================================================
 COMMANDS                                                  *airline-commands*
 
@@ -542,6 +539,12 @@ Note: If you are using neovim (has('tablineat') = 1), then you can click
 on the tabline with the left mouse button to switch to that buffer, and
 with the middle mouse button to delete that buffer.
 
+* enable/disable preserving window layout when closing a buffer with middle
+  click by opening a new buffer in the windows which have the clicked buffer
+  open >
+  
+  let g:airline#extensions#tabline#middle_click_preserves_windows = 0
+<
 * enable/disable displaying tabs, regardless of number. (c)
   let g:airline#extensions#tabline#show_tabs = 1
 <

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -145,7 +145,9 @@ values):
  >
   let g:airline_skip_empty_sections = 1
 <
-
+* preserve windows when closing a buffer from the bufferline >
+  let g:airline_middle_click_preserve_windows=1
+<
 ==============================================================================
 COMMANDS                                                  *airline-commands*
 


### PR DESCRIPTION
Adding an option to prevent windows from being closed when a buffer in the tabline is middle clicked and the clicked buffer is currently open in a window.

When this option is enabled, instead of closing the window a new buffer will be opened in all of the windows editing the clicked buffer instead.

This is my first pull request AND my first experience with vimscript, so my apologies if this is a bit sloppy 😄 
