### PR TITLE
Redesign tabline visible buffers algorithm

### DIFF
--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -79,7 +79,7 @@ function! airline#extensions#tabline#buffers#get()
   let pgroup = ''
   for nr in s:get_visible_buffers()
     if nr < 0
-      call b.add_raw('%#airline_tabhid#'.s:ellipsis)
+      call b.add_section('airline_tabhid', s:ellipsis)
       continue
     endif
 
@@ -155,7 +155,7 @@ function! s:get_visible_buffers()
   " calculate widths for basic components of the buffer list
   let len_spc = s:strchars(s:spc)
   let len_divider = 1 " Should always be a single symbol (REVISIT: Is this really always the case?)
-  let len_ellipsis = s:strchars(s:ellipsis)
+  let len_ellipsis = s:strchars(s:ellipsis) + len_divider
 
   " show_tab_type=1 adds '< buffers ' to the right of the tabline
   " Otherwise, there is 1 extra space after the last divider (always ' ' independent of s:spc)

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -3,15 +3,6 @@
 
 scriptencoding utf-8
 
-let s:spc = get(g:, 'airline#extensions#tabline#pad_with_spaces', 1)
-      \ ? g:airline_symbols.space
-      \ : ''
-
-let s:ellipsis = get(g:, 'airline#extensions#tabline#ellipsis', '...')
-
-let s:buffers_label = get(g:, 'airline#extensions#tabline#buffers_label', 'buffers')
-let s:show_tab_type = get(g:, 'airline#extensions#tabline#show_tab_type', 1)
-
 let s:current_bufnr = -1
 let s:current_modified = 0
 let s:current_tabline = ''
@@ -73,13 +64,17 @@ function! airline#extensions#tabline#buffers#get()
   if get(g:, 'airline#extensions#tabline#buf_label_first', 0)
     let show_buf_label_first = 1
   endif
+
+  let spc = get(g:, 'airline#extensions#tabline#spaces_around_buffer_name', 1) ? g:airline_symbols.space : ''
+  let ellipsis = get(g:, 'airline#extensions#tabline#ellipsis', '...')
+
   if show_buf_label_first
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
   let pgroup = ''
   for nr in s:get_visible_buffers()
     if nr < 0
-      call b.add_section('airline_tabhid', s:ellipsis)
+      call b.add_section('airline_tabhid', ellipsis)
       continue
     endif
 
@@ -95,20 +90,20 @@ function! airline#extensions#tabline#buffers#get()
     endif
 
     if get(g:, 'airline_powerline_fonts', 0)
-      let space = s:spc
+      let space = spc
     else
-      let space= (pgroup == group ? s:spc : '')
+      let space= (pgroup == group ? spc : '')
     endif
 
     if get(g:, 'airline#extensions#tabline#buffer_idx_mode', 0)
       if len(s:number_map) > 0
-        call b.add_section(group, space. get(s:number_map, index, '') . '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)' . s:spc)
+        call b.add_section(group, space. get(s:number_map, index, '') . '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)' . spc)
       else
-        call b.add_section(group, '['.index.s:spc.'%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)'.']')
+        call b.add_section(group, '['.index.spc.'%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)'.']')
       endif
       let index += 1
     else
-      call b.add_section(group, space.'%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)'.s:spc)
+      call b.add_section(group, space.'%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)'.spc)
     endif
 
     if has("tablineat")
@@ -153,13 +148,14 @@ function! s:get_visible_buffers()
   endif
 
   " calculate widths for basic components of the buffer list
-  let len_spc = s:strchars(s:spc)
+  let len_spc = get(g:, 'airline#extensions#tabline#spaces_around_buffer_name', 1) ? s:strchars(g:airline_symbols.space) : 0
+  let len_buffers_label = s:strchars(get(g:, 'airline#extensions#tabline#buffers_label', 'buffers'))
   let len_divider = 1 " Should always be a single symbol (REVISIT: Is this really always the case?)
