### PR TITLE
vim-airline ctrlspace uses undefined hashmap structure g:airline_symbols

### DIFF
--- a/autoload/airline/extensions/ctrlspace.vim
+++ b/autoload/airline/extensions/ctrlspace.vim
@@ -3,6 +3,10 @@
 
 scriptencoding utf-8
 
+if !exists('g:airline_symbols')
+  let g:airline_symbols = { 'space' : ' ' }
+endif
+
 let s:spc = g:airline_symbols.space
 let s:padding = s:spc . s:spc . s:spc
 


### PR DESCRIPTION
Resolves issue #1440