### PR TITLE
Truncation fix for whitespace extension

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -9,10 +9,10 @@ let s:show_message = get(g:, 'airline#extensions#whitespace#show_message', 1)
 let s:symbol = get(g:, 'airline#extensions#whitespace#symbol', g:airline_symbols.whitespace)
 let s:default_checks = ['indent', 'trailing', 'mixed-indent-file']
 
-let s:trailing_format = get(g:, 'airline#extensions#whitespace#trailing_format', 'trailing[%s]')
-let s:mixed_indent_format = get(g:, 'airline#extensions#whitespace#mixed_indent_format', 'mixed-indent[%s]')
-let s:long_format = get(g:, 'airline#extensions#whitespace#long_format', 'long[%s]')
-let s:mixed_indent_file_format = get(g:, 'airline#extensions#whitespace#mixed_indent_file_format', 'mix-indent-file[%s]')
+let s:trailing_format = get(g:, 'airline#extensions#whitespace#trailing_format', '[%s]trailing')
+let s:mixed_indent_format = get(g:, 'airline#extensions#whitespace#mixed_indent_format', '[%s]mixed-indent')
+let s:long_format = get(g:, 'airline#extensions#whitespace#long_format', '[%s]long')
+let s:mixed_indent_file_format = get(g:, 'airline#extensions#whitespace#mixed_indent_file_format', '[%s]mix-indent-file')
 let s:indent_algo = get(g:, 'airline#extensions#whitespace#mixed_indent_algo', 0)
 let s:skip_check_ft = {'make': ['indent', 'mixed-indent-file'] }
 let s:max_lines = get(g:, 'airline#extensions#whitespace#max_lines', 20000)


### PR DESCRIPTION
Line numbers are now displayed before the warning instead of after, preventing truncation. The truncation makes the whitespace/indent section essentially useless in smaller terminals. See screenshots for the problem I refer to.

<img width="1098" alt="1" src="https://cloud.githubusercontent.com/assets/6699838/22693008/ca3049f4-ed41-11e6-942b-a33cd5423da5.png">

<img width="698" alt="2" src="https://cloud.githubusercontent.com/assets/6699838/22693014/d16b946c-ed41-11e6-9367-790b93de5d14.png">

