### PR TITLE
Enable scrolling for tabs in the tabline

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -22,6 +22,18 @@ function! s:prototype.add_raw(text) dict
   call add(self._sections, ['', a:text])
 endfunction
 
+function! s:prototype.insert_section(group, contents, position) dict
+  call insert(self._sections, [a:group, a:contents], a:position)
+endfunction
+
+function! s:prototype.insert_raw(text, position) dict
+  call insert(self._sections, ['', a:text], a:position)
+endfunction
+
+function! s:prototype.get_position() dict
+  return len(self._sections)
+endfunction
+
 function! s:get_prev_group(sections, i)
   let x = a:i - 1
   while x >= 0

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -31,7 +31,7 @@ function! s:evaluate_tabline(tabline)
   let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
   let tabline = substitute(tabline, '%(\([^)]\+\)%)', '\1', 'g')
   let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
-  let tabline = substitute(tabline, '%=', '  ', 'g')
+  let tabline = substitute(tabline, '%=', '', 'g')
   let tabline = substitute(tabline, '%\d*\*', '', 'g')
   return tabline
 endfunction

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -105,7 +105,7 @@ function! airline#extensions#tabline#tabs#get()
   call airline#extensions#tabline#add_label(b, 'tabs')
   for i in s:get_visible_tabs()
     if i < 0
-      call b.add_raw('%#airline_tabhid#...')
+      call b.add_raw('%#airline_tab#...')
       continue
     endif
     if i == curtab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -46,6 +46,16 @@ function! s:get_title(tab_nr_type, i)
   return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
 endfunction
 
+" Compatibility wrapper for strchars, in case this vim version does not
+" have it natively
+function! s:strchars(str)
+  if exists('*strchars')
+    return strchars(a:str)
+  else
+    return strlen(substitute(a:str, '.', 'a', 'g'))
+  endif
+endfunction
+
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -91,14 +101,14 @@ function! airline#extensions#tabline#tabs#get()
   let right_tab = curtab + 1
   let left_position = tabs_position
   let right_position = tabs_position + 1
-  let remaining_space = &columns - strlen(s:evaluate_tabline(b.build()))
+  let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
 
   let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#skipped_tabs_marker', '...')
-  let remaining_space -= 4 + 2 * strlen(s:evaluate_tabline(skipped_tabs_marker))
+  let remaining_space -= 4 + 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
 
   " Add the current tab
   let tab_title = s:get_title(tab_nr_type, curtab)
-  let remaining_space -= strlen(s:evaluate_tabline(tab_title)) + 1
+  let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
   let group = 'airline_tabsel'
   if g:airline_detect_modified
     for bi in tabpagebuflist(curtab)
@@ -118,7 +128,7 @@ function! airline#extensions#tabline#tabs#get()
   " Add the tab to the right
   if right_tab <= num_tabs
     let tab_title = s:get_title(tab_nr_type, right_tab)
-    let remaining_space -= strlen(s:evaluate_tabline(tab_title)) + 1
+    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
     call b.insert_section('airline_tab', tab_title, right_position)
     let right_position += 1
     let right_tab += 1
@@ -127,7 +137,7 @@ function! airline#extensions#tabline#tabs#get()
   while remaining_space > 0
     if left_tab > 0
       let tab_title = s:get_title(tab_nr_type, left_tab)
-      let remaining_space -= strlen(s:evaluate_tabline(tab_title)) + 1
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
       if remaining_space >= 0
         call b.insert_section('airline_tab', tab_title, left_position)
         let right_position += 1
@@ -135,7 +145,7 @@ function! airline#extensions#tabline#tabs#get()
       endif
     elseif right_tab <= num_tabs
       let tab_title = s:get_title(tab_nr_type, right_tab)
