### PR TITLE
Add support for denite

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lean &amp; mean status/tabline for vim that's light as air.
    [undotree][17], [nerdtree][18], [tagbar][19], [vim-gitgutter][29],
    [vim-signify][30], [quickfixsigns][39], [syntastic][5], [eclim][34],
    [lawrencium][21], [virtualenv][31], [tmuxline][35], [taboo.vim][37],
-   [ctrlspace][38], [vim-bufmru][47], [vimagit][50] and more.
+   [ctrlspace][38], [vim-bufmru][47], [vimagit][50], [denite][51] and more.
 *  Looks good with regular fonts and provides configuration points so you can use unicode or powerline symbols.
 *  Optimized for speed; it loads in under a millisecond.
 *  Extensive suite of themes for popular color schemes including [solarized][23] (dark and light), [tomorrow][24] (all variants), [base16][32] (all variants), [molokai][25], [jellybeans][26] and others.
@@ -71,6 +71,9 @@ vim-airline integrates with a variety of plugins out of the box.  These extensio
 
 #### [unite.vim][9]
 ![image](https://f.cloud.github.com/assets/306502/962319/4d7d3a7e-04ed-11e3-9d59-ab29cb310ff8.png)
+
+#### [denite.nvim][51]
+![image](https://cloud.githubusercontent.com/assets/246230/23939717/f65bce6e-099c-11e7-85c3-918dbc839392.png)
 
 #### [tagbar][19]
 ![image](https://f.cloud.github.com/assets/306502/962150/7e7bfae6-04ea-11e3-9e28-32af206aed80.png)
@@ -252,3 +255,4 @@ MIT License. Copyright (c) 2013-2016 Bailey Ling.
 [48]: https://github.com/ierton/xkb-switch
 [49]: https://github.com/vovkasm/input-source-switcher
 [50]: https://github.com/jreybert/vimagit
+[51]: https://github.com/Shougo/denite.nvim

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -143,6 +143,11 @@ function! airline#extensions#load()
     call add(loaded_ext, 'unite')
   endif
 
+  if get(g:, 'loaded_denite', 0)
+    call airline#extensions#denite#init(s:ext)
+    call add(loaded_ext, 'denite')
+  endif
+
   if exists(':NetrwSettings')
     call airline#extensions#netrw#init(s:ext)
     call add(loaded_ext, 'netrw')

--- a/autoload/airline/extensions/denite.vim
+++ b/autoload/airline/extensions/denite.vim
@@ -1,0 +1,43 @@
+" MIT License. Copyright (c) 2017 Thomas Dy
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+if !get(g:, 'loaded_denite', 0)
+  finish
+endif
+
+" Denite does not use vim's built-in modal editing but has a custom prompt
+" that implements its own insert/normal mode so we have to handle changing the
+" highlight
+function! airline#extensions#denite#check_denite_mode(bufnr)
+  let l:mode = split(denite#get_status_mode(), ' ')
+  let l:mode = tolower(l:mode[1])
+  call airline#highlighter#highlight([l:mode], a:bufnr)
+  return ''
+endfunction
+
+function! airline#extensions#denite#apply(...)
+  if &ft == 'denite'
+    call a:1.add_section('airline_a', ' Denite %{airline#extensions#denite#check_denite_mode('.a:2['bufnr'].')}')
+    call a:1.add_section('airline_c', ' %{denite#get_status_sources()}')
+    call a:1.split()
+    call a:1.add_section('airline_y', ' %{denite#get_status_path()} ')
+    call a:1.add_section('airline_z', ' %{denite#get_status_linenr()} ')
+    return 1
+  endif
+endfunction
+
+function! airline#extensions#denite#init(ext)
+  call denite#custom#option('_', 'statusline', 0)
+  call a:ext.add_statusline_func('airline#extensions#denite#apply')
+
+  " airline#extensions#denite#apply normally gets called only after the
+  " denite window gets closed, so we have to call airline#update_statusline
+  " ourselves to make sure it's applied when the window is opened.
+  augroup airline_denite
+    autocmd!
+    autocmd FileType denite call airline#update_statusline()
+  augroup END
+endfunction
+


### PR DESCRIPTION
Denite is the next-generation unite.vim. I mostly based this off the original unite extension. I'm not too familiar with airline, so I'm kind of concerned if the following are okay:

1. Manually updating the highlight within the extension
2. Manually calling update_statusline on autocmd FileType