### PR TITLE
Add a function to disable whitespace-detection

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -139,6 +139,12 @@ function! airline#extensions#whitespace#toggle()
   echo 'Whitespace checking: '.(s:enabled ? 'Enabled' : 'Disabled')
 endfunction
 
+function! airline#extensions#whitespace#disable()
+  if s:enabled
+    call airline#extensions#whitespace#toggle()
+  endif
+endfunction
+
 function! airline#extensions#whitespace#init(...)
   call airline#parts#define_function('whitespace', 'airline#extensions#whitespace#check')
 

--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -72,6 +72,7 @@ function! airline#highlighter#exec(group, colors)
   if len(colors) == 4
     call add(colors, '')
   endif
+  let colors = s:CheckDefined(colors)
   if old_hi != colors
     let cmd = printf('hi %s %s %s %s %s %s %s %s',
         \ a:group, s:Get(colors, 0, 'guifg=', ''), s:Get(colors, 1, 'guibg=', ''),
@@ -80,6 +81,24 @@ function! airline#highlighter#exec(group, colors)
         \ s:Get(colors, 4, 'term=', ''))
     exe cmd
   endif
+endfunction
+
+function! s:CheckDefined(colors)
+  " Checks, whether the definition of the colors is valid and is not empty or NONE
+  " e.g. if the colors would expand to this:
+  " hi airline_c ctermfg=NONE ctermbg=NONE
+  " that means to clear that highlighting group, therefore, add a special term=NONE
+  " argument
+  for val in a:colors
+    if !empty(val) && val !=# 'NONE'
+      return a:colors
+    endif
+  endfor
+  " this adds the bold attribute to the term argument of the :hi command,
+  " but at least this makes sure, the group will be defined
+  let fg = synIDattr(synIDtrans(hlID('Normal')), 'fg', 'cterm')
+  let bg = synIDattr(synIDtrans(hlID('Normal')), 'bg', 'cterm')
+  return a:colors[0:1] + [fg, bg] + [a:colors[4]]
 endfunction
 
 function! s:Get(dict, key, prefix, default)

--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -73,7 +73,7 @@ function! airline#highlighter#exec(group, colors)
     call add(colors, '')
   endif
   let colors = s:CheckDefined(colors)
-  if old_hi != colors
+  if old_hi != colors || !hlexists(a:group)
     let cmd = printf('hi %s %s %s %s %s %s %s %s',
         \ a:group, s:Get(colors, 0, 'guifg=', ''), s:Get(colors, 1, 'guibg=', ''),
         \ s:Get(colors, 2, 'ctermfg=', ''), s:Get(colors, 3, 'ctermbg=', ''),

--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -22,12 +22,17 @@ function! s:get_syn(group, what)
   if !exists("g:airline_gui_mode")
     let g:airline_gui_mode = airline#init#gui_mode()
   endif
-  let color = synIDattr(synIDtrans(hlID(a:group)), a:what, g:airline_gui_mode)
-  if empty(color) || color == -1
-    let color = synIDattr(synIDtrans(hlID('Normal')), a:what, g:airline_gui_mode)
+  let color = ''
+  if hlexists(a:group)
+    let color = synIDattr(synIDtrans(hlID(a:group)), a:what, g:airline_gui_mode)
   endif
   if empty(color) || color == -1
-    let color = 'NONE'
+    " should always exists
+    let color = synIDattr(synIDtrans(hlID('Normal')), a:what, g:airline_gui_mode)
+    " however, just in case
+    if empty(color) || color == -1
+      let color = 'NONE'
+    endif
   endif
   return color
 endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -87,7 +87,7 @@ function! airline#init#bootstrap()
           \ 'notexists': "\u0246",
           \ 'crypt': nr2char(0x1F512),
           \ }, 'keep')
-  elseif &encoding==?'utf-8'
+  elseif &encoding==?'utf-8' && !get(g:, "g:airline_symbols_ascii", 0)
     " Symbols for Unicode terminals
     call s:check_defined('g:airline_left_sep', "")
     call s:check_defined('g:airline_left_alt_sep', "")

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -17,10 +17,10 @@ function! airline#init#bootstrap()
   let s:loaded = 1
 
   let g:airline#init#bootstrapping = 1
