### PR TITLE
Fix white space in tabline when showing buffers

### DIFF
--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -87,7 +87,11 @@ function! airline#extensions#tabline#buffers#get()
       call b.add_raw('%'.nr.'@airline#extensions#tabline#buffers#clickbuf@')
     endif
 
-    let space= (pgroup == group ? s:spc : '')
+    if get(g:, 'airline_powerline_fonts', 0)
+      let space = s:spc
+    else
+      let space= (pgroup == group ? s:spc : '')
+    endif
 
     if get(g:, 'airline#extensions#tabline#buffer_idx_mode', 0)
       if len(s:number_map) > 0


### PR DESCRIPTION
This fixes #1631 

Before:
![image](https://user-images.githubusercontent.com/9994172/36009837-ff672566-0d02-11e8-8b91-b313279b05bb.png)
After:
![image](https://user-images.githubusercontent.com/9994172/36009818-ddb7d3ac-0d02-11e8-9a76-5e10e8303083.png)
