### PR TITLE
Use neovim's async job's instead of system

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -185,7 +185,7 @@ function! s:update_untracked()
       " doesn't happen often in practice, so we let it be.
       call s:get_vcs_untracked_async(l:config, l:file)
     else
-      let output = system(l:config.cmd . shellescape(l:file))
+      let output = airline#util#system(l:config.cmd . shellescape(l:file))
       if output =~? ('^' . l:config.untracked_mark)
         let l:config.untracked[l:file] = get(g:, 'airline#extensions#branch#notexists', g:airline_symbols.notexists)
       else
@@ -365,7 +365,7 @@ endfunction
 
 function! s:reset_untracked_cache(shellcmdpost)
   " shellcmdpost - whether function was called as a result of ShellCmdPost hook
-  if !s:has_async
+  if !s:has_async && !has('nvim')
     if a:shellcmdpost
       " Clear cache only if there was no error or the script uses an
       " asynchronous interface. Otherwise, cache clearing would overwrite

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -77,3 +77,34 @@ else
     return 0
   endfunction
 endif
+
+" Define a wrapper over system() that uses nvim's async job control if
+" available. This way we avoid overwriting v:shell_error, which might
+" potentially disrupt other plugins.
+if has('nvim')
+  function! s:system_job_handler(job_id, data, event)
+    if a:event == 'stdout'
+      let self.buf .=  join(a:data)
+    endif
+  endfunction
+
+  function! airline#util#system(cmd)
+    let l:config = {
+    \ 'buf': '',
+    \ 'on_stdout': function('s:system_job_handler'),
+    \ }
+    let l:id = jobstart(a:cmd, l:config)
+    if l:id < 1
+      return system(a:cmd)
+    endif
+    let l:ret_code = jobwait([l:id])
+    if l:ret_code != [0]
+      return system(a:cmd)
+    endif
+    return l:config.buf
+  endfunction
+else
+  function! airline#util#system(cmd)
+    return system(a:cmd)
+  endfunction
+endif


### PR DESCRIPTION
This commit makes branch.vim use neovim's async jobs instead of a system()
function. This way we avoid the v:shell_error overwrite bug and allow live
updates of the untracked status.