### PR TITLE
Make branch detection customizable

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -459,6 +459,23 @@ notexists symbol will be displayed after the branch name.
 <
 * truncate sha1 commits at this number of characters  >
   let g:airline#extensions#branch#sha1_len = 10
+
+* customize branch name retrieval for any version control system >
+  let g:airline#extensions#branch#custom_head = 'GetScmBranch'
+  function! GetScmBranch()
+    if !exists('b:perforce_client')
+      let b:perforce_client = system('p4 client -o | grep Client')
+      " Invalidate cache to prevent stale data when switching clients. Use a
+      " buffer-unique group name to prevent clearing autocmds for other
+      " buffers.
+      exec 'augroup perforce_client-'. bufnr("%")
+          au!
+          autocmd BufWinLeave <buffer> silent! unlet! b:perforce_client
+      augroup END
+    endif
+    return b:perforce_client
+  endfunction
+
 <
 -------------------------------------                    *airline-syntastic*
 syntastic <https://github.com/vim-syntastic/syntastic>


### PR DESCRIPTION
Instead of requiring each version control plugin to modify airline to
show the current branch, provide a customization function we can check
instead.

Following the example of airline_theme_patch_func, you define the
variable like so:

    let g:airline#extensions#branch#custom_head = 'david#svn#get_branch'

You probably want the function to have something fancy like this to
ensure it stays up to date:

    " Use a buffer-unique group name to prevent clearing autocmds for other
    " buffers.
    exec 'augroup svndavid-'. bufnr("%")
        au!
        autocmd BufWinLeave <buffer> unlet! b:svndavid_branch
    augroup END

This change lets me integrate with vc.vim (I couldn't get VCSCommand
working for svn) or write my own thing for perforce.

I also added a note that how the has variables are init is working by
coincidence. I can remove if you're not interested in changing it.