### PR TITLE
Improve denite extension performance

### DIFF
--- a/autoload/airline/extensions/denite.vim
+++ b/autoload/airline/extensions/denite.vim
@@ -13,7 +13,10 @@ endif
 function! airline#extensions#denite#check_denite_mode(bufnr)
   let l:mode = split(denite#get_status_mode(), ' ')
   let l:mode = tolower(l:mode[1])
-  call airline#highlighter#highlight([l:mode], a:bufnr)
+  if !exists('b:denite_mode_cache') || l:mode != b:denite_mode_cache
+    call airline#highlighter#highlight([l:mode], a:bufnr)
+    let b:denite_mode_cache = l:mode
+  endif
   return ''
 endfunction
 


### PR DESCRIPTION
This tiny change solves the problem described in #1460 (which is closed even though it wasn't really fixed)
The condition check avoids many redundant calls to the highlight function, as it's only needed when the buffer initially appears or changes its mode