### PR TITLE
Update the ALE extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -240,7 +240,7 @@ function! airline#extensions#load()
     call add(loaded_ext, 'syntastic')
   endif
 
-  if (get(g:, 'airline#extensions#ale#enabled', 1) && exists('g:loaded_ale'))
+  if (get(g:, 'airline#extensions#ale#enabled', 1) && exists(':ALELint'))
     call airline#extensions#ale#init(s:ext)
     call add(loaded_ext, 'ale')
   endif

--- a/autoload/airline/extensions/ale.vim
+++ b/autoload/airline/extensions/ale.vim
@@ -1,23 +1,32 @@
-" MIT License. Copyright (c) 2013-2016 Bjorn Neergaard.
+" MIT License. Copyright (c) 2013-2017 Bjorn Neergaard, w0rp
 " vim: et ts=2 sts=2 sw=2
-
-if !exists('g:loaded_ale')
-  finish
-endif
 
 let s:error_symbol = get(g:, 'airline#extensions#ale#error_symbol', 'E:')
 let s:warning_symbol = get(g:, 'airline#extensions#ale#warning_symbol', 'W:')
 
-function! s:count(index)
-  let l:buf = bufnr('%')
-  let l:count = ale#statusline#Count(l:buf)
-  if type(l:count) ==# type(0)
-    let l:count = 0
-  else
-    let l:count = l:count[a:index]
+function! airline#extensions#ale#get(type)
+  if !exists(':ALELint')
+    return ''
   endif
 
-  return l:count
+  let l:is_err = a:type ==# 'error'
+  let l:counts = ale#statusline#Count(bufnr(''))
+  let l:symbol = l:is_err ? s:error_symbol : s:warning_symbol
+
+  if type(l:counts) == type({}) && has_key(l:counts, 'error')
+    " Use the current Dictionary format.
+    let l:errors = l:counts.error + l:counts.style_error
+    let l:num = l:is_err ? l:errors : l:counts.total - l:errors
+  else
+    " Use the old List format.
+    let l:num = l:is_err ? l:counts[0] : l:counts[1]
+  endif
+
+  if l:num == 0
+    return ''
+  else
+    return l:symbol . l:num
+  endif
 endfunction
 
 function! airline#extensions#ale#get_warning()
@@ -26,16 +35,6 @@ endfunction
 
 function! airline#extensions#ale#get_error()
   return airline#extensions#ale#get('error')
-endfunction
-
-function! airline#extensions#ale#get(type)
-  let is_err = a:type is# 'error'
-  let cnt = s:count(is_err)
-  if cnt == 0
-    return ''
-  else
-    return (is_err ? s:error_symbol : s:warning_symbol) . cnt
-  endif
 endfunction
 
 function! airline#extensions#ale#init(ext)


### PR DESCRIPTION
This pull request will bring the ALE extension up-to-date in the following ways.

1. `exists(':ALELint')` is used for detecting if ALE loaded successfully instead of `exists('g:loaded_ale')`. This is a more reliable way of checking if ALE is loaded.
2. The `exists()` check is performed inside the section functions, like other extensions, so the extension can be loaded before or after ALE is loaded.
3. The return value for the count function from ALE is checked, so that the old List format can _eventually_ be removed from ALE. Support for the old List format remains for users of old ALE versions.