-  let len_ellipsis = s:strchars(s:ellipsis) + len_divider
+  let len_ellipsis = s:strchars(get(g:, 'airline#extensions#tabline#ellipsis', '...')) + len_divider
 
   " show_tab_type=1 adds '< buffers ' to the right of the tabline
-  " Otherwise, there is 1 extra space after the last divider (always ' ' independent of s:spc)
-  let len_extra = s:show_tab_type ? s:strchars(s:buffers_label) + (2*len_spc) + len_divider : 1
+  " Otherwise, there is 1 extra space after the last divider (always ' ' independent of spc)
+  let len_extra = get(g:, 'airline#extensions#tabline#show_tab_type', 1) ? buffers_label + (2*len_spc) + len_divider : 1
 
   " calculate widths for the various buffer names
   let total_width = 0

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -827,6 +827,10 @@ with the middle mouse button to delete that buffer.
 * configure symbol used to represent close button >
   let g:airline#extensions#tabline#close_symbol = 'X'
 
+* configure symbol used to represent an ellipsis
+  (for example, when the tabline is not wide enough to fit everything)
+  let g:airline#extensions#tabline#ellipsis = '...'
+
 * configure pattern to be ignored on BufAdd autocommand >
   " fixes unnecessary redraw, when e.g. opening Gundo window
   let airline#extensions#tabline#ignore_bufadd_pat =
@@ -841,7 +845,12 @@ Note: Enabling this extension will modify 'showtabline' and 'guioptions'.
 
 * preserve windows when closing a buffer from the bufferline (default: 0) >
   let airline#extensions#tabline#middle_click_preserves_windows = 1
-<
+
+* add spaces around buffer names (' <bufname> ' instead of '<bufname>')
+  useful when using powerline symbols, since the spaces are no longer
+  necessary as separators.
+  let g:airline#extensions#tabline#spaces_around_buffer_name = 1
+
 -------------------------------------                     *airline-tmuxline*
 tmuxline <https://github.com/edkolev/tmuxline.vim>
 


### PR DESCRIPTION
I've been using vim-airline since forever, and it always annoyed me how for some reason my buffers in tabline would start overflowing even though there was still so much space left. Usually, 100+ screen columns would be left free (wasted) even though tabline was already overflowing the buffer list.

Recently, I had a little bit of free time to look into it, and found 2 bugs in the file tabline/buffers.vim s:get_visible_buffers() causing this undesired behaviour:

1. The width of each buffer name is calculated using strlen, which counts bytes and not characters. This means that buffer names with unicode characters (or added by a plugin, e.g. vim-devicons) will be counted as multiple characters.

2. When the width of the buffers is too large, the algorithm assumes that each buffer name has the same width as the buffer with the largest name. Additionally, if no buffer is selected (i.e. position == -1), then no buffers are removed from the tab list.

I set out to change this, and have done so in this pull request. Now, if the list of buffers is too large, it will start by placing the current buffer into the tabline (so there is always at least 1 buffer), and then try to add further buffers (using their correct width) until the maximum width is hit, alternating between buffers to the right and to the left. This results in the currently selected buffer being always somewhere around the center of the screen, with very little wasted space. In case there is no selected buffer, the previously selected buffer is used. If no buffer was ever selected, the first buffer available will be used.

Note also that I added a way to customize the padding around the buffer names (I personally prefer more space for buffers, the section separators airline provides are already enough) as well as the ellipsis (there are some unicode characters that look nice and occupy 1/3rd of the space of '...').

It should work no matter if tabline#show_tab_type = 1 or 0, as I take the size of tabline#buffers_label into consideration. However, due to the huge breadth of tabline customization options, it is likely that I am missing some case where the algorithm used wouldn't work. There might be a better way to get the available width of the tabline, but I am not familiar enough with the code-base to know how.

I've tested this on neovim and it works quite well. It also seems to work fine on vim 7.2, but my testing was not at all thorough.

I'm open to all kinds of suggestions, fixes, etc.