### PR TITLE
Fix: Use the CS-symbol of ctrlspace which may be changed by user in ctrlspace-extension

### DIFF
--- a/autoload/airline/extensions/ctrlspace.vim
+++ b/autoload/airline/extensions/ctrlspace.vim
@@ -5,10 +5,11 @@ scriptencoding utf-8
 
 let s:spc = g:airline_symbols.space
 let s:padding = s:spc . s:spc . s:spc
+let s:cs = ctrlspace#context#Configuration().Symbols.CS
 
 function! airline#extensions#ctrlspace#statusline(...)
   let b = airline#builder#new({ 'active': 1 })
-  call b.add_section('airline_b', '⌗' . s:padding . ctrlspace#api#StatuslineModeSegment(s:padding))
+  call b.add_section('airline_b', s:cs . s:padding . ctrlspace#api#StatuslineModeSegment(s:padding))
   call b.split()
   call b.add_section('airline_x', s:spc . ctrlspace#api#StatuslineTabSegment() . s:spc)
   return b.build()


### PR DESCRIPTION
If user changed the CS-symbol of ctrlspace, the corresponded CS-symbol in ctrlspace-extension would not be changed. And this fix is to get the CS-symbol of ctrlspace in ctrlspace-externsion.