### PR TITLE
Permit appending content to a theme copied from dark.vim

### DIFF
--- a/autoload/airline/themes/dark.vim
+++ b/autoload/airline/themes/dark.vim
@@ -94,11 +94,10 @@ let g:airline#themes#dark#palette.accents = {
 " variable so that related functionality is loaded iff the user is using
 " ctrlp. Note that this is optional, and if you do not define ctrlp colors
 " they will be chosen automatically from the existing palette.
-if !get(g:, 'loaded_ctrlp', 0)
-  finish
+if get(g:, 'loaded_ctrlp', 0)
+  let g:airline#themes#dark#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
+        \ [ '#d7d7ff' , '#5f00af' , 189 , 55  , ''     ],
+        \ [ '#ffffff' , '#875fd7' , 231 , 98  , ''     ],
+        \ [ '#5f00af' , '#ffffff' , 55  , 231 , 'bold' ])
 endif
-let g:airline#themes#dark#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
-      \ [ '#d7d7ff' , '#5f00af' , 189 , 55  , ''     ],
-      \ [ '#ffffff' , '#875fd7' , 231 , 98  , ''     ],
-      \ [ '#5f00af' , '#ffffff' , 55  , 231 , 'bold' ])
 


### PR DESCRIPTION
Long-time user, first-time submitter.

`dark.vim` serves as reference and documentation for new themes.  However, presently, if `ctrlp` is not loaded, `dark.vim` calls `finish`.  As a result, copying `dark.vim` and adding to the end silently ignores the additions if you don't have `ctrlp`.  Ask me how I know! ;)

This change simply removes the `finish` so that the theme will keep executing if ctrlp isn't loaded.  I think this will reduce confusion for novice theme designers (such as myself) basing their themes on `dark.vim`.

I looked in the issues and didn't see this; my apologies if I missed something!