-  call s:check_defined('g:airline_left_sep', get(g:, 'airline_powerline_fonts', 0) ? "\ue0b0" : " ")
-  call s:check_defined('g:airline_left_alt_sep', get(g:, 'airline_powerline_fonts', 0) ? "\ue0b1" : "|")
-  call s:check_defined('g:airline_right_sep', get(g:, 'airline_powerline_fonts', 0) ? "\ue0b2" : " ")
-  call s:check_defined('g:airline_right_alt_sep', get(g:, 'airline_powerline_fonts', 0) ? "\ue0b3" : "|")
+
+  let g:airline#util#async = v:version >= 800 && has('job')
+  let g:airline#util#is_windows = has('win32') || has('win64')
+
   call s:check_defined('g:airline_detect_modified', 1)
   call s:check_defined('g:airline_detect_paste', 1)
   call s:check_defined('g:airline_detect_crypt', 1)
@@ -31,9 +31,6 @@ function! airline#init#bootstrap()
   call s:check_defined('g:airline_exclude_filetypes', [])
   call s:check_defined('g:airline_exclude_preview', 0)
   call s:check_defined('g:airline_gui_mode', airline#init#gui_mode())
-
-  let g:airline#util#async = v:version >= 800 && has('job')
-  let g:airline#util#is_windows = has('win32') || has('win64')
 
   call s:check_defined('g:airline_mode_map', {})
   call extend(g:airline_mode_map, {
@@ -64,19 +61,64 @@ function! airline#init#bootstrap()
         \ }, 'keep')
 
   call s:check_defined('g:airline_symbols', {})
+  " First define the symbols,
+  " that are common in Powerline/Unicode/ASCII mode,
+  " then add specific symbols for either mode
   call extend(g:airline_symbols, {
-        \ 'paste': 'PASTE',
-        \ 'spell': 'SPELL',
-        \ 'readonly': get(g:, 'airline_powerline_fonts', 0) ? "\ue0a2" : 'RO',
-        \ 'whitespace': get(g:, 'airline_powerline_fonts', 0) ? "\u2632" : "\u2632",
-        \ 'linenr': get(g:, 'airline_powerline_fonts', 0) ? "\ue0a1" : "\u33D1",
-        \ 'maxlinenr': get(g:, 'airline_powerline_fonts', 0) ? "\u2630" : "\u2630",
-        \ 'branch': get(g:, 'airline_powerline_fonts', 0) ? "\ue0a0" : "\u16A0",
-        \ 'notexists': "\u2204",
-        \ 'modified': '+',
-        \ 'space': ' ',
-        \ 'crypt': get(g:, 'airline_crypt_symbol', nr2char(0x1F512)),
-        \ }, 'keep')
+          \ 'paste': 'PASTE',
+          \ 'spell': 'SPELL',
+          \ 'modified': '+',
+          \ 'space': ' '
+          \  }, 'keep')
+
+  if exists('g:airline_powerline_fonts')
+    " Symbols for Powerline terminals
+    call s:check_defined('g:airline_left_sep', "\ue0b0")      " 
+    call s:check_defined('g:airline_left_alt_sep', "\ue0b1")  " 
+    call s:check_defined('g:airline_right_sep', "\ue0b2")     " 
+    call s:check_defined('g:airline_right_alt_sep', "\ue0b3") " 
+    " ro=, ws=☲, lnr=☰, mlnr=, br=, nx=Ɇ, crypt=🔒
+    call extend(g:airline_symbols, {
+          \ 'readonly': "\ue0a2",
+          \ 'whitespace': "\u2632",
+          \ 'linenr': "\u2630",
+          \ 'maxlinenr': "\ue0a1",
+          \ 'branch': "\ue0a0",
+          \ 'notexists': "\u0246",
+          \ 'crypt': nr2char(0x1F512),
+          \ }, 'keep')
+  elseif &encoding==?'utf-8'
+    " Symbols for Unicode terminals
+    call s:check_defined('g:airline_left_sep', "")
+    call s:check_defined('g:airline_left_alt_sep', "")
+    call s:check_defined('g:airline_right_sep', "")
+    call s:check_defined('g:airline_right_alt_sep', "")
+    " ro=⊝, ws=☲, lnr=☰, mlnr=㏑, br=ᚠ, nx=Ɇ, crypt=🔒
+    call extend(g:airline_symbols, {
+          \ 'readonly': "\u229D",
+          \ 'whitespace': "\u2632",
+          \ 'linenr': "\u2630",
+          \ 'maxlinenr': "\u33D1",
+          \ 'branch': "\u16A0",
+          \ 'notexists': "\u0246",
+          \ 'crypt': nr2char(0x1F512),
+          \ }, 'keep')
+  else
+    " Symbols for ASCII terminals
+    call s:check_defined('g:airline_left_sep', "")
+    call s:check_defined('g:airline_left_alt_sep', "")
+    call s:check_defined('g:airline_right_sep', "")
+    call s:check_defined('g:airline_right_alt_sep', "")
+    call extend(g:airline_symbols, {
+          \ 'readonly': 'RO',
+          \ 'whitespace': '!',
+          \ 'linenr': 'ln',
+          \ 'maxlinenr': ':',
+          \ 'branch': '',
+          \ 'notexists': '?',
+          \ 'crypt': 'cr',
+          \ }, 'keep')
+  endif
 
   call airline#parts#define('mode', {
         \ 'function': 'airline#parts#mode',

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -17,10 +17,10 @@ function! airline#init#bootstrap()
   let s:loaded = 1
 
   let g:airline#init#bootstrapping = 1
-  call s:check_defined('g:airline_left_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b0":">")
-  call s:check_defined('g:airline_left_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b1":">")
-  call s:check_defined('g:airline_right_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b2":"<")
-  call s:check_defined('g:airline_right_alt_sep', get(g:, 'airline_powerline_fonts', 0)?"\ue0b3":"<")
+  call s:check_defined('g:airline_left_sep', get(g:, 'airline_powerline_fonts', 0) ? "\ue0b0" : " ")
+  call s:check_defined('g:airline_left_alt_sep', get(g:, 'airline_powerline_fonts', 0) ? "\ue0b1" : "|")
+  call s:check_defined('g:airline_right_sep', get(g:, 'airline_powerline_fonts', 0) ? "\ue0b2" : " ")
+  call s:check_defined('g:airline_right_alt_sep', get(g:, 'airline_powerline_fonts', 0) ? "\ue0b3" : "|")
   call s:check_defined('g:airline_detect_modified', 1)
   call s:check_defined('g:airline_detect_paste', 1)
   call s:check_defined('g:airline_detect_crypt', 1)
@@ -68,10 +68,10 @@ function! airline#init#bootstrap()
         \ 'paste': 'PASTE',
         \ 'spell': 'SPELL',
         \ 'readonly': get(g:, 'airline_powerline_fonts', 0) ? "\ue0a2" : 'RO',
-        \ 'whitespace': get(g:, 'airline_powerline_fonts', 0) ? "\u2739" : '!',
-        \ 'linenr': get(g:, 'airline_powerline_fonts', 0) ? "\ue0a1" : ':',
-        \ 'maxlinenr': get(g:, 'airline_powerline_fonts', 0) ? "\u2630" : '',
-        \ 'branch': get(g:, 'airline_powerline_fonts', 0) ? "\ue0a0" : '',
+        \ 'whitespace': get(g:, 'airline_powerline_fonts', 0) ? "\u2632" : "\u2632",
+        \ 'linenr': get(g:, 'airline_powerline_fonts', 0) ? "\ue0a1" : "\u33D1",
+        \ 'maxlinenr': get(g:, 'airline_powerline_fonts', 0) ? "\u2630" : "\u2630",
+        \ 'branch': get(g:, 'airline_powerline_fonts', 0) ? "\ue0a0" : "\u16A0",
         \ 'notexists': "\u2204",
         \ 'modified': '+',
         \ 'space': ' ',

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -87,7 +87,7 @@ function! airline#init#bootstrap()
           \ 'notexists': "\u0246",
           \ 'crypt': nr2char(0x1F512),
           \ }, 'keep')
-  elseif &encoding==?'utf-8' && !get(g:, "g:airline_symbols_ascii", 0)
+  elseif &encoding==?'utf-8' && !get(g:, "airline_symbols_ascii", 0)
     " Symbols for Unicode terminals
     call s:check_defined('g:airline_left_sep', "")
     call s:check_defined('g:airline_left_alt_sep', "")

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -102,9 +102,12 @@ values):
     endif
   endfunction
 <
-* enable/disable automatic population of the `g:airline_symbols` dictionary
-  with powerline symbols. >
-  let g:airline_powerline_fonts=0
+* By default, airline will use unicode symbols if your encoding matches
+  utf-8. If you want the powerline symbols set this variable: >
+  let g:airline_powerline_fonts = 1
+<
+  If you want to use plain ascii symbols, set this variable: >
+  let g:airline_symbols_ascii = 1
 <
 * define the set of text to display for each mode.  >
   let g:airline_mode_map = {} " see source for the defaults

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -489,6 +489,10 @@ eclim <https://eclim.org>
 * enable/disable detection of whitespace errors. >
   let g:airline#extensions#whitespace#enabled = 1
 <
+* disable detection of whitespace errors. >
+  " useful to call for particular file types (e.g., in "ftplugin/*")
+  silent! call airline#extensions#whitespace#disable
+<
 * customize the type of mixed indent checking to perform. >
   " must be all spaces or all tabs before the first non-whitespace character
   let g:airline#extensions#whitespace#mixed_indent_algo = 0 (default)

--- a/t/builder.vim
+++ b/t/builder.vim
@@ -15,7 +15,7 @@ describe 'active builder'
     call s:builder.add_section('Normal', 'hello')
     call s:builder.add_section('Search', 'world')
     let stl = s:builder.build()
-    Expect stl =~ '%#Normal#hello%#Normal_to_Search#>%#Search#world'
+    Expect stl =~ '%#Normal#hello%#Normal_to_Search#%#Search#world'
   end
 
   it 'should reuse highlight group if background colors match'
@@ -24,7 +24,7 @@ describe 'active builder'
     call s:builder.add_section('Foo1', 'hello')
     call s:builder.add_section('Foo2', 'world')
     let stl = s:builder.build()
-    Expect stl =~ '%#Foo1#hello>world'
+    Expect stl =~ '%#Foo1#helloworld'
   end
 
   it 'should switch highlight groups if foreground colors differ'
@@ -33,7 +33,7 @@ describe 'active builder'
     call s:builder.add_section('Foo1', 'hello')
     call s:builder.add_section('Foo2', 'world')
     let stl = s:builder.build()
-    Expect stl =~ '%#Foo1#hello%#Foo1_to_Foo2#>%#Foo2#world'
+    Expect stl =~ '%#Foo1#hello%#Foo1_to_Foo2#%#Foo2#world'
   end
 
   it 'should split left/right sections'
@@ -47,14 +47,14 @@ describe 'active builder'
     call s:builder.add_section('Normal', 'hello')
     call s:builder.add_section('Search', 'world')
     let stl = s:builder.build()
-    Expect stl =~ 'hello%#Normal_to_Search#<%#Search#world'
+    Expect stl =~ 'hello%#Normal_to_Search#%#Search#world'
   end
 
   it 'should not repeat the same highlight group'
     call s:builder.add_section('Normal', 'hello')
     call s:builder.add_section('Normal', 'hello')
     let stl = s:builder.build()
-    Expect stl == '%#Normal#hello>hello'
+    Expect stl == '%#Normal#hellohello'
   end
 
   it 'should replace accent groups with the specified group'
@@ -94,7 +94,7 @@ describe 'inactive builder'
     call s:builder.add_section('Normal', 'hello')
     call s:builder.add_section('Search', 'world')
     let stl = s:builder.build()
-    Expect stl =~ '%#Normal_inactive#hello%#Normal_to_Search_inactive#>%#Search_inactive#world'
+    Expect stl =~ '%#Normal_inactive#hello%#Normal_to_Search_inactive#%#Search_inactive#world'
   end
 
   it 'should not render accents'

--- a/t/section.vim
+++ b/t/section.vim
@@ -57,13 +57,13 @@ describe 'section'
 
   it 'should force add separators for raw and missing keys'
     let s = airline#section#create_left(['asdf', 'raw'])
-    Expect s == 'asdf > raw'
+    Expect s == 'asdf  raw'
     let s = airline#section#create_left(['asdf', 'aaaa', 'raw'])
-    Expect s == 'asdf > aaaa > raw'
+    Expect s == 'asdf  aaaa  raw'
     let s = airline#section#create_right(['raw', '%f'])
-    Expect s == 'raw < %f'
+    Expect s == 'raw  %f'
     let s = airline#section#create_right(['%t', 'asdf', '%{getcwd()}'])
-    Expect s == '%t < asdf < %{getcwd()}'
+    Expect s == '%t  asdf  %{getcwd()}'
   end
 
   it 'should empty out parts that do not pass their condition'

--- a/t/util.vim
+++ b/t/util.vim
@@ -17,12 +17,12 @@ describe 'util'
 
   it 'has append wrapper function'
     Expect airline#util#append('', 0) == ''
-    Expect airline#util#append('1', 0) == '  > 1'
+    Expect airline#util#append('1', 0) == '   1'
   end
 
   it 'has prepend wrapper function'
     Expect airline#util#prepend('', 0) == ''
-    Expect airline#util#prepend('1', 0) == '1 < '
+    Expect airline#util#prepend('1', 0) == '1  '
   end
 
   it 'has getwinvar function'
@@ -40,8 +40,8 @@ describe 'util'
   end
 
   it 'should ignore minwidth if less than 0'
-    Expect airline#util#append('foo', -1) == '  > foo'
-    Expect airline#util#prepend('foo', -1) == 'foo < '
+    Expect airline#util#append('foo', -1) == '   foo'
+    Expect airline#util#prepend('foo', -1) == 'foo  '
     Expect airline#util#wrap('foo', -1) == 'foo'
   end
 


### PR DESCRIPTION
Useful to call for particular file types (e.g., .tex files):
ftplugin/tex.vim:
    call airline#extensions#whitespace#disable()