### PR TITLE
skip toggling ctrlspace tabline plugin when not installed

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -31,14 +31,18 @@ function! s:toggle_off()
   call airline#extensions#tabline#autoshow#off()
   call airline#extensions#tabline#tabs#off()
   call airline#extensions#tabline#buffers#off()
-  call airline#extensions#tabline#ctrlspace#off()
+  if s:ctrlspace
+    call airline#extensions#tabline#ctrlspace#off()
+  endif
 endfunction
 
 function! s:toggle_on()
   call airline#extensions#tabline#autoshow#on()
   call airline#extensions#tabline#tabs#on()
   call airline#extensions#tabline#buffers#on()
-  call airline#extensions#tabline#ctrlspace#on()
+  if s:ctrlspace
+    call airline#extensions#tabline#ctrlspace#on()
+  endif
 
   set tabline=%!airline#extensions#tabline#get()
 endfunction


### PR DESCRIPTION
when an user does not install vim-ctrlspace, 
airline#extensions#tabline#init raises error in ```call s:toggle_on()```.