### PR TITLE
Abbreviate the text for 'po' translation files.

### DIFF
--- a/autoload/airline/extensions/po.vim
+++ b/autoload/airline/extensions/po.vim
@@ -77,6 +77,7 @@ function! airline#extensions#po#stats()
     endif
     try
       let b:airline_po_stats = '['. split(airline_po_stats, '\n')[0]. ']'
+      let b:airline_po_stats = substitute(b:airline_po_stats, ' \(message\|translation\)s*\.*', '', 'g')
     catch
       let b:airline_po_stats = ''
     endtry


### PR DESCRIPTION
A typical status line for a 'po' (Portable Object) translation file is:
```
1152 translated messages, 91 fuzzy translations, 42 untranslated messages.
```
Adding a `substitute()`, tidies this to:
```
1152 translated, 91 fuzzy, 42 untranslated
```
which is still informative, but less verbose.