### PR TITLE
Hotfix: Autoswitch theme for colorschemes with funny casing (like PaperColor)

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -76,7 +76,7 @@ endfunction
 function! airline#switch_matching_theme()
   if exists('g:colors_name')
     let existing = g:airline_theme
-    let theme = substitute(g:colors_name, '-', '_', 'g')
+    let theme = substitute(tolower(g:colors_name), '-', '_', 'g')
     try
       let palette = g:airline#themes#{theme}#palette
       call airline#switch_theme(theme)


### PR DESCRIPTION
Airline theme auto-switching is broken for colorschemes (like PaperColor) whose `g:colors_name` value is not all lowercase. This fixes that.

Didn't bother opening an issue for this since it was such a small fix (hope that's okay).

Alternately, if the team thinks that setting a camelcased value for a color scheme is an unacceptable violation of vim convention, I'd be happy to open an issue/PR on [papercolor-theme](https://github.com/NLKNguyen/papercolor-theme) instead.