### PR TITLE
tabline: fix tabline on :syn on

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -96,7 +96,8 @@ function! s:airline_toggle()
 
       autocmd GUIEnter,ColorScheme * call <sid>on_colorscheme_changed()
       " Refresh airline for :syntax off
-      autocmd SourcePre */syntax/*syntax.vim call <sid>airline_refresh()
+      autocmd SourcePre */syntax/syntax.vim
+            \ call airline#extensions#tabline#buffers#invalidate()
       autocmd VimEnter,WinEnter,BufWinEnter,FileType,BufUnload *
             \ call <sid>on_window_changed()
       if exists('#CompleteDone')


### PR DESCRIPTION
This fixes #1590 much more cleanly. Previous solution refreshes airline entirely, which is much slower and could also cause other problems. We don't need to trigger a reset on `:syn off` either.