### PR TITLE
cursormode: allow custom mode names

### DIFF
--- a/autoload/airline/extensions/cursormode.vim
+++ b/autoload/airline/extensions/cursormode.vim
@@ -40,8 +40,12 @@ endfunction
 let s:iTerm_escape_template = '\033]Pl%s\033\\'
 let s:xterm_escape_template = '\033]12;%s\007'
 
+function! s:get_mode()
+  return call(get(g:, 'cursormode_mode_func', 'mode'), [])
+endfunction
+
 function! airline#extensions#cursormode#set(...)
-  let mode = mode()
+  let mode = s:get_mode()
   if mode !=# s:last_mode
     let s:last_mode = mode
   call s:set_cursor_color_for(mode)

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1035,11 +1035,27 @@ neomake <https://github.com/neomake/neomake>
 -------------------------------------                    *airline-cursormode*
 cursormode <https://github.com/vheon/vim-cursormode>
 
-Displays cursor in different colors depending on the current mode (only works
-in terminals iTerm, AppleTerm and xterm)
+Built-in extension to displays cursor in different colors depending on the
+current mode (only works in terminals iTerm, AppleTerm and xterm)
 
 * enable cursormode integration >
   let g:airline#extensions#cursormode#enabled = 1
+
+* mode function. Return value is used as key for the color mapping. Default is
+  |mode()|
+  `let g:cursormode_mode_func = 'mode'`
+
+* color mapping. Keys come from `g:cursormode_mode_func` (background value can
+  be appended)
+  `let g:cursormode_color_map = {`
+    `\   "nlight": '#000000',`
+    `\   "ndark": '#BBBBBB',`
+    `\   "i": g:airline#themes#{g:airline_theme}#palette.insert.airline_a[1],`
+    `\   "R": g:airline#themes#{g:airline_theme}#palette.replace.airline_a[1],`
+    `\   "v": g:airline#themes#{g:airline_theme}#palette.visual.airline_a[1],`
+    `\   "V": g:airline#themes#{g:airline_theme}#palette.visual.airline_a[1],`
+    `\   "\<C-V>": g:airline#themes#{g:airline_theme}#palette.visual.airline_a[1],`
+    `\ }`
 
 ==============================================================================
 ADVANCED CUSTOMIZATION                      *airline-advanced-customization*


### PR DESCRIPTION
Hi!

Add a variable to set the function returning the current mode. By default, it is still mode() but this would allows more customization.

Also add some documentation. State that the plugin is a builtin. This is to avoid the confusion of downloading it from `vheon/vim-cursormode`