### PR TITLE
Revert "tagbar: do not error out, if autoloaded function does not exist"

### DIFF
--- a/autoload/airline/extensions/tagbar.vim
+++ b/autoload/airline/extensions/tagbar.vim
@@ -29,8 +29,7 @@ let s:airline_tagbar_last_lookup_time = 0
 let s:airline_tagbar_last_lookup_val = ''
 function! airline#extensions#tagbar#currenttag()
   if get(w:, 'airline_active', 0)
-    " function tagbar#currenttag does not exist, if filetype is not enabled
-    if s:airline_tagbar_last_lookup_time != localtime() && exists("*tagbar#currenttag")
+    if s:airline_tagbar_last_lookup_time != localtime()
       let s:airline_tagbar_last_lookup_val = tagbar#currenttag('%s', '', s:flags)
       let s:airline_tagbar_last_lookup_time = localtime()
     endif


### PR DESCRIPTION
Before 232b6415d95e9770b0a427fe3ff4d7053ffb52d2, the airline will display function name when we enter the vim. But now, the function name is not initially displayed, and after opening the tagbar, the function name starts to  appear.

I think the original behavior is better. To remain the same behavior. Revert 232b6415d95e9770b0a427fe3ff4d7053ffb52d2.