-      let remaining_space -= strlen(s:evaluate_tabline(tab_title)) + 1
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
       if remaining_space >= 0
         call b.insert_section('airline_tab', tab_title, right_position)
         let right_position += 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -29,7 +29,7 @@ function! s:evaluate_tabline(tabline)
   let tabline = a:tabline
   let tabline = substitute(tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
   let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
-  let tabline = substitute(tabline, '%(\([^)]\+\))', '\1', 'g')
+  let tabline = substitute(tabline, '%(\([^)]\+\)%)', '\1', 'g')
   let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
   let tabline = substitute(tabline, '%=', '  ', 'g')
   let tabline = substitute(tabline, '%\d*\*', '', 'g')

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -31,7 +31,7 @@ function! s:evaluate_tabline(tabline)
   let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
   let tabline = substitute(tabline, '%(\([^)]\+\))', '\1', 'g')
   let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
-  let tabline = substitute(tabline, '%=', '', 'g')
+  let tabline = substitute(tabline, '%=', '  ', 'g')
   let tabline = substitute(tabline, '%\d*\*', '', 'g')
   return tabline
 endfunction
@@ -91,7 +91,10 @@ function! airline#extensions#tabline#tabs#get()
   let right_tab = curtab + 1
   let left_position = tabs_position
   let right_position = tabs_position + 1
-  let remaining_space = &columns - strlen(s:evaluate_tabline(b.build())) - 8
+  let remaining_space = &columns - strlen(s:evaluate_tabline(b.build()))
+
+  let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#skipped_tabs_marker', '...')
+  let remaining_space -= 4 + 2 * strlen(s:evaluate_tabline(skipped_tabs_marker))
 
   " Add the current tab
   let tab_title = s:get_title(tab_nr_type, curtab)
@@ -147,12 +150,12 @@ function! airline#extensions#tabline#tabs#get()
     if get(g:, 'airline#extensions#tabline#current_first', 0)
       let left_position -= 1
     endif
-    call b.insert_raw('%#airline_tab#...', left_position)
+    call b.insert_raw('%#airline_tab#'.skipped_tabs_marker, left_position)
     let right_position += 1
   endif
 
   if right_tab <= num_tabs
-    call b.insert_raw('%#airline_tab#...', right_position)
+    call b.insert_raw('%#airline_tab#'.skipped_tabs_marker, right_position)
   endif
 
   let s:current_bufnr = curbuf

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -98,6 +98,16 @@ function! s:evaluate_tabline(tabline)
   return tabline
 endfunction
 
+function! s:get_title(tab_nr_type, i)
+  let val = '%('
+
+  if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
+    let val .= airline#extensions#tabline#tabs#tabnr_formatter(a:tab_nr_type, a:i)
+  endif
+
+  return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
+endfunction
+
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -141,13 +151,7 @@ function! airline#extensions#tabline#tabs#get()
 
   let tab_titles = []
   for i in range(1, tabpagenr('$'))
-    let val = '%('
-
-    if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
-      let val .= airline#extensions#tabline#tabs#tabnr_formatter(tab_nr_type, i)
-    endif
-
-    call add(tab_titles, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)')
+    call add(tab_titles, s:get_title(tab_nr_type, i))
   endfor
 
   for i in s:get_visible_tabs(&columns - strlen(b_tabline), tab_titles)

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -102,9 +102,31 @@ function! airline#extensions#tabline#tabs#get()
   let b = airline#extensions#tabline#new_builder()
 
   call airline#extensions#tabline#add_label(b, 'tabs')
+
+  let tabs_position = b.get_position()
+
+  call b.add_section('airline_tabfill', '')
+  call b.split()
+  call b.add_section('airline_tabfill', '')
+
+  if get(g:, 'airline#extensions#tabline#show_close_button', 1)
+    call b.add_section('airline_tab_right', ' %999X'.
+          \ get(g:, 'airline#extensions#tabline#close_symbol', 'X').' ')
+  endif
+
+  if get(g:, 'airline#extensions#tabline#show_splits', 1) == 1
+    let buffers = tabpagebuflist(curtab)
+    for nr in buffers
+      let group = airline#extensions#tabline#group_of_bufnr(buffers, nr) . "_right"
+      call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
+    endfor
+    call airline#extensions#tabline#add_label(b, 'buffers')
+  endif
+
   for i in s:get_visible_tabs(&columns)
     if i < 0
-      call b.add_raw('%#airline_tab#...')
+      call b.insert_raw('%#airline_tab#...', tabs_position)
+      let tabs_position += 1
       continue
     endif
     if i == curtab
@@ -125,26 +147,9 @@ function! airline#extensions#tabline#tabs#get()
     if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
       let val .= airline#extensions#tabline#tabs#tabnr_formatter(tab_nr_type, i)
     endif
-    call b.add_section(group, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)')
+    call b.insert_section(group, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)', tabs_position)
+    let tabs_position += 1
   endfor
-
-  call b.add_section('airline_tabfill', '')
-  call b.split()
-  call b.add_section('airline_tabfill', '')
-
-  if get(g:, 'airline#extensions#tabline#show_close_button', 1)
-    call b.add_section('airline_tab_right', ' %999X'.
-          \ get(g:, 'airline#extensions#tabline#close_symbol', 'X').' ')
-  endif
-
-  if get(g:, 'airline#extensions#tabline#show_splits', 1) == 1
-    let buffers = tabpagebuflist(curtab)
-    for nr in buffers
-      let group = airline#extensions#tabline#group_of_bufnr(buffers, nr) . "_right"
-      call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
-    endfor
-    call airline#extensions#tabline#add_label(b, 'buffers')
-  endif
 
   let s:current_bufnr = curbuf
   let s:current_tabnr = curtab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -25,7 +25,7 @@ function! airline#extensions#tabline#tabs#invalidate()
   let s:current_bufnr = -1
 endfunction
 
-function! s:get_visible_tabs()
+function! s:get_visible_tabs(width)
   let tablist = range(1, tabpagenr('$'))
   let curbuf = bufnr('%')
 
@@ -48,13 +48,12 @@ function! s:get_visible_tabs()
 
   " only show current and surrounding tabs if there are too many tabs
   let position  = index(tablist, curbuf)
-  let vimwidth = &columns
-  if total_width > vimwidth && position > -1
+  if total_width > a:width && position > -1
     let tab_count = len(tablist)
 
     " determine how many tabs to show based on the longest tab width,
     " use one on the right side and put the rest on the left
-    let tab_max   = vimwidth / max_width
+    let tab_max   = a:width / max_width
     let tab_right = 1
     let tab_left  = max([0, tab_max - tab_right])
 
@@ -103,7 +102,7 @@ function! airline#extensions#tabline#tabs#get()
   let b = airline#extensions#tabline#new_builder()
 
   call airline#extensions#tabline#add_label(b, 'tabs')
-  for i in s:get_visible_tabs()
+  for i in s:get_visible_tabs(&columns)
     if i < 0
       call b.add_raw('%#airline_tab#...')
       continue

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -104,7 +104,7 @@ function! airline#extensions#tabline#tabs#get()
   let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
 
   let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-  let remaining_space -= 4 + 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+  let remaining_space -= 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
 
   " Add the current tab
   let tab_title = s:get_title(tab_nr_type, curtab)

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -123,7 +123,15 @@ function! airline#extensions#tabline#tabs#get()
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
 
-  for i in s:get_visible_tabs(&columns)
+  let b_tabline = b.build()
+  let b_tabline = substitute(b_tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
+  let b_tabline = substitute(b_tabline, '%#[^#]\+#', '', 'g')
+  let b_tabline = substitute(b_tabline, '%(\([^)]\+\))', '\1', 'g')
+  let b_tabline = substitute(b_tabline, '%\d\+[TX]', '', 'g')
+  let b_tabline = substitute(b_tabline, '%=', '', 'g')
+  let b_tabline = substitute(b_tabline, '%\d*\*', '', 'g')
+
+  for i in s:get_visible_tabs(&columns - strlen(b_tabline))
     if i < 0
       call b.insert_raw('%#airline_tab#...', tabs_position)
       let tabs_position += 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -46,14 +46,17 @@ function! s:get_visible_tabs(width, titles)
     let max_width = max([max_width, width])
   endfor
 
+  " leave space for end ellipsis (...) and the left/right split (2 spaces)
+  let tab_columns = a:width - 8
+
   " only show current and surrounding tabs if there are too many tabs
   let position  = index(tablist, curbuf)
-  if total_width > a:width && position > -1
+  if total_width > tab_columns && position > -1
     let tab_count = len(tablist)
 
     " determine how many tabs to show based on the longest tab width,
     " use one on the right side and put the rest on the left
-    let tab_max   = a:width / max_width
+    let tab_max   = tab_columns / max_width
     let tab_right = 1
     let tab_left  = max([0, tab_max - tab_right])
 

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -103,7 +103,7 @@ function! airline#extensions#tabline#tabs#get()
   let right_position = tabs_position + 1
   let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
 
-  let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#skipped_tabs_marker', '...')
+  let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
   let remaining_space -= 4 + 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
 
   " Add the current tab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -103,12 +103,20 @@ function! airline#extensions#tabline#tabs#get()
   let right_position = tabs_position + 1
   let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
 
+  let left_sep_size = s:strchars(s:evaluate_tabline(b._context.left_sep))
+  let left_alt_sep_size = s:strchars(s:evaluate_tabline(b._context.left_alt_sep))
+
   let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-  let remaining_space -= 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+  let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+  " The left marker will have left_alt_sep, and the right will have left_sep.
+  let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
 
   " Add the current tab
   let tab_title = s:get_title(tab_nr_type, curtab)
-  let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
+  let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
+  " There are always two left_seps (either side of the selected tab) and all
+  " other seperators are left_alt_seps.
+  let remaining_space -= 2 * left_sep_size - left_alt_sep_size
   let group = 'airline_tabsel'
   if g:airline_detect_modified
     for bi in tabpagebuflist(curtab)
@@ -128,7 +136,7 @@ function! airline#extensions#tabline#tabs#get()
   " Add the tab to the right
   if right_tab <= num_tabs
     let tab_title = s:get_title(tab_nr_type, right_tab)
-    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
+    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
     call b.insert_section('airline_tab', tab_title, right_position)
     let right_position += 1
     let right_tab += 1
@@ -137,7 +145,7 @@ function! airline#extensions#tabline#tabs#get()
   while remaining_space > 0
     if left_tab > 0
       let tab_title = s:get_title(tab_nr_type, left_tab)
-      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
       if remaining_space >= 0
         call b.insert_section('airline_tab', tab_title, left_position)
         let right_position += 1
@@ -145,7 +153,7 @@ function! airline#extensions#tabline#tabs#get()
       endif
     elseif right_tab <= num_tabs
       let tab_title = s:get_title(tab_nr_type, right_tab)
-      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
       if remaining_space >= 0
         call b.insert_section('airline_tab', tab_title, right_position)
         let right_position += 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -25,6 +25,20 @@ function! airline#extensions#tabline#tabs#invalidate()
   let s:current_bufnr = -1
 endfunction
 
+function! s:get_tabs()
+  let tablist = range(1, tabpagenr('$'))
+  let curbuf = bufnr('%')
+
+  if get(g:, 'airline#extensions#tabline#current_first', 0)
+    " always have current tabpage first
+    if index(tablist, curtab) > -1
+      call remove(tablist, index(tablist, curtab))
+    endif
+    let tablist = [curtab] + tablist
+  endif
+  return tablist
+endfunction
+
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -43,15 +57,7 @@ function! airline#extensions#tabline#tabs#get()
   let b = airline#extensions#tabline#new_builder()
 
   call airline#extensions#tabline#add_label(b, 'tabs')
-  " always have current tabpage first
-  let tablist = range(1, tabpagenr('$'))
-  if get(g:, 'airline#extensions#tabline#current_first', 0)
-    if index(tablist, curtab) > -1
-      call remove(tablist, index(tablist, curtab))
-    endif
-    let tablist = [curtab] + tablist
-  endif
-  for i in tablist
+  for i in s:get_tabs()
     if i == curtab
       let group = 'airline_tabsel'
       if g:airline_detect_modified

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -95,7 +95,6 @@ function! airline#extensions#tabline#tabs#get()
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
 
-  let b_tabline = s:evaluate_tabline(b.build())
   let num_tabs = tabpagenr('$')
   let left_tab = curtab - 1
   let right_tab = curtab + 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -84,6 +84,17 @@ function! s:get_visible_tabs(width)
   return tablist
 endfunction
 
+function! s:evaluate_tabline(tabline)
+  let tabline = a:tabline
+  let tabline = substitute(tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
+  let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
+  let tabline = substitute(tabline, '%(\([^)]\+\))', '\1', 'g')
+  let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
+  let tabline = substitute(tabline, '%=', '', 'g')
+  let tabline = substitute(tabline, '%\d*\*', '', 'g')
+  return tabline
+endfunction
+
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -123,13 +134,7 @@ function! airline#extensions#tabline#tabs#get()
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
 
-  let b_tabline = b.build()
-  let b_tabline = substitute(b_tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
-  let b_tabline = substitute(b_tabline, '%#[^#]\+#', '', 'g')
-  let b_tabline = substitute(b_tabline, '%(\([^)]\+\))', '\1', 'g')
-  let b_tabline = substitute(b_tabline, '%\d\+[TX]', '', 'g')
-  let b_tabline = substitute(b_tabline, '%=', '', 'g')
-  let b_tabline = substitute(b_tabline, '%\d*\*', '', 'g')
+  let b_tabline = s:evaluate_tabline(b.build())
 
   for i in s:get_visible_tabs(&columns - strlen(b_tabline))
     if i < 0

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -64,7 +64,7 @@ function! airline#extensions#tabline#tabs#get()
   catch
     " no-op
   endtry
-  if curbuf == s:current_bufnr && curtab == s:current_tabnr
+  if curbuf == s:current_bufnr && curtab == s:current_tabnr && &columns == s:column_width
     if !g:airline_detect_modified || getbufvar(curbuf, '&modified') == s:current_modified
       return s:current_tabline
     endif
@@ -170,6 +170,7 @@ function! airline#extensions#tabline#tabs#get()
 
   let s:current_bufnr = curbuf
   let s:current_tabnr = curtab
+  let s:column_width = &columns
   let s:current_tabline = b.build()
   return s:current_tabline
 endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -70,7 +70,8 @@ function! airline#init#bootstrap()
           \ 'spell': 'SPELL',
           \ 'modified': '+',
           \ 'space': ' ',
-          \ 'keymap': 'Keymap:'
+          \ 'keymap': 'Keymap:',
+          \ 'ellipsis': '...'
           \  }, 'keep')
 
   if get(g:, 'airline_powerline_fonts', 0)

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -709,6 +709,9 @@ with the middle mouse button to delete that buffer.
 * rename label for tabs (default: 'tabs') (c) >
   let g:airline#extensions#tabline#tabs_label = 't'
 
+* change the symbol for skipped tabs/buffers (default '...') >
+  let g:airline#extensions#tabline#skipped_tabs_marker = '…'
+
 * always show current tabpage/buffer first >
   let airline#extensions#tabline#current_first = 1
 <  default: 0

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -710,7 +710,7 @@ with the middle mouse button to delete that buffer.
   let g:airline#extensions#tabline#tabs_label = 't'
 
 * change the symbol for skipped tabs/buffers (default '...') >
-  let g:airline#extensions#tabline#skipped_tabs_marker = '…'
+  let g:airline#extensions#tabline#overflow_marker = '…'
 
 * always show current tabpage/buffer first >
   let airline#extensions#tabline#current_first = 1


### PR DESCRIPTION
This fixes #1468 (and the now-closed #488).

The core of this PR is the function `s:get_visible_tabs` (directly adapted from PR #266, where scrolling for buffers was implemented). This is slightly more complex than the buffer case:
* The tabs tabline has more going on in it, and so determining the space left for tabs is hard.
  - This is done by doing (some of) the processing that a tabline refresh would do, to work out the number of characters used.
  - Several parts of that processing are omitted, for the sake of simplicity
* There is content that comes *after* the tabs in the tabline but has variable width.
  - To get the content for processing, it was easiest to build the whole tabline *except* the tabs, and then insert the tabs afterwards for the actual build.
  - There are new functions in the builder prototype for this purpose.

Screenshots:
* first tab
![screenshot from 2018-03-12 23-11-39](https://user-images.githubusercontent.com/1847343/37314251-01ce9ea4-264b-11e8-9acd-802cae387fcd.png)
* tab in the initial strip
![screenshot from 2018-03-12 23-11-52](https://user-images.githubusercontent.com/1847343/37314252-0217a5ea-264b-11e8-83e5-97b276872477.png)
* tab in the middle
![screenshot from 2018-03-12 23-12-17](https://user-images.githubusercontent.com/1847343/37314253-023f348e-264b-11e8-9cae-ccbff45e5793.png)
* tab with long names (overflow)
![screenshot from 2018-03-12 23-12-37](https://user-images.githubusercontent.com/1847343/37314254-026e97e2-264b-11e8-9372-b53a12be86b7.png)
* tab in the final strip
![screenshot from 2018-03-12 23-12-59](https://user-images.githubusercontent.com/1847343/37314255-02924264-264b-11e8-9003-8d15c456c5a4.png)
* last tab
![screenshot from 2018-03-12 23-13-15](https://user-images.githubusercontent.com/1847343/37314256-02b3a5d0-264b-11e8-8020-47491c366c4a.png)
* wider terminal
![screenshot from 2018-03-12 23-22-27](https://user-images.githubusercontent.com/1847343/37314496-57064362-264c-11e8-98a3-c2e195124d42.png)

Original:
* tab not in the final strip
![screenshot from 2018-03-12 23-17-43](https://user-images.githubusercontent.com/1847343/37314411-d74fa67c-264b-11e8-9356-501c969b24f4.png)
* tab in the final strip
![screenshot from 2018-03-12 23-19-10](https://user-images.githubusercontent.com/1847343/37314396-c9abbfd8-264b-11e8-8cf7-84c7c36d8aac.png)
