### PR TITLE
Shorten mode message for small windows

### DIFF
--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -53,7 +53,7 @@ endfunction
 " }}}
 
 function! airline#parts#mode()
-  return get(w:, 'airline_current_mode', '')
+  return airline#util#shorten(get(w:, 'airline_current_mode', ''), 79, 1)
 endfunction
 
 function! airline#parts#crypt()


### PR DESCRIPTION
For short windows < 79 chars, shorten the mode message to 1 char