### PR TITLE
Disable async support in neovim

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -18,7 +18,7 @@ function! airline#init#bootstrap()
 
   let g:airline#init#bootstrapping = 1
 
-  let g:airline#init#async = (has("nvim") || (v:version >= 800 && has('job')))
+  let g:airline#init#async = v:version >= 800 && has('job')
   let g:airline#init#is_windows = has('win32') || has('win64')
 
   call s:check_defined('g:airline_detect_modified', 1)


### PR DESCRIPTION
Neovim uses a different async jobs API, which we don't currently support. Ideally we would add support for Neovim jobs, but this patch should restore functionality in the meantime.

 Fixes #1532