### PR TITLE
Add vimtex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ vim-airline integrates with a variety of plugins out of the box.  These extensio
 #### [xkb-switch][48]/[xkb-layout][49]
 ![image](https://cloud.githubusercontent.com/assets/5715281/22061422/347e7842-ddb8-11e6-8bdb-7abbd418653c.gif)
 
+#### [vimtex][53]
+![image](https://cloud.githubusercontent.com/assets/1798172/25799740/e77d5c2e-33ee-11e7-8660-d34ce4c5f13f.png)
+
 ## Extras
 
 vim-airline also supplies some supplementary stand-alone extensions.  In addition to the tabline extension mentioned earlier, there is also:
@@ -253,3 +256,4 @@ MIT License. Copyright (c) 2013-2016 Bailey Ling.
 [50]: https://github.com/jreybert/vimagit
 [51]: https://github.com/Shougo/denite.nvim
 [52]: https://github.com/Shougo/dein.vim
+[53]: https://github.com/lervag/vimtex

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -310,6 +310,12 @@ function! airline#extensions#load()
     call add(loaded_ext, 'obsession')
   endif
 
+  runtime autoload/vimtex.vim
+  if (get(g:, 'airline#extensions#vimtex#enabled', 1)) && exists('*vimtex#init')
+   call airline#extensions#vimtex#init(s:ext)
+   call add(loaded_ext, 'vimtex')
+  endif
+
   if !get(g:, 'airline#extensions#disable_rtp_load', 0)
     " load all other extensions, which are not part of the default distribution.
     " (autoload/airline/extensions/*.vim outside of our s:script_path).

--- a/autoload/airline/extensions/vimtex.vim
+++ b/autoload/airline/extensions/vimtex.vim
@@ -1,0 +1,81 @@
+scriptencoding utf-8
+
+let s:spc = g:airline_symbols.space
+
+function! s:SetDefault(var, val)
+  if !exists(a:var)
+    execute 'let ' . a:var . '=' . string(a:val)
+  endif
+endfunction
+
+" Left and right delimiters (added only when status string is not empty)
+call s:SetDefault( 'g:airline#extensions#vimtex#left',       "{")
+call s:SetDefault( 'g:airline#extensions#vimtex#right',      "}")
+
+" The current tex file is the main project file
+call s:SetDefault( 'g:airline#extensions#vimtex#main',       "" )
+"
+" The current tex file is a subfile of the project
+" and the compilation is set for the main file
+call s:SetDefault( 'g:airline#extensions#vimtex#sub_main',   "m")
+"
+" The current tex file is a subfile of the project
+" and the compilation is set for this subfile
+call s:SetDefault( 'g:airline#extensions#vimtex#sub_local',  "l")
+"
+" Compilation is running and continuous compilation is off
+call s:SetDefault( 'g:airline#extensions#vimtex#compiled',   "c₁")
+
+" Compilation is running and continuous compilation is on
+call s:SetDefault( 'g:airline#extensions#vimtex#continuous', "c")
+
+" Viewer is opened
+call s:SetDefault( 'g:airline#extensions#vimtex#viewer',     "v")
+
+function! airline#extensions#vimtex#init(ext)
+  call airline#parts#define_raw('vimtex', '%{airline#extensions#vimtex#get_scope()}')
+  call a:ext.add_statusline_func('airline#extensions#vimtex#apply')
+endfunction
+
+function! airline#extensions#vimtex#apply(...)
+  if exists("b:vimtex")
+    let w:airline_section_x = get(w:, 'airline_section_x', g:airline_section_x)
+    let w:airline_section_x.=s:spc.g:airline_left_alt_sep.s:spc.'%{airline#extensions#vimtex#get_scope()}'
+  endif
+endfunction
+
+function! airline#extensions#vimtex#get_scope()
+  let l:status = ''
+
+  let vt_local = get(b:, 'vimtex_local', {})
+  if empty(vt_local)
+    let l:status .= g:airline#extensions#vimtex#main
+  else
+    if get(vt_local, 'active')
+      let l:status .= g:airline#extensions#vimtex#sub_local
+    else
+      let l:status .= g:airline#extensions#vimtex#sub_main
+    endif
+  endif
+
+  if get(get(get(b:, 'vimtex', {}), 'viewer', {}), 'xwin_id')
+    let l:status .= g:airline#extensions#vimtex#viewer
+  endif
+
+  let l:compiler = get(get(b:, 'vimtex', {}), 'compiler', {})
+  if !empty(l:compiler)
+    if has_key(l:compiler, 'is_running') && b:vimtex.compiler.is_running()
+      if get(l:compiler, 'continuous')
+        let l:status .= g:airline#extensions#vimtex#continuous
+      else
+        let l:status .= g:airline#extensions#vimtex#compiled
+      endif
+    endif
+  endif
+
+  if !empty(l:status)
+    let l:status = g:airline#extensions#vimtex#left . l:status . g:airline#extensions#vimtex#right
+  endif
+  return l:status
+endfunction
+

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -67,7 +67,7 @@ section  meaning (example)~
   C      filename + read-only flag (~/.vim/vimrc RO)
   X      filetype  (vim)
   Y      file encoding[fileformat] (utf-8[unix])
-  Z      current position in the file 
+  Z      current position in the file
            percentage % ☰ current line/number of lines ln : column
            So this: 10% ☰ 10/100 ln : 20   means: >
               10%     - 10 percent
@@ -617,7 +617,7 @@ are supported!
 * enable/disable displaying open splits per tab (only when tabs are opened). >
   let g:airline#extensions#tabline#show_splits = 1
     *
-* switch position of buffers and tabs on splited tabline (c) 
+* switch position of buffers and tabs on splited tabline (c)
   (only supported for ctrlspace plugin). >
   let g:airline#extensions#tabline#switch_buffers_and_tabs = 0
 <
@@ -898,7 +898,41 @@ po.vim <http://www.vim.org/scripts/script.php?script_id=2530>
 <
 * truncate width names to a fixed length >
   let g:airline#extensions#po#displayed_limit = 0
+
+-------------------------------------                          *airline-vimtex*
+vimtex <https://github.com/lervag/vimtex>
+
+Shows the current file's vimtex related info.
+
+* enable/disable vimtex integration >
+  let g:airline#extensions#vimtex#enabled = 1
 <
+* left and right delimiters (shown only when status string is not empty)
+  let g:airline#extensions#vimtex#left = "{"
+  let g:airline#extensions#vimtex#right = "}"
+
+State indicators:
+
+* the current tex file is the main project file (nothing is shown by default)
+  let g:airline#extensions#vimtex#main = ""
+
+* the current tex file is a subfile of the project 
+  and the compilation is set for the main file
+  let g:airline#extensions#vimtex#sub_main = "m"
+
+* the current tex file is a subfile of the project
+  and the compilation is set for this subfile
+  let g:airline#extensions#vimtex#sub_local = "l"
+
+* single compilation is running
+  let g:airline#extensions#vimtex#compiled = "c₁"
+
+* continuousr compilation is running
+  let g:airline#extensions#vimtex#continuous = "c"
+
+* viewer is opened
+  let g:airline#extensions#vimtex#viewer = "v"
+
 ==============================================================================
 ADVANCED CUSTOMIZATION                      *airline-advanced-customization*
 


### PR DESCRIPTION
This patch adds `vimtex` support to the airline. The following indicators are defined:
- the viewer is opened
- the compilation is running (single)
- the compilation is running (continuous)
- the file is a subfile and configuration refers to the main file
- the file is a subfile and configuration refers to the local file

The patch is based on the discussion lervag/vimtex#765.