### PR TITLE
Improve fugitive integration

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -229,6 +229,12 @@ function! airline#extensions#load()
     call add(loaded_ext, 'bufferline')
   endif
 
+  if get(g:, 'airline#extensions#fugitiveline#enabled', 1)
+        \ && exists('*fugitive#head')
+    call airline#extensions#fugitiveline#init(s:ext)
+    call add(loaded_ext, 'fugitiveline')
+  endif
+
   if (get(g:, 'airline#extensions#virtualenv#enabled', 1) && (exists(':VirtualEnvList') || isdirectory($VIRTUAL_ENV)))
     call airline#extensions#virtualenv#init(s:ext)
     call add(loaded_ext, 'virtualenv')

--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -84,6 +84,7 @@ endif
 
 " Fugitive special revisions. call '0' "staging" ?
 let s:names = {'0': 'index', '1': 'ancestor', '2':'target', '3':'merged'}
+let s:sha1size = get(g:, 'airline#extensions#branch#sha1_len', 7)
 
 function! s:update_git_branch()
   if !s:has_fugitive
@@ -91,7 +92,7 @@ function! s:update_git_branch()
     return
   endif
 
-  let name = fugitive#head(7)
+  let name = fugitive#head(s:sha1size)
 
   try
     let commit = fugitive#buffer().commit()
@@ -103,7 +104,7 @@ function! s:update_git_branch()
       if ref !~ "^fatal: no tag exactly matches"
         let name = s:format_name(substitute(ref, '\v\C^%(heads/|remotes/|tags/)=','',''))."(".name.")"
       else
-        let name = commit[:6]."(".name.")"
+        let name = commit[0:s:sha1size-1]."(".name.")"
       endif
     endif
   catch

--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -247,9 +247,6 @@ function! airline#extensions#branch#head()
     endif
   endif
 
-  if has_key(heads, 'git') && !s:check_in_path()
-    let b:airline_head = ''
-  endif
   let minwidth = empty(get(b:, 'airline_hunks', '')) ? 14 : 7
   let b:airline_head = airline#util#shorten(b:airline_head, 120, minwidth)
   return b:airline_head
@@ -262,35 +259,6 @@ function! airline#extensions#branch#get_head()
   return empty(head)
         \ ? empty_message
         \ : printf('%s%s', empty(symbol) ? '' : symbol.(g:airline_symbols.space), head)
-endfunction
-
-function! s:check_in_path()
-  if !exists('b:airline_file_in_root')
-    let root = get(b:, 'git_dir', get(b:, 'mercurial_dir', ''))
-    let bufferpath = resolve(fnamemodify(expand('%'), ':p'))
-
-    if !filereadable(root) "not a file
-      " if .git is a directory, it's the old submodule format
-      if match(root, '\.git$') >= 0
-        let root = expand(fnamemodify(root, ':h'))
-      else
-        " else it's the newer format, and we need to guesstimate
-        " 1) check for worktrees
-        if match(root, 'worktrees') > -1
-          " worktree can be anywhere, so simply assume true here
-          return 1
-        endif
-        " 2) check for submodules
-        let pattern = '\.git[\\/]\(modules\)[\\/]'
-        if match(root, pattern) >= 0
-          let root = substitute(root, pattern, '', '')
-        endif
-      endif
-    endif
-
-    let b:airline_file_in_root = stridx(bufferpath, root) > -1
-  endif
-  return b:airline_file_in_root
 endfunction
 
 function! s:reset_untracked_cache(shellcmdpost)
@@ -319,7 +287,6 @@ endfunction
 function! airline#extensions#branch#init(ext)
   call airline#parts#define_function('branch', 'airline#extensions#branch#get_head')
 
-  autocmd BufReadPost * unlet! b:airline_file_in_root
   autocmd ShellCmdPost,CmdwinLeave * unlet! b:airline_head b:airline_do_mq_check
   autocmd User AirlineBeforeRefresh unlet! b:airline_head b:airline_do_mq_check
   autocmd BufWritePost * call s:reset_untracked_cache(0)

--- a/autoload/airline/extensions/fugitiveline.vim
+++ b/autoload/airline/extensions/fugitiveline.vim
@@ -1,0 +1,37 @@
+" MIT License. Copyright (c) 2017 Cimbali.
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+if !exists('*fugitive#head')
+  finish
+endif
+
+
+if exists("+autochdir") && &autochdir == 1
+  let s:fmod = ':p'
+else
+  let s:fmod = ':.'
+endif
+
+function! airline#extensions#fugitiveline#bufname()
+  try
+    let buffer = fugitive#buffer()
+    if buffer.type('blob')
+      return fnamemodify(buffer.repo().translate(buffer.path()), s:fmod)
+    endif
+  catch
+  endtry
+
+  return fnamemodify(bufname('%'), s:fmod)
+endfunction
+
+function! airline#extensions#fugitiveline#init(ext)
+  if exists("+autochdir") && &autochdir == 1
+    " if 'acd' is set, vim-airline uses the path section, so we need to redefine this here as well
+    call airline#parts#define_raw('path', '%<%{airline#extensions#fugitiveline#bufname()}%m')
+  else
+    call airline#parts#define_raw('file', '%<%{airline#extensions#fugitiveline#bufname()}%m')
+  endif
+endfunction
+

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -400,6 +400,13 @@ vim-bufferline <https://github.com/bling/vim-bufferline>
 * determine whether bufferline will overwrite customization variables >
   let g:airline#extensions#bufferline#overwrite_variables = 1
 <
+-------------------------------------                   *airline-fugitiveline*
+This extension hides the fugitive://**// part of the buffer names, to only
+show the file name as if it were in the current working tree.
+
+* enable/disable bufferline integration >
+  let g:airline#extensions#fugitiveline#enabled = 1
+<
 -------------------------------------                       *airline-branch*
 
 vim-airline will display the branch-indicator together with the branch name in

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -453,6 +453,9 @@ notexists symbol will be displayed after the branch name.
     return '[' . a:name . ']'
   endfunction
 <
+* truncate sha1 commits at this number of characters  >
+  let g:airline#extensions#branch#sha1_len = 10
+<
 -------------------------------------                    *airline-syntastic*
 syntastic <https://github.com/vim-syntastic/syntastic>
 


### PR DESCRIPTION
Fixes #1591 and improves display of git metadata of fugitive files, by showing:
- filename stripped of fugitive://.../sha1// elements in status line
- the sha1 or ref when opening a file from a different revision in a buffer
- a reminder of the current checked out branch, thus `8d4355(master)` for example 

Also fix not recognizing files as part of repos correctly, when inside submodules.