### PR TITLE
Use getwininfo() for checking quickfix window

### DIFF
--- a/autoload/airline/extensions/quickfix.vim
+++ b/autoload/airline/extensions/quickfix.vim
@@ -27,6 +27,14 @@ function! airline#extensions#quickfix#inactive_qf_window(...)
 endfunction
 
 function! s:get_text()
+  if exists("*win_getid") && exists("*getwininfo")
+    let dict = getwininfo(win_getid())
+    if len(dict) > 0 && dict[0].quickfix && !dict[0].loclist
+      return g:airline#extensions#quickfix#quickfix_text
+    elseif len(dict) > 0 && dict[0].quickfix && dict[0].loclist
+      return g:airline#extensions#quickfix#location_text
+    endif
+  endif
   redir => buffers
   silent ls
   redir END
@@ -43,4 +51,3 @@ function! s:get_text()
   endfor
   return ''
 endfunction
-


### PR DESCRIPTION
Since Vim8 we have win_getid() and getwininfo() functions to get
information about the current window. So we can use those functions to
find out, whether the current window is a quickfix or location list
window.

This avoids using a redir() over the :ls command and trying to
manually match the string quickfix and should be faster and also be more
robust, as the redir may fail if done recursively.

fixes #1319