### PR TITLE
Neomake integration: if loclist is empty, fallback to quickfix

### DIFF
--- a/autoload/airline/extensions/neomake.vim
+++ b/autoload/airline/extensions/neomake.vim
@@ -7,14 +7,24 @@ endif
 let s:error_symbol = get(g:, 'airline#extensions#neomake#error_symbol', 'E:')
 let s:warning_symbol = get(g:, 'airline#extensions#neomake#warning_symbol', 'W:')
 
+function! s:get_counts()
+  let l:counts = neomake#statusline#LoclistCounts()
+
+  if empty(l:counts)
+    return neomake#statusline#QflistCounts()
+  else
+    return l:counts
+  endif
+endfunction
+
 function! airline#extensions#neomake#get_warnings()
-  let counts = neomake#statusline#LoclistCounts()
+  let counts = s:get_counts()
   let warnings = get(counts, 'W', 0)
   return warnings ? s:warning_symbol.warnings : ''
 endfunction
 
 function! airline#extensions#neomake#get_errors()
-  let counts = neomake#statusline#LoclistCounts()
+  let counts = s:get_counts()
   let errors = get(counts, 'E', 0)
   return errors ? s:error_symbol.errors : ''
 endfunction


### PR DESCRIPTION
Neomake can record errors/warning in two different places: the quickfix and location list. This PR adds support for the quickfix list by checking it iff the location list is empty.