### PR TITLE
ALE: add option to disable line numbers

### DIFF
--- a/autoload/airline/extensions/ale.vim
+++ b/autoload/airline/extensions/ale.vim
@@ -5,6 +5,7 @@ scriptencoding utf-8
 
 let s:error_symbol = get(g:, 'airline#extensions#ale#error_symbol', 'E:')
 let s:warning_symbol = get(g:, 'airline#extensions#ale#warning_symbol', 'W:')
+let s:show_line_numbers = get(g:, 'airline#extensions#ale#show_line_numbers', 1)
 
 function! s:airline_ale_count(cnt, symbol)
   return a:cnt ? a:symbol. a:cnt : ''
@@ -52,7 +53,11 @@ function! airline#extensions#ale#get(type)
     let num = is_err ? counts[0] : counts[1]
   endif
 
-  return s:airline_ale_count(num, symbol) . <sid>airline_ale_get_line_number(num, a:type)
+  if s:show_line_numbers == 1
+    return s:airline_ale_count(num, symbol) . <sid>airline_ale_get_line_number(num, a:type)
+  else
+    return s:airline_ale_count(num, symbol)
+  endif
 endfunction
 
 function! airline#extensions#ale#get_warning()

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1020,6 +1020,9 @@ ale <https://github.com/w0rp/ale>
 <
 * ale warning >
   let airline#extensions#ale#warning_symbol = 'W:'
+
+* ale show_line_numbers >
+  let airline#extensions#ale#show_line_numbers = 1
 <
 * ale open_lnum_symbol >
   let airline#extensions#ale#open_lnum_symbol = '(L'


### PR DESCRIPTION
Add option to toggle displaying of line numbers of ALE warnings and errors introduced in #1600. Displaying line numbers is turned on by default.