### PR TITLE
Add dict to function referencing self

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -5,20 +5,20 @@ scriptencoding utf-8
 
 let s:prototype = {}
 
-function! s:prototype.split(...)
+function! s:prototype.split(...) dict
   call add(self._sections, ['|', a:0 ? a:1 : '%='])
 endfunction
 
-function! s:prototype.add_section_spaced(group, contents)
+function! s:prototype.add_section_spaced(group, contents) dict
   let spc = empty(a:contents) ? '' : g:airline_symbols.space
   call self.add_section(a:group, spc.a:contents.spc)
 endfunction
 
-function! s:prototype.add_section(group, contents)
+function! s:prototype.add_section(group, contents) dict
   call add(self._sections, [a:group, a:contents])
 endfunction
 
-function! s:prototype.add_raw(text)
+function! s:prototype.add_raw(text) dict
   call add(self._sections, ['', a:text])
 endfunction
 
@@ -34,7 +34,7 @@ function! s:get_prev_group(sections, i)
   return ''
 endfunction
 
-function! s:prototype.build()
+function! s:prototype.build() dict
   let side = 1
   let line = ''
   let i = 0

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -82,7 +82,7 @@ endif
 " available. This way we avoid overwriting v:shell_error, which might
 " potentially disrupt other plugins.
 if has('nvim')
-  function! s:system_job_handler(job_id, data, event)
+  function! s:system_job_handler(job_id, data, event) dict
     if a:event == 'stdout'
       let self.buf .=  join(a:data)
     endif


### PR DESCRIPTION
## Enviroment
NVIM v0.2.0-137-g5855f30c
OS: OSX 10.11.6
vim-airline: 7cb5c2415172372ecd89662279350baf890dc8a0

## Problem
When I save buffer, neovim throws this.

```
Error detected while processing function airline#extensions#branch#get_head[1]..airline#extensions#branch#head[6]..<SNR>59_update_untracked[28]..airline#util#system[9]..<SNR>71_system_job_handler:
line    2:
E121: Undefined variable: self
```

This is related neovim [issue](https://github.com/neovim/neovim/issues/5763)