### PR TITLE
Do not forward v:shell_error on command fail.

### DIFF
--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -97,10 +97,7 @@ if has('nvim')
     if l:id < 1
       return system(a:cmd)
     endif
-    let l:ret_code = jobwait([l:id])
-    if l:ret_code != [0]
-      return system(a:cmd)
-    endif
+    call jobwait([l:id])
     return l:config.buf
   endfunction
 else


### PR DESCRIPTION
airline#system#util for nvim used to fall back to 'system' implementation on
command error. This behavior caused conflict with other plugins if 'util' was
executed with a failing command as part of a ShellCmdPost event.

This commit makes 'util' interpret command error as persistent and not call
'system' in such a case.

This commit fixes #1317.