### PR TITLE
Fix git hunk status disappearance on CursorHold

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -402,7 +402,7 @@ function! airline#extensions#branch#init(ext)
   call airline#parts#define_function('branch', 'airline#extensions#branch#get_head')
 
   autocmd BufReadPost * unlet! b:airline_file_in_root
-  autocmd CursorHold,ShellCmdPost,CmdwinLeave * unlet! b:airline_head
+  autocmd ShellCmdPost,CmdwinLeave * unlet! b:airline_head
   autocmd User AirlineBeforeRefresh unlet! b:airline_head
   autocmd BufWritePost * call s:reset_untracked_cache(0)
   autocmd ShellCmdPost * call s:reset_untracked_cache(1)


### PR DESCRIPTION
When using vim-gitgutter and fugitive:

The hunks extension and the branch extension work as expected when the
file is first loaded; both parts are added to the statusline.

Once the cursor is moved and stopped for &updatetime ms:

1. The branch extension clears b:airline_head on CursorHold
2. Somehow (?) airline#statusline gets called on CursorHold
3. The hunks extension returns '' when b:airline_head is empty, causing
the hunks to be removed from the statusline.

It doesn't make sense to clear airline_head just because the cursor
moved, and the commit message adding the line doesn't say why:
13297cee03a3003b66a4ec07b734066cb32b7e04

Commit 174b7e1962c9fbb8450a56fa09b11201bd3b7622 relies on airline_head
being set.

Debug detail:
```
Executing CursorHold Auto commands for "*"
autocommand unlet! b:airline_head
[...]
continuing in CursorHold Auto commands for "*"
calling function airline#statusline(1)
[...]
line 1:   return exists('*airline#extensions#branch#head') && empty(get(b:, 'airline_head', ''))
function airline#extensions#hunks#get_hunks[13]..<SNR>32_get_hunks[14]..<SNR>32_get_hunks_gitgutter[1]..<SNR>32_is_branch_empty returning #1
function airline#extensions#hunks#get_hunks[13]..<SNR>32_get_hunks[14]..<SNR>32_get_hunks_gitgutter returning ''
function airline#extensions#hunks#get_hunks[13]..<SNR>32_get_hunks returning ''
function airline#extensions#hunks#get_hunks returning ''
```

```
:au CursorHold
--- Auto-Commands ---
gitgutter  CursorHold
    *         call gitgutter#process_buffer(bufnr(''), 1)
CursorHold
    *         unlet! b:airline_head
airline_whitespace  CursorHold
    *         call <sid>ws_refresh()
```

------------------------

Sample vimrc:

```
set nocompatible

if empty(glob('~/.vim/autoload/plug.vim'))
  silent !curl -fLo ~/.vim/autoload/plug.vim --create-dirs
    \ https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
  autocmd VimEnter * PlugInstall --sync | q | doautocmd WinEnter
endif

autocmd VimEnter *
  \  if len(filter(values(g:plugs), '!isdirectory(v:val.dir)'))
  \|   PlugInstall --sync | q
  \| endif

call plug#begin('~/.vim/bundle/')
Plug 'vim-airline/vim-airline'
Plug 'tpope/vim-fugitive'
Plug 'airblade/vim-gitgutter'
call plug#end()
set laststatus=2
set updatetime=250
let g:airline_theme = 'dark'
```