### PR TITLE
Add formatter for js files

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ Separators can be configured independently for the tabline, so here is how you c
     let g:airline#extensions#tabline#left_sep = ' '
     let g:airline#extensions#tabline#left_alt_sep = '|'
 
+In addition, you can also choose which path formatter airline uses. This affects how file paths are
+displayed in each individual tab as well as the current buffer indicator in the upper right.
+To do so, set the `formatter` field with:
+
+    let g:airline#extensions#tabline#formatter = 'default'
+
+Here is a complete list of formatters with screenshots:
+
+#### `default`
+![image](https://user-images.githubusercontent.com/2652762/34422844-1d005efa-ebe6-11e7-8053-c784c0da7ba7.png)
+
+#### `jsformatter`
+![image](https://user-images.githubusercontent.com/2652762/34422843-1cf6a4d2-ebe6-11e7-810a-07e6eb08de24.png)
+
+#### `unique_tail`
+![image](https://user-images.githubusercontent.com/2652762/34422841-1ce5b4ec-ebe6-11e7-86e9-3d45c876068b.png)
+
+#### `unique_tail_improved`
+![image](https://user-images.githubusercontent.com/2652762/34422842-1cee23f2-ebe6-11e7-962d-97e068873077.png)
+
 ## Seamless integration
 
 vim-airline integrates with a variety of plugins out of the box.  These extensions will be lazily loaded if and only if you have the other plugins installed (and of course you can turn them off).

--- a/autoload/airline/extensions/tabline/formatters/jsformatter.vim
+++ b/autoload/airline/extensions/tabline/formatters/jsformatter.vim
@@ -1,0 +1,10 @@
+function! airline#extensions#tabline#formatters#jsformatter#format(bufnr, buffers)
+  let buf = bufname(a:bufnr)
+  let filename = fnamemodify(buf, ':t')
+
+  if filename == 'index.js' || filename == 'index.jsx'
+    return fnamemodify(buf, ':p:h:t') . '/i'
+  else
+    return airline#extensions#tabline#formatters#unique_tail_improved#format(a:bufnr, a:buffers)
+  endif
+endfunction


### PR DESCRIPTION
It's a little rough using vim-airline in javascript, as many many files are called `index.js` or `index.jsx`, which means every open file in the tab bar just says `index.js` or whatever. This PR creates another tabline formatter so that you can see what the parent folder is called if you're editing one of those files. Based off of this gist: https://gist.github.com/valerybugakov/c85dcc802548f6585db3ef3060b293a7
and then changed the default to be the `unique_tail_improved` formatter that's already in vim-airline

Side note: I realize this is super specific for javascript, but I think it'd be awesome if we had some sort of standard for different languages! I'm sure there are other languages that have this similar problem, maybe we could a. generalize this method so it works in more than just js, or b. have some sort of standard for creating new formatters for different languages