### PR TITLE
Disable fugitiveline if bufferline is activated

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -231,6 +231,7 @@ function! airline#extensions#load()
 
   if get(g:, 'airline#extensions#fugitiveline#enabled', 1)
         \ && exists('*fugitive#head')
+        \ && index(loaded_ext, 'bufferline') == -1
     call airline#extensions#fugitiveline#init(s:ext)
     call add(loaded_ext, 'fugitiveline')
   endif

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -406,6 +406,7 @@ vim-bufferline <https://github.com/bling/vim-bufferline>
 -------------------------------------                   *airline-fugitiveline*
 This extension hides the fugitive://**// part of the buffer names, to only
 show the file name as if it were in the current working tree.
+It is deactivated by default if *airline-bufferline* is activated.
 
 * enable/disable bufferline integration >
   let g:airline#extensions#fugitiveline#enabled = 1


### PR DESCRIPTION
This fixes the conflict of both plugins redifining the 'file' (or 'path')
function. Closes #1670.
As fugitiveline modifies the path display and bufferline replaces it,
the latter should be the plugin to be used if both are activated.