### PR TITLE
Use regex matching to prevent message from bubbling up

### DIFF
--- a/autoload/airline/async.vim
+++ b/autoload/airline/async.vim
@@ -17,7 +17,7 @@ endfunction
 function! s:mq_output(buf, file)
   let buf=a:buf
   if !empty(a:buf)
-    if a:buf is# 'no patches applied' ||
+    if a:buf is# 'no patches applied ' ||
       \ a:buf =~# "unknown command 'qtop'"
       let buf = ''
     elseif exists("b:mq") && b:mq isnot# buf

--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -132,7 +132,7 @@ function! s:update_hg_branch(...)
       else
         " remove \n at the end of the command
         let output=system(cmd)[0:-2]
-        if output is# 'no patches applied' ||
+        if output is# 'no patches applied ' ||
           \ output =~# "unknown command 'qtop'"
           let b:mq=''
         else


### PR DESCRIPTION
Using neovim v0.2.0 and mercurial v4.2.2 on Mac OS X 10.12.6, a recent change to vim-airline causes the phrase 'no patches applied' to be displayed along with the branch information. This branch uses regex matching to solve the issue. I also tried adding a trailing space to the string to be matched, and that also worked. However, I don't know the consequences in other situations so this seems a better fix.

![screen shot 2017-09-16 at 2 03 56 pm](https://user-images.githubusercontent.com/1024788/30515130-f0fb0cc8-9ae7-11e7-9476-ed891927c69a.png)
