### PR TITLE
Changing 'airline_tablabel' text and colors back to old style

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -206,7 +206,7 @@ endfunction
 
 function! airline#extensions#tabline#add_label(dict, type)
   if get(g:, 'airline#extensions#tabline#show_tab_type', 1)
-    call a:dict.add_section_spaced('airline_tablabel', 
-          \ get(g:, 'airline#extensions#tabline#'.a:type.'_label', '['.a:type.']'))
+    call a:dict.add_section_spaced('airline_tablabel',
+          \ get(g:, 'airline#extensions#tabline#'.a:type.'_label', a:type))
   endif
 endfunction


### PR DESCRIPTION
I think the current labels without a colored background like before, look broken.

Before the change:
![2018-01-25-224805_1914x110_scrot](https://user-images.githubusercontent.com/16831326/35428279-f0bfdf0c-0222-11e8-894e-fe2329ff07cb.png)

After the change:
![2018-01-25-224551_1915x133_scrot](https://user-images.githubusercontent.com/16831326/35428290-0162eaf2-0223-11e8-858f-a0e6f9ee900a.png)