### PR TITLE
Fixed bug where highlighting on inactive windows wouldn't refresh.

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -108,6 +108,7 @@ function! airline#highlighter#load_theme()
   for winnr in filter(range(1, winnr('$')), 'v:val != winnr()')
     call airline#highlighter#highlight_modified_inactive(winbufnr(winnr))
   endfor
+  call airline#highlighter#highlight(['inactive'])
   if getbufvar( bufnr('%'), '&modified'  )
     call airline#highlighter#highlight(['normal', 'modified'])
   else


### PR DESCRIPTION
Repro steps:

1. Install some theme that depends on the background color
   (Soares/base16.nvim has a bunch)
2. `set background=dark` in your vimrc, and `colorscheme` one of the
   aforementioned schemes.
3. Open a split window. Note the colors on the inactive window's airline.
4. `set background=light` manually. note the colors on the inactive
   window's airline. Note how they have not updated. (In particular,
   airline_c_inactive has updated, but all the other inactive groups
   have not.)
5. Enter the inactive window. Exit the inactive window. Observe that the
   colors are now correct (showing that it is in fact a problem with the
   airline load_theme code, and not with the theme).

There might be a better way to fix this; I'm not sure.

It seems strange that the code as written only expects
airline_c_inactive to have styling; perhaps there is some norm that
themes are supposed to handle inactive windows in a particular way? For
the record, my theme did something like this:

```
let s:IA1   = s:airlist('similar1', 'similar2')
let s:IA2   = s:airlist('similar1', 'similar2')
let s:IA3   = s:airlist('similar1', 'similar2')
let g:airline#themes#{s:palette}#palette.inactive = airline#themes#generate_color_map(s:IA1, s:IA2, s:IA3)
let g:airline#themes#{s:palette}#palette.inactive.airline_warning = s:airlist('base', 'contrast3')
let g:airline#themes#{s:palette}#palette.inactive.airline_error = s:airlist('base', 'antibase')
```