### PR TITLE
Improvements to wordcount formatting

### DIFF
--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -3,7 +3,6 @@
 
 scriptencoding utf-8
 
-let s:format = get(g:, 'airline#extensions#wordcount#format', '%d words')
 let s:formatter = get(g:, 'airline#extensions#wordcount#formatter', 'default')
 let g:airline#extensions#wordcount#filetypes = get(g:, 'airline#extensions#wordcount#filetypes',
       \ '\vhelp|markdown|rst|org|text|asciidoc|tex|mail')

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -7,7 +7,7 @@ let s:formatter = get(g:, 'airline#extensions#wordcount#formatter', 'default')
 let g:airline#extensions#wordcount#filetypes = get(g:, 'airline#extensions#wordcount#filetypes',
       \ '\vhelp|markdown|rst|org|text|asciidoc|tex|mail')
 
-function! s:update()
+function! s:wordcount_update()
   if match(&ft, get(g:, 'airline#extensions#wordcount#filetypes')) > -1
     let l:mode = mode()
     if l:mode ==# 'v' || l:mode ==# 'V' || l:mode ==# 's' || l:mode ==# 'S'
@@ -36,5 +36,5 @@ endfunction
 
 function! airline#extensions#wordcount#init(ext)
   call a:ext.add_statusline_func('airline#extensions#wordcount#apply')
-  autocmd BufReadPost,CursorMoved,CursorMovedI * call s:update()
+  autocmd BufReadPost,CursorMoved,CursorMovedI * call s:wordcount_update()
 endfunction

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -16,11 +16,13 @@ function! s:update()
     else
       if get(b:, 'airline_wordcount_cache', '') is# '' ||
             \ b:airline_wordcount_cache isnot# get(b:, 'airline_wordcount', '') ||
-            \ get(b:, 'airline_change_tick', 0) != b:changedtick
+            \ get(b:, 'airline_change_tick', 0) != b:changedtick || 
+            \ get(b:, 'airline_winwidth', 0) != winwidth(0)
         " cache data
         let b:airline_wordcount = airline#extensions#wordcount#formatters#{s:formatter}#format()
         let b:airline_wordcount_cache = b:airline_wordcount
         let b:airline_change_tick = b:changedtick
+        let b:airline_winwidth = winwidth(0)
       endif
     endif
   endif

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -8,6 +8,9 @@ let g:airline#extensions#wordcount#filetypes = get(g:, 'airline#extensions#wordc
       \ '\vhelp|markdown|rst|org|text|asciidoc|tex|mail')
 
 function! s:wordcount_update()
+  if empty(bufname(''))
+    return
+  endif
   if match(&ft, get(g:, 'airline#extensions#wordcount#filetypes')) > -1
     let l:mode = mode()
     if l:mode ==# 'v' || l:mode ==# 'V' || l:mode ==# 's' || l:mode ==# 'S'

--- a/autoload/airline/extensions/wordcount/formatters/default.vim
+++ b/autoload/airline/extensions/wordcount/formatters/default.vim
@@ -13,9 +13,7 @@ function! airline#extensions#wordcount#formatters#default#format()
     let separator = s:get_decimal_group()
     if words > 999 && !empty(separator)
       " Format number according to locale, e.g. German: 1.245 or English: 1,245
-      let a = join(reverse(split(words, '.\zs')),'')
-      let a = substitute(a, '...', '&'.separator, 'g')
-      let words = join(reverse(split(a, '.\zs')),'')
+      let words = substitute(words, '\d\@<=\(\(\d\{3\}\)\+\)$', separator.'&', 'g')
     endif
     let result = printf("%s%s", words, " words"). result
   else

--- a/autoload/airline/extensions/wordcount/formatters/default.vim
+++ b/autoload/airline/extensions/wordcount/formatters/default.vim
@@ -8,14 +8,20 @@ function! airline#extensions#wordcount#formatters#default#format()
   if empty(words)
     return
   endif
-  let separator = s:get_decimal_group()
-  if words > 999 && !empty(separator)
-    " Format number according to locale, e.g. German: 1.245 or English: 1,245
-    let a = join(reverse(split(words, '.\zs')),'')
-    let a = substitute(a, '...', '&'.separator, 'g')
-    let words = join(reverse(split(a, '.\zs')),'')
+  let result = g:airline_symbols.space . g:airline_right_alt_sep . g:airline_symbols.space
+  if winwidth(0) >= 80
+    let separator = s:get_decimal_group()
+    if words > 999 && !empty(separator)
+      " Format number according to locale, e.g. German: 1.245 or English: 1,245
+      let a = join(reverse(split(words, '.\zs')),'')
+      let a = substitute(a, '...', '&'.separator, 'g')
+      let words = join(reverse(split(a, '.\zs')),'')
+    endif
+    let result = printf("%s%s", words, " words"). result
+  else
+    let result = printf("%s%s", words, "W"). result
   endif
-  return  words . " words" . g:airline_symbols.space . g:airline_right_alt_sep . g:airline_symbols.space
+  return result
 endfunction
 
 function! s:wordcount()

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -41,7 +41,7 @@ function! s:on_window_changed()
   endif
   " Handle each window only once, since we might come here several times for
   " different autocommands.
-  let l:key = [bufnr('%'), winnr(), winnr('$'), tabpagenr()]
+  let l:key = [bufnr('%'), winnr(), winnr('$'), tabpagenr(), &ft]
   if get(g:, 'airline_last_window_changed', []) == l:key
         \ && &stl is# '%!airline#statusline('.winnr().')'
     return


### PR DESCRIPTION
Among others, this does:
- make the wordcount format shrinkable on windows < 80 chars
- faster reformatting of wordcount number with separator
- remove unused variable