### PR TITLE
Add function to show line number

### DIFF
--- a/autoload/airline/extensions/ale.vim
+++ b/autoload/airline/extensions/ale.vim
@@ -8,6 +8,27 @@ function! s:airline_ale_count(cnt, symbol)
   return a:cnt ? a:symbol. a:cnt : ''
 endfunction
 
+function! s:airline_ale_get_line_number(cnt, type) abort
+  if a:cnt == 0
+    return ''
+  endif
+
+  let buffer       = bufnr('')
+  let problem_type = (a:type ==# 'error') ? 'E' : 'W'
+  let problems     = copy(ale#engine#GetLoclist(buffer))
+
+  call filter(problems, 'v:val.bufnr is buffer && v:val.type is# problem_type')
+
+  if empty(problems)
+    return ''
+  endif
+
+  let open_lnum_symbol  = get(g:, 'airline#extensions#ale#open_lnum_symbol', '(L')
+  let close_lnum_symbol = get(g:, 'airline#extensions#ale#close_lnum_symbol', ')')
+
+  return open_lnum_symbol . problems[0].lnum . close_lnum_symbol
+endfunction
+
 function! airline#extensions#ale#get(type)
   if !exists(':ALELint')
     return ''
@@ -29,7 +50,7 @@ function! airline#extensions#ale#get(type)
     let num = is_err ? counts[0] : counts[1]
   endif
 
-  return s:airline_ale_count(num, symbol)
+  return s:airline_ale_count(num, symbol) . <sid>airline_ale_get_line_number(num, a:type)
 endfunction
 
 function! airline#extensions#ale#get_warning()

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -987,6 +987,12 @@ ale <https://github.com/w0rp/ale>
 * ale warning >
   let airline#extensions#ale#warning_symbol = 'W:'
 <
+* ale open_lnum_symbol >
+  let airline#extensions#ale#open_lnum_symbol = '(L'
+<
+* ale close_lnum_symbol >
+  let airline#extensions#ale#close_lnum_symbol = ')'
+<
 -------------------------------------                    *airline-neomake*
 neomake <https://github.com/neomake/neomake>
 


### PR DESCRIPTION
The function shows the line number of the first error/warning that appears in the current buffer. If there are 20 warnings and the first warning exists on line 33, then vim-airline would show `W:20(L33)`.

One can change how the line number is represented using: `g:airline#extensions#ale#open_lnum_symbol` where the default is `(L` and `airline#extensions#ale#close_lnum_symbol` where the default is `)`. I don't know if a variable that lets the user toggle seeing the line number or a toggle seeing the line number of the last warning/error in the buffer would be worthwhile additions.