### PR TITLE
Support for test status on neoterm

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -244,6 +244,11 @@ function! airline#extensions#load()
     call add(loaded_ext, 'neomake')
   endif
 
+  if (get(g:, 'airline#extensions#neoterm#enabled', 1) && exists(':Tnew'))
+    call airline#extensions#neoterm#init(s:ext)
+    call add(loaded_ext, 'neoterm')
+  endif
+
   if get(g:, 'airline#extensions#po#enabled', 1) && executable('msgfmt')
     call airline#extensions#po#init(s:ext)
     call add(loaded_ext, 'po')

--- a/autoload/airline/extensions/neoterm.vim
+++ b/autoload/airline/extensions/neoterm.vim
@@ -1,0 +1,19 @@
+" vim: et ts=2 sts=2 sw=2
+
+if !exists(':Tnew')
+  finish
+endif
+
+let g:neoterm_test_status = {'running': '🏃','success': '💚','failed': '💔'}
+let g:neoterm_test_status_format = '%s'
+
+function! AirlineNeotermSpecStatus()
+ return printf('%s', g:neoterm_statusline )
+endfunction
+
+function! airline#extensions#neoterm#init(ext)
+  call airline#parts#define_function(
+        \ 'neoterm_test_status',
+        \ 'AirlineNeotermSpecStatus'
+        \)
+endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -102,7 +102,7 @@ function! airline#init#bootstrap()
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
   call airline#parts#define_empty(['hunks', 'branch', 'obsession', 'tagbar', 'syntastic',
         \ 'eclim', 'whitespace','windowswap', 'ycm_error_count', 'ycm_warning_count',
-        \ 'neomake_error_count', 'neomake_warning_count', 'ale_error_count', 'ale_warning_count'])
+        \ 'neomake_error_count', 'neomake_warning_count', 'ale_error_count', 'ale_warning_count','neoterm_test_status'])
   call airline#parts#define_text('capslock', '')
 
   unlet g:airline#init#bootstrapping
@@ -136,7 +136,7 @@ function! airline#init#sections()
     let g:airline_section_x = airline#section#create_right(['tagbar', 'filetype'])
   endif
   if !exists('g:airline_section_y')
-    let g:airline_section_y = airline#section#create_right(['ffenc'])
+    let g:airline_section_y = airline#section#create_right(['ffenc','neoterm_test_status'])
   endif
   if !exists('g:airline_section_z')
     if winwidth(0) > 80

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -812,6 +812,16 @@ po.vim <http://www.vim.org/scripts/script.php?script_id=2530>
 <
 * truncate width names to a fixed length >
   let g:airline#extensions#po#displayed_limit = 0
+
+-------------------------------------                  *airline-neoterm-test-status*
+neoterm <https://github.com/kassio/neoterm>
+
+* enable/disable neoterm integration >
+  let g:airline#extensions#neoterm#enabled = 1
+
+  this extension will automatically set neoterm variable as follows
+  let g:neoterm_test_status = {'running': '🏃','success': '💚','failed': '💔'}
+  let g:neoterm_test_status_format = '%s'
 <
 ==============================================================================
 ADVANCED CUSTOMIZATION                      *airline-advanced-customization*

--- a/t/init.vim
+++ b/t/init.vim
@@ -65,6 +65,7 @@ describe 'init sections'
     Expect airline#parts#get('syntastic').raw == ''
     Expect airline#parts#get('eclim').raw == ''
     Expect airline#parts#get('whitespace').raw == ''
+    Expect airline#parts#get('neoterm_test_status').raw == ''
   end
 end
 


### PR DESCRIPTION
Display test status (rspec & minitest) using neoterm.
There are three states of test:
- Success: 💚
- Running: 🏃
- Failed: 💔

Using neoterm, rspec/minitest can be performed asynchronously and the
result will be displayed on airline(section_x)

The result will look like gif below
![test-status-airline](https://cloud.githubusercontent.com/assets/120483/8212291/425189d2-14f1-11e5-8059-822eda0b702c.gif)