### PR TITLE
Fix over-caching of paths

### DIFF
--- a/autoload/airline/extensions/fugitiveline.vim
+++ b/autoload/airline/extensions/fugitiveline.vim
@@ -15,21 +15,22 @@ else
 endif
 
 function! airline#extensions#fugitiveline#bufname()
-  if exists('b:fugitive_name')
-    return b:fugitive_name
+  if !exists('b:fugitive_name')
+    let b:fugitive_name = ''
+    try
+      let buffer = fugitive#buffer()
+      if buffer.type('blob')
+        let b:fugitive_name = buffer.repo().translate(buffer.path())
+      endif
+    catch
+    endtry
   endif
 
-  let b:fugitive_name = fnamemodify(bufname('%'), s:fmod)
-
-  try
-    let buffer = fugitive#buffer()
-    if buffer.type('blob')
-      let b:fugitive_name = fnamemodify(buffer.repo().translate(buffer.path()), s:fmod)
-    endif
-  catch
-  endtry
-
-  return b:fugitive_name
+  if empty(b:fugitive_name)
+    return fnamemodify(bufname('%'), s:fmod)
+  else
+    return fnamemodify(b:fugitive_name, s:fmod)
+  endif
 endfunction
 
 function! airline#extensions#fugitiveline#init(ext)


### PR DESCRIPTION
Improve the caching mechanism so it only covers the git calls, leaving the usual mechanics (`bufname`, `fnamemodify`). This keeps the relative paths in the statusline after changing directories up to date.