### PR TITLE
Allow user overrides for highlight groups

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -68,7 +68,7 @@ function! airline#highlighter#exec(group, colors)
     call add(colors, '')
   endif
   if old_hi != colors
-    let cmd = printf('hi %s %s %s %s %s %s %s %s',
+    let cmd = printf('hi default %s %s %s %s %s %s %s %s',
         \ a:group, s:Get(colors, 0, 'guifg=', ''), s:Get(colors, 1, 'guibg=', ''),
         \ s:Get(colors, 2, 'ctermfg=', ''), s:Get(colors, 3, 'ctermbg=', ''),
         \ s:Get(colors, 4, 'gui=', ''), s:Get(colors, 4, 'cterm=', ''),


### PR DESCRIPTION
This tiny change makes it so that if the user has manually set the values of certain airline highlight groups, then airline won't clobber them.

(Use case: I have a base16 theme that makes *everything* be a different shade of green, and want there to be *some* way to set even things like `airline_error` to be a shade of green, even if it's somewhat roundabout. Currently, `airline_error`, `airline_warning`, and co do not let themselves be set by the base16 theme; this is the minimal change to make my use case possible.)