### PR TITLE
Rework tabline for tabs and buffers

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -34,7 +34,7 @@ function! s:prototype.get_position() dict
   return len(self._sections)
 endfunction
 
-function! s:get_prev_group(sections, i)
+function! airline#builder#get_prev_group(sections, i)
   let x = a:i - 1
   while x >= 0
     let group = a:sections[x][0]
@@ -42,6 +42,19 @@ function! s:get_prev_group(sections, i)
       return group
     endif
     let x = x - 1
+  endwhile
+  return ''
+endfunction
+
+function! airline#builder#get_next_group(sections, i)
+  let x = a:i + 1
+  let l = len(a:sections)
+  while x < l
+    let group = a:sections[x][0]
+    if group != '' && group != '|'
+      return group
+    endif
+    let x = x + 1
   endwhile
   return ''
 endfunction
@@ -60,7 +73,7 @@ function! s:prototype.build() dict
     let group = section[0]
     let contents = section[1]
     let pgroup = prev_group
-    let prev_group = s:get_prev_group(self._sections, i)
+    let prev_group = airline#builder#get_prev_group(self._sections, i)
     if group ==# 'airline_c' && &buftype ==# 'terminal' && self._context.active
       let group = 'airline_term'
     elseif group ==# 'airline_c' && !self._context.active && has_key(self._context, 'bufnr')
@@ -114,7 +127,7 @@ function! s:prototype.build() dict
   return line
 endfunction
 
-function! s:should_change_group(group1, group2)
+function! airline#builder#should_change_group(group1, group2)
   if a:group1 == a:group2
     return 0
   endif
@@ -144,7 +157,7 @@ function! s:get_transitioned_seperator(self, prev_group, group, side)
 endfunction
 
 function! s:get_seperator(self, prev_group, group, side)
-  if s:should_change_group(a:prev_group, a:group)
+  if airline#builder#should_change_group(a:prev_group, a:group)
     return s:get_transitioned_seperator(a:self, a:prev_group, a:group, a:side)
   else
     return a:side ? a:self._context.left_alt_sep : a:self._context.right_alt_sep

--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -22,6 +22,18 @@ function! s:prototype.add_raw(text) dict
   call add(self._sections, ['', a:text])
 endfunction
 
+function! s:prototype.insert_section(group, contents, position) dict
+  call insert(self._sections, [a:group, a:contents], a:position)
+endfunction
+
+function! s:prototype.insert_raw(text, position) dict
+  call insert(self._sections, ['', a:text], a:position)
+endfunction
+
+function! s:prototype.get_position() dict
+  return len(self._sections)
+endfunction
+
 function! s:get_prev_group(sections, i)
   let x = a:i - 1
   while x >= 0

--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -181,7 +181,7 @@ function! airline#extensions#tabline#new_builder()
     let builder_context.left_alt_sep = get(g:, 'airline#extensions#tabline#left_alt_sep' , '|')
   endif
 
-  return airline#builder#new(builder_context)
+  return airline#extensions#tabline#builder#new(builder_context)
 endfunction
 
 function! airline#extensions#tabline#group_of_bufnr(tab_bufs, bufnr)

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -52,7 +52,7 @@ function! airline#extensions#tabline#buffers#get()
     " no-op
   endtry
   let cur = bufnr('%')
-  if cur == s:current_bufnr
+  if cur == s:current_bufnr && &columns == s:column_width
     if !g:airline_detect_modified || getbufvar(cur, '&modified') == s:current_modified
       return s:current_tabline
     endif
@@ -140,6 +140,7 @@ function! airline#extensions#tabline#buffers#get()
   endif
 
   let s:current_bufnr = cur
+  let s:column_width = &columns
   let s:current_tabline = b.build()
   let s:current_visible_buffers = copy(b.buffers)
   if b._right_tab <= last_buffer

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -143,11 +143,11 @@ function! airline#extensions#tabline#buffers#get()
   let s:column_width = &columns
   let s:current_tabline = b.build()
   let s:current_visible_buffers = copy(b.buffers)
-  if b._right_tab <= last_buffer
-    call remove(s:current_visible_buffers, b._right_tab, last_buffer)
+  if b._right_title <= last_buffer
+    call remove(s:current_visible_buffers, b._right_title, last_buffer)
   endif
-  if b._left_tab > 0
-    call remove(s:current_visible_buffers, 0, b._left_tab)
+  if b._left_title > 0
+    call remove(s:current_visible_buffers, 0, b._left_title)
   endif
   return s:current_tabline
 endfunction

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -125,8 +125,9 @@ function! airline#extensions#tabline#buffers#get()
     endif
   endfunction
 
+  let current_buffer = max([index(b.buffers, cur), 0])
   let last_buffer = len(b.buffers) - 1
-  call b.insert_titles(index(b.buffers, cur), 0, last_buffer)
+  call b.insert_titles(current_buffer, 0, last_buffer)
 
   call b.add_section('airline_tabfill', '')
   call b.split()

--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -126,7 +126,7 @@ function! airline#extensions#tabline#buffers#get()
   endfunction
 
   let last_buffer = len(b.buffers) - 1
-  call b.insert_tabs(index(b.buffers, cur), 0, last_buffer)
+  call b.insert_titles(index(b.buffers, cur), 0, last_buffer)
 
   call b.add_section('airline_tabfill', '')
   call b.split()

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -62,8 +62,8 @@ function! s:prototype.build() dict
 
     let center_active = get(g:, 'airline#extensions#tabline#center_active', 0)
 
-    let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
-    let left_alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
+    let sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
+    let alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
 
     let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
     let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
@@ -76,8 +76,8 @@ function! s:prototype.build() dict
     " Add the current tab
     let group = self.get_group(self._left_tab)
     let sep_change =
-      \ s:get_separator_change(group, "", outer_left_group, left_sep_size, left_alt_sep_size) +
-      \ s:get_separator_change(group, "", outer_right_group, left_sep_size, left_alt_sep_size)
+      \ s:get_separator_change(group, "", outer_left_group, sep_size, alt_sep_size) +
+      \ s:get_separator_change(group, "", outer_right_group, sep_size, alt_sep_size)
     let last_left_group = group
     let last_right_group = group
     let self._left_tab -=
@@ -92,7 +92,7 @@ function! s:prototype.build() dict
     if !center_active && self._right_tab <= self._last_tab
       let group = self.get_group(self._right_tab)
       let sep_change =
-        \ s:get_separator_change(group, last_right_group, outer_right_group, left_sep_size, left_alt_sep_size)
+        \ s:get_separator_change(group, last_right_group, outer_right_group, sep_size, alt_sep_size)
       let last_right_group = group
       let self._right_tab +=
       \ self.try_insert_tab(self._right_tab, group, self._right_position, sep_change, 1)
@@ -103,7 +103,7 @@ function! s:prototype.build() dict
       if self._left_tab >= self._first_tab
         let group = self.get_group(self._left_tab)
         let sep_change =
-          \ s:get_separator_change(group, last_left_group, outer_left_group, left_sep_size, left_alt_sep_size)
+          \ s:get_separator_change(group, last_left_group, outer_left_group, sep_size, alt_sep_size)
         let last_left_group = group
         let done = self.try_insert_tab(self._left_tab, group, self._left_position, sep_change, 0)
         let self._left_tab -= done
@@ -111,7 +111,7 @@ function! s:prototype.build() dict
       if self._right_tab <= self._last_tab && (center_active || !done)
         let group = self.get_group(self._right_tab)
         let sep_change =
-          \ s:get_separator_change(group, last_right_group, outer_right_group, left_sep_size, left_alt_sep_size)
+          \ s:get_separator_change(group, last_right_group, outer_right_group, sep_size, alt_sep_size)
         let last_right_group = group
         let done = self.try_insert_tab(self._right_tab, group, self._right_position, sep_change, 0)
         let self._right_tab += done

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -5,7 +5,8 @@ scriptencoding utf-8
 
 let s:prototype = {}
 
-function! s:prototype.insert_tabs(curtab) dict
+function! s:prototype.insert_tabs(curtab, numtabs) dict
+  let self._num_tabs = a:numtabs
   let self._left_tab = a:curtab
   let self._right_tab = a:curtab + 1
   let self._left_position = self.get_position()
@@ -25,7 +26,6 @@ endfunction
 
 function! s:prototype.build() dict
   if has_key(self, '_left_position')
-    let num_tabs = tabpagenr('$')
     let self._remaining_space = &columns - s:strchars(s:evaluate_tabline(self._build()))
 
     let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
@@ -50,7 +50,7 @@ function! s:prototype.build() dict
     endif
 
     " Add the tab to the right
-    if self._right_tab <= num_tabs
+    if self._right_tab <= self._num_tabs
       let self._right_tab +=
       \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 1)
     endif
@@ -59,7 +59,7 @@ function! s:prototype.build() dict
       if self._left_tab > 0
         let self._left_tab -=
           \ self.try_insert_tab(self._left_tab, self._left_position, left_alt_sep_size, 0)
-      elseif self._right_tab <= num_tabs
+      elseif self._right_tab <= self._num_tabs
         let self._right_tab +=
           \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 0)
       else
@@ -75,7 +75,7 @@ function! s:prototype.build() dict
       let self._right_position += 1
     endif
 
-    if self._right_tab <= num_tabs
+    if self._right_tab <= self._num_tabs
       call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, self._right_position)
     endif
   endif

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -16,7 +16,7 @@ function! s:prototype.build() dict
   if has_key(self, '_left_position')
     let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
     let num_tabs = tabpagenr('$')
-    let remaining_space = &columns - s:strchars(s:evaluate_tabline(self._build()))
+    let self._remaining_space = &columns - s:strchars(s:evaluate_tabline(self._build()))
 
     let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
     let left_alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
@@ -24,14 +24,14 @@ function! s:prototype.build() dict
     let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
     let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
     " The left marker will have left_alt_sep, and the right will have left_sep.
-    let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
+    let self._remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
 
     " Add the current tab
     let tab_title = self.get_title(tab_nr_type, self._left_tab)
-    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
+    let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
     " There are always two left_seps (either side of the selected tab) and all
     " other seperators are left_alt_seps.
-    let remaining_space -= 2 * left_sep_size - left_alt_sep_size
+    let self._remaining_space -= 2 * left_sep_size - left_alt_sep_size
     call self.insert_section(self.get_group(self._left_tab), tab_title, self._left_position)
     let self._right_position += 1
     let self._left_tab -= 1
@@ -44,25 +44,25 @@ function! s:prototype.build() dict
     " Add the tab to the right
     if self._right_tab <= num_tabs
       let tab_title = self.get_title(tab_nr_type, self._right_tab)
-      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
+      let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
       call self.insert_section(self.get_group(self._right_tab), tab_title, self._right_position)
       let self._right_position += 1
       let self._right_tab += 1
     endif
 
-    while remaining_space > 0
+    while self._remaining_space > 0
       if self._left_tab > 0
         let tab_title = self.get_title(tab_nr_type, self._left_tab)
-        let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-        if remaining_space >= 0
+        let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
+        if self._remaining_space >= 0
           call self.insert_section(self.get_group(self._left_tab), tab_title, self._left_position)
           let self._right_position += 1
           let self._left_tab -= 1
         endif
       elseif self._right_tab <= num_tabs
         let tab_title = self.get_title(tab_nr_type, self._right_tab)
-        let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-        if remaining_space >= 0
+        let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
+        if self._remaining_space >= 0
           call self.insert_section(self.get_group(self._right_tab), tab_title, self._right_position)
           let self._right_position += 1
           let self._right_tab += 1

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -5,7 +5,7 @@ scriptencoding utf-8
 
 let s:prototype = {}
 
-function! s:prototype.insert_tabs(curtab, first_tab, last_tab) dict
+function! s:prototype.insert_titles(curtab, first_tab, last_tab) dict
   let self._first_tab = a:first_tab
   let self._last_tab = a:last_tab
   let self._left_tab = a:curtab
@@ -14,7 +14,7 @@ function! s:prototype.insert_tabs(curtab, first_tab, last_tab) dict
   let self._right_position = self._left_position
 endfunction
 
-function! s:prototype.try_insert_tab(tab, group, pos, sep_size, force) dict
+function! s:prototype.try_insert_title(tab, group, pos, sep_size, force) dict
   let tab_title = self.get_title(a:tab)
   let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + a:sep_size
   if a:force || self._remaining_space >= 0
@@ -81,7 +81,7 @@ function! s:prototype.build() dict
     let left_group = group
     let right_group = group
     let self._left_tab -=
-      \ self.try_insert_tab(self._left_tab, group, self._left_position, sep_change, 1)
+      \ self.try_insert_title(self._left_tab, group, self._left_position, sep_change, 1)
 
     if get(g:, 'airline#extensions#tabline#current_first', 0)
       " always have current tabpage first
@@ -95,7 +95,7 @@ function! s:prototype.build() dict
         \ s:get_separator_change(group, right_group, outer_right_group, sep_size, alt_sep_size)
       let right_group = group
       let self._right_tab +=
-      \ self.try_insert_tab(self._right_tab, group, self._right_position, sep_change, 1)
+      \ self.try_insert_title(self._right_tab, group, self._right_position, sep_change, 1)
     endif
 
     while self._remaining_space > 0
@@ -105,7 +105,7 @@ function! s:prototype.build() dict
         let sep_change =
           \ s:get_separator_change(group, left_group, outer_left_group, sep_size, alt_sep_size)
         let left_group = group
-        let done = self.try_insert_tab(self._left_tab, group, self._left_position, sep_change, 0)
+        let done = self.try_insert_title(self._left_tab, group, self._left_position, sep_change, 0)
         let self._left_tab -= done
       endif
       if self._right_tab <= self._last_tab && (center_active || !done)
@@ -113,7 +113,7 @@ function! s:prototype.build() dict
         let sep_change =
           \ s:get_separator_change(group, right_group, outer_right_group, sep_size, alt_sep_size)
         let right_group = group
-        let done = self.try_insert_tab(self._right_tab, group, self._right_position, sep_change, 0)
+        let done = self.try_insert_title(self._right_tab, group, self._right_position, sep_change, 0)
         let self._right_tab += done
       endif
       if !done

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -36,6 +36,8 @@ function! s:prototype.try_insert_tab(tab, pos, sep_size, force) dict
     endif
 
     return 1
+  else
+    let self._remaining_space += s:strchars(s:evaluate_tabline(tab_title)) + a:sep_size
   endif
   return 0
 endfunction
@@ -76,14 +78,12 @@ function! s:prototype.build() dict
     while self._remaining_space > 0
       let done = 0
       if self._left_tab >= self._first_tab
-        let self._left_tab -=
-          \ self.try_insert_tab(self._left_tab, self._left_position, left_alt_sep_size, 0)
-        let done = 1
+        let done = self.try_insert_tab(self._left_tab, self._left_position, left_alt_sep_size, 0)
+        let self._left_tab -= done
       endif
       if self._right_tab <= self._last_tab && (center_active || !done)
-        let self._right_tab +=
-          \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 0)
-        let done = 1
+        let done = self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 0)
+        let self._right_tab += done
       endif
       if !done
         break

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -78,8 +78,8 @@ function! s:prototype.build() dict
     let sep_change =
       \ s:get_separator_change(group, "", outer_left_group, sep_size, alt_sep_size) +
       \ s:get_separator_change(group, "", outer_right_group, sep_size, alt_sep_size)
-    let last_left_group = group
-    let last_right_group = group
+    let left_group = group
+    let right_group = group
     let self._left_tab -=
       \ self.try_insert_tab(self._left_tab, group, self._left_position, sep_change, 1)
 
@@ -92,8 +92,8 @@ function! s:prototype.build() dict
     if !center_active && self._right_tab <= self._last_tab
       let group = self.get_group(self._right_tab)
       let sep_change =
-        \ s:get_separator_change(group, last_right_group, outer_right_group, sep_size, alt_sep_size)
-      let last_right_group = group
+        \ s:get_separator_change(group, right_group, outer_right_group, sep_size, alt_sep_size)
+      let right_group = group
       let self._right_tab +=
       \ self.try_insert_tab(self._right_tab, group, self._right_position, sep_change, 1)
     endif
@@ -103,16 +103,16 @@ function! s:prototype.build() dict
       if self._left_tab >= self._first_tab
         let group = self.get_group(self._left_tab)
         let sep_change =
-          \ s:get_separator_change(group, last_left_group, outer_left_group, sep_size, alt_sep_size)
-        let last_left_group = group
+          \ s:get_separator_change(group, left_group, outer_left_group, sep_size, alt_sep_size)
+        let left_group = group
         let done = self.try_insert_tab(self._left_tab, group, self._left_position, sep_change, 0)
         let self._left_tab -= done
       endif
       if self._right_tab <= self._last_tab && (center_active || !done)
         let group = self.get_group(self._right_tab)
         let sep_change =
-          \ s:get_separator_change(group, last_right_group, outer_right_group, sep_size, alt_sep_size)
-        let last_right_group = group
+          \ s:get_separator_change(group, right_group, outer_right_group, sep_size, alt_sep_size)
+        let right_group = group
         let done = self.try_insert_tab(self._right_tab, group, self._right_position, sep_change, 0)
         let self._right_tab += done
       endif

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -17,8 +17,23 @@ function! s:prototype.try_insert_tab(tab, pos, sep_size, force) dict
   let tab_title = self.get_title(a:tab)
   let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + a:sep_size
   if a:force || self._remaining_space >= 0
-    call self.insert_section(self.get_group(a:tab), tab_title, a:pos)
+    let pos = a:pos
+    if has_key(self, "get_pretitle")
+      call self.insert_raw(self.get_pretitle(a:tab), pos)
+      let self._right_position += 1
+      let pos += 1
+    endif
+
+    call self.insert_section(self.get_group(a:tab), tab_title, pos)
     let self._right_position += 1
+    let pos += 1
+
+    if has_key(self, "get_posttitle")
+      call self.insert_raw(self.get_posttitle(a:tab), pos)
+      let self._right_position += 1
+      let pos += 1
+    endif
+
     return 1
   endif
   return 0

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -65,10 +65,10 @@ function! s:prototype.build() dict
     let sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
     let alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
 
-    let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-    let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+    let overflow_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
+    let overflow_marker_size = s:strchars(s:evaluate_tabline(overflow_marker))
     " Allow space for the markers before we begin filling in titles.
-    let self._remaining_space -= 2 * skipped_tabs_marker_size
+    let self._remaining_space -= 2 * overflow_marker_size
 
     let outer_left_group = airline#builder#get_prev_group(self._sections, self._left_position)
     let outer_right_group = airline#builder#get_next_group(self._sections, self._right_position)
@@ -125,12 +125,12 @@ function! s:prototype.build() dict
       if get(g:, 'airline#extensions#tabline#current_first', 0)
         let self._left_position -= 1
       endif
-      call self.insert_raw('%#'.self.overflow_group.'#'.skipped_tabs_marker, self._left_position)
+      call self.insert_raw('%#'.self.overflow_group.'#'.overflow_marker, self._left_position)
       let self._right_position += 1
     endif
 
     if self._right_tab <= self._last_tab
-      call self.insert_raw('%#'.self.overflow_group.'#'.skipped_tabs_marker, self._right_position)
+      call self.insert_raw('%#'.self.overflow_group.'#'.overflow_marker, self._right_position)
     endif
   endif
 

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -94,7 +94,7 @@ endfunction
 " Callers should define at least |get_title| and |get_group| on the host
 " object if |insert_titles| has been called on it.
 function! s:prototype.build() dict
-  if has_key(self, '_left_position')
+  if has_key(self, '_left_position') && self._first_title <= self._last_title
     let self._remaining_space = &columns - s:tabline_evaluated_length(self._build())
 
     let center_active = get(g:, 'airline#extensions#tabline#center_active', 0)

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -66,19 +66,23 @@ function! s:prototype.try_insert_title(index, group, pos, sep_size, force) dict
   return 0
 endfunction
 
-" Compute the size of the change in tabs caused by separators
+function! s:get_separator_change(new_group, old_group, end_group, sep_size, alt_sep_size)
+  return s:get_separator_change_with_end(a:new_group, a:old_group, a:end_group, a:end_group, a:sep_size, a:alt_sep_size)
+endfunction
+
+" Compute the change in size of the tabline caused by separators
 "
 " This should be kept up-to-date with |s:get_transitioned_seperator| and
 " |s:get_separator| in autoload/airline/builder.vim
-function! s:get_separator_change(new_group, old_group, end_group, sep_size, alt_sep_size)
+function! s:get_separator_change_with_end(new_group, old_group, new_end_group, old_end_group, sep_size, alt_sep_size)
   let sep_change = 0
-  if !empty(a:end_group) " Separator between title and the end
-    let sep_change += airline#builder#should_change_group(a:new_group, a:end_group) ? a:sep_size : a:alt_sep_size
+  if !empty(a:new_end_group) " Separator between title and the end
+    let sep_change += airline#builder#should_change_group(a:new_group, a:new_end_group) ? a:sep_size : a:alt_sep_size
   endif
   if !empty(a:old_group) " Separator between the title and the one adjacent
     let sep_change += airline#builder#should_change_group(a:new_group, a:old_group) ? a:sep_size : a:alt_sep_size
-    if !empty(a:end_group) " Remove mis-predicted separator
-      let sep_change -= airline#builder#should_change_group(a:old_group, a:end_group) ? a:sep_size : a:alt_sep_size
+    if !empty(a:old_end_group) " Remove mis-predicted separator
+      let sep_change -= airline#builder#should_change_group(a:old_group, a:old_end_group) ? a:sep_size : a:alt_sep_size
     endif
   endif
   return sep_change

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -12,6 +12,17 @@ function! s:prototype.insert_tabs(curtab) dict
   let self._right_position = self._left_position
 endfunction
 
+function! s:prototype.try_insert_tab(tab, pos, tab_nr_type, sep_size, force) dict
+  let tab_title = self.get_title(a:tab_nr_type, a:tab)
+  let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + a:sep_size
+  if a:force || self._remaining_space >= 0
+    call self.insert_section(self.get_group(a:tab), tab_title, a:pos)
+    let self._right_position += 1
+    return 1
+  endif
+  return 0
+endfunction
+
 function! s:prototype.build() dict
   if has_key(self, '_left_position')
     let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
@@ -25,16 +36,14 @@ function! s:prototype.build() dict
     let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
     " The left marker will have left_alt_sep, and the right will have left_sep.
     let self._remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
-
-    " Add the current tab
-    let tab_title = self.get_title(tab_nr_type, self._left_tab)
-    let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
+    "
     " There are always two left_seps (either side of the selected tab) and all
     " other seperators are left_alt_seps.
-    let self._remaining_space -= 2 * left_sep_size - left_alt_sep_size
-    call self.insert_section(self.get_group(self._left_tab), tab_title, self._left_position)
-    let self._right_position += 1
-    let self._left_tab -= 1
+    let self._remaining_space -= left_sep_size - left_alt_sep_size
+
+    " Add the current tab
+    let self._left_tab -=
+      \ self.try_insert_tab(self._left_tab, self._left_position, tab_nr_type, left_sep_size, 1)
 
     if get(g:, 'airline#extensions#tabline#current_first', 0)
       " always have current tabpage first
@@ -43,30 +52,17 @@ function! s:prototype.build() dict
 
     " Add the tab to the right
     if self._right_tab <= num_tabs
-      let tab_title = self.get_title(tab_nr_type, self._right_tab)
-      let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-      call self.insert_section(self.get_group(self._right_tab), tab_title, self._right_position)
-      let self._right_position += 1
-      let self._right_tab += 1
+      let self._right_tab +=
+      \ self.try_insert_tab(self._right_tab, self._right_position, tab_nr_type, left_alt_sep_size, 1)
     endif
 
     while self._remaining_space > 0
       if self._left_tab > 0
-        let tab_title = self.get_title(tab_nr_type, self._left_tab)
-        let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-        if self._remaining_space >= 0
-          call self.insert_section(self.get_group(self._left_tab), tab_title, self._left_position)
-          let self._right_position += 1
-          let self._left_tab -= 1
-        endif
+        let self._left_tab -=
+          \ self.try_insert_tab(self._left_tab, self._left_position, tab_nr_type, left_alt_sep_size, 0)
       elseif self._right_tab <= num_tabs
-        let tab_title = self.get_title(tab_nr_type, self._right_tab)
-        let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-        if self._remaining_space >= 0
-          call self.insert_section(self.get_group(self._right_tab), tab_title, self._right_position)
-          let self._right_position += 1
-          let self._right_tab += 1
-        endif
+        let self._right_tab +=
+          \ self.try_insert_tab(self._right_tab, self._right_position, tab_nr_type, left_alt_sep_size, 0)
       else
         break
       endif

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -91,6 +91,9 @@ function! s:evaluate_tabline(tabline)
   let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
   let tabline = substitute(tabline, '%=', '', 'g')
   let tabline = substitute(tabline, '%\d*\*', '', 'g')
+  if has('tablineat')
+    let tabline = substitute(tabline, '%@[^@]\+@', '', 'g')
+  endif
   return tabline
 endfunction
 

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -44,6 +44,8 @@ function! s:prototype.build() dict
   if has_key(self, '_left_position')
     let self._remaining_space = &columns - s:strchars(s:evaluate_tabline(self._build()))
 
+    let center_active = get(g:, 'airline#extensions#tabline#center_active', 0)
+
     let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
     let left_alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
 
@@ -66,19 +68,24 @@ function! s:prototype.build() dict
     endif
 
     " Add the tab to the right
-    if self._right_tab <= self._last_tab
+    if !center_active && self._right_tab <= self._last_tab
       let self._right_tab +=
       \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 1)
     endif
 
     while self._remaining_space > 0
+      let done = 0
       if self._left_tab >= self._first_tab
         let self._left_tab -=
           \ self.try_insert_tab(self._left_tab, self._left_position, left_alt_sep_size, 0)
-      elseif self._right_tab <= self._last_tab
+        let done = 1
+      endif
+      if self._right_tab <= self._last_tab && (center_active || !done)
         let self._right_tab +=
           \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 0)
-      else
+        let done = 1
+      endif
+      if !done
         break
       endif
     endwhile

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -5,6 +5,101 @@ scriptencoding utf-8
 
 let s:prototype = {}
 
+function! s:prototype.insert_tabs(tabs_position, curtab) dict
+  let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
+  let num_tabs = tabpagenr('$')
+  let left_tab = a:curtab - 1
+  let right_tab = a:curtab + 1
+  let left_position = a:tabs_position
+  let right_position = a:tabs_position + 1
+  let remaining_space = &columns - s:strchars(s:evaluate_tabline(self.build()))
+
+  let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
+  let left_alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
+
+  let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
+  let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+  " The left marker will have left_alt_sep, and the right will have left_sep.
+  let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
+
+  " Add the current tab
+  let tab_title = self.get_title(tab_nr_type, a:curtab)
+  let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
+  " There are always two left_seps (either side of the selected tab) and all
+  " other seperators are left_alt_seps.
+  let remaining_space -= 2 * left_sep_size - left_alt_sep_size
+  call self.insert_section(self.get_group(a:curtab), tab_title, left_position)
+
+  if get(g:, 'airline#extensions#tabline#current_first', 0)
+    " always have current tabpage first
+    let left_position += 1
+  endif
+
+  " Add the tab to the right
+  if right_tab <= num_tabs
+    let tab_title = self.get_title(tab_nr_type, right_tab)
+    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
+    call self.insert_section(self.get_group(right_tab), tab_title, right_position)
+    let right_position += 1
+    let right_tab += 1
+  endif
+
+  while remaining_space > 0
+    if left_tab > 0
+      let tab_title = self.get_title(tab_nr_type, left_tab)
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
+      if remaining_space >= 0
+        call self.insert_section(self.get_group(left_tab), tab_title, left_position)
+        let right_position += 1
+        let left_tab -= 1
+      endif
+    elseif right_tab <= num_tabs
+      let tab_title = self.get_title(tab_nr_type, right_tab)
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
+      if remaining_space >= 0
+        call self.insert_section(self.get_group(right_tab), tab_title, right_position)
+        let right_position += 1
+        let right_tab += 1
+      endif
+    else
+      break
+    endif
+  endwhile
+
+  if left_tab > 0
+    if get(g:, 'airline#extensions#tabline#current_first', 0)
+      let left_position -= 1
+    endif
+    call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, left_position)
+    let right_position += 1
+  endif
+
+  if right_tab <= num_tabs
+    call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, right_position)
+  endif
+endfunction
+
+function! s:evaluate_tabline(tabline)
+  let tabline = a:tabline
+  let tabline = substitute(tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
+  let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
+  let tabline = substitute(tabline, '%(\([^)]\+\)%)', '\1', 'g')
+  let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
+  let tabline = substitute(tabline, '%=', '', 'g')
+  let tabline = substitute(tabline, '%\d*\*', '', 'g')
+  return tabline
+endfunction
+
+" Compatibility wrapper for strchars, in case this vim version does not
+" have it natively
+function! s:strchars(str)
+  if exists('*strchars')
+    return strchars(a:str)
+  else
+    return strlen(substitute(a:str, '.', 'a', 'g'))
+  endif
+endfunction
+
 function! airline#extensions#tabline#builder#new(context)
   let builder = airline#builder#new(a:context)
   call extend(builder, s:prototype, 'force')

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -5,39 +5,39 @@ scriptencoding utf-8
 
 let s:prototype = {}
 
-function! s:prototype.insert_titles(curtab, first_tab, last_tab) dict
-  let self._first_tab = a:first_tab
-  let self._last_tab = a:last_tab
-  let self._left_tab = a:curtab
-  let self._right_tab = a:curtab + 1
+function! s:prototype.insert_titles(current, first, last) dict
+  let self._first_title = a:first
+  let self._last_title = a:last
+  let self._left_title = a:current
+  let self._right_title = a:current + 1
   let self._left_position = self.get_position()
   let self._right_position = self._left_position
 endfunction
 
-function! s:prototype.try_insert_title(tab, group, pos, sep_size, force) dict
-  let tab_title = self.get_title(a:tab)
-  let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + a:sep_size
+function! s:prototype.try_insert_title(index, group, pos, sep_size, force) dict
+  let title = self.get_title(a:index)
+  let self._remaining_space -= s:strchars(s:evaluate_tabline(title)) + a:sep_size
   if a:force || self._remaining_space >= 0
     let pos = a:pos
     if has_key(self, "get_pretitle")
-      call self.insert_raw(self.get_pretitle(a:tab), pos)
+      call self.insert_raw(self.get_pretitle(a:index), pos)
       let self._right_position += 1
       let pos += 1
     endif
 
-    call self.insert_section(a:group, tab_title, pos)
+    call self.insert_section(a:group, title, pos)
     let self._right_position += 1
     let pos += 1
 
     if has_key(self, "get_posttitle")
-      call self.insert_raw(self.get_posttitle(a:tab), pos)
+      call self.insert_raw(self.get_posttitle(a:index), pos)
       let self._right_position += 1
       let pos += 1
     endif
 
     return 1
   else
-    let self._remaining_space += s:strchars(s:evaluate_tabline(tab_title)) + a:sep_size
+    let self._remaining_space += s:strchars(s:evaluate_tabline(title)) + a:sep_size
   endif
   return 0
 endfunction
@@ -73,55 +73,55 @@ function! s:prototype.build() dict
     let outer_left_group = airline#builder#get_prev_group(self._sections, self._left_position)
     let outer_right_group = airline#builder#get_next_group(self._sections, self._right_position)
 
-    " Add the current tab
-    let group = self.get_group(self._left_tab)
+    " Add the current title
+    let group = self.get_group(self._left_title)
     let sep_change =
       \ s:get_separator_change(group, "", outer_left_group, sep_size, alt_sep_size) +
       \ s:get_separator_change(group, "", outer_right_group, sep_size, alt_sep_size)
     let left_group = group
     let right_group = group
-    let self._left_tab -=
-      \ self.try_insert_title(self._left_tab, group, self._left_position, sep_change, 1)
+    let self._left_title -=
+      \ self.try_insert_title(self._left_title, group, self._left_position, sep_change, 1)
 
     if get(g:, 'airline#extensions#tabline#current_first', 0)
-      " always have current tabpage first
+      " always have current title first
       let self._left_position += 1
     endif
 
-    " Add the tab to the right
-    if !center_active && self._right_tab <= self._last_tab
-      let group = self.get_group(self._right_tab)
+    " Add the title to the right
+    if !center_active && self._right_title <= self._last_title
+      let group = self.get_group(self._right_title)
       let sep_change =
         \ s:get_separator_change(group, right_group, outer_right_group, sep_size, alt_sep_size)
       let right_group = group
-      let self._right_tab +=
-      \ self.try_insert_title(self._right_tab, group, self._right_position, sep_change, 1)
+      let self._right_title +=
+      \ self.try_insert_title(self._right_title, group, self._right_position, sep_change, 1)
     endif
 
     while self._remaining_space > 0
       let done = 0
-      if self._left_tab >= self._first_tab
-        let group = self.get_group(self._left_tab)
+      if self._left_title >= self._first_title
+        let group = self.get_group(self._left_title)
         let sep_change =
           \ s:get_separator_change(group, left_group, outer_left_group, sep_size, alt_sep_size)
         let left_group = group
-        let done = self.try_insert_title(self._left_tab, group, self._left_position, sep_change, 0)
-        let self._left_tab -= done
+        let done = self.try_insert_title(self._left_title, group, self._left_position, sep_change, 0)
+        let self._left_title -= done
       endif
-      if self._right_tab <= self._last_tab && (center_active || !done)
-        let group = self.get_group(self._right_tab)
+      if self._right_title <= self._last_title && (center_active || !done)
+        let group = self.get_group(self._right_title)
         let sep_change =
           \ s:get_separator_change(group, right_group, outer_right_group, sep_size, alt_sep_size)
         let right_group = group
-        let done = self.try_insert_title(self._right_tab, group, self._right_position, sep_change, 0)
-        let self._right_tab += done
+        let done = self.try_insert_title(self._right_title, group, self._right_position, sep_change, 0)
+        let self._right_title += done
       endif
       if !done
         break
       endif
     endwhile
 
-    if self._left_tab >= self._first_tab
+    if self._left_title >= self._first_title
       if get(g:, 'airline#extensions#tabline#current_first', 0)
         let self._left_position -= 1
       endif
@@ -129,7 +129,7 @@ function! s:prototype.build() dict
       let self._right_position += 1
     endif
 
-    if self._right_tab <= self._last_tab
+    if self._right_title <= self._last_title
       call self.insert_raw('%#'.self.overflow_group.'#'.overflow_marker, self._right_position)
     endif
   endif

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -16,7 +16,7 @@ endfunction
 
 function! s:prototype.try_insert_title(index, group, pos, sep_size, force) dict
   let title = self.get_title(a:index)
-  let self._remaining_space -= airline#util#strchars(s:evaluate_tabline(title)) + a:sep_size
+  let self._remaining_space -= s:tabline_evaluated_length(title) + a:sep_size
   if a:force || self._remaining_space >= 0
     let pos = a:pos
     if has_key(self, "get_pretitle")
@@ -37,7 +37,7 @@ function! s:prototype.try_insert_title(index, group, pos, sep_size, force) dict
 
     return 1
   else
-    let self._remaining_space += airline#util#strchars(s:evaluate_tabline(title)) + a:sep_size
+    let self._remaining_space += s:tabline_evaluated_length(title) + a:sep_size
   endif
   return 0
 endfunction
@@ -58,15 +58,15 @@ endfunction
 
 function! s:prototype.build() dict
   if has_key(self, '_left_position')
-    let self._remaining_space = &columns - airline#util#strchars(s:evaluate_tabline(self._build()))
+    let self._remaining_space = &columns - s:tabline_evaluated_length(self._build())
 
     let center_active = get(g:, 'airline#extensions#tabline#center_active', 0)
 
-    let sep_size = airline#util#strchars(s:evaluate_tabline(self._context.left_sep))
-    let alt_sep_size = airline#util#strchars(s:evaluate_tabline(self._context.left_alt_sep))
+    let sep_size = s:tabline_evaluated_length(self._context.left_sep)
+    let alt_sep_size = s:tabline_evaluated_length(self._context.left_alt_sep)
 
     let overflow_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-    let overflow_marker_size = airline#util#strchars(s:evaluate_tabline(overflow_marker))
+    let overflow_marker_size = s:tabline_evaluated_length(overflow_marker)
     " Allow space for the markers before we begin filling in titles.
     let self._remaining_space -= 2 * overflow_marker_size
 
@@ -151,6 +151,10 @@ function! s:evaluate_tabline(tabline)
     let tabline = substitute(tabline, '%@[^@]\+@', '', 'g')
   endif
   return tabline
+endfunction
+
+function! s:tabline_evaluated_length(tabline)
+  return airline#util#strchars(s:evaluate_tabline(a:tabline))
 endfunction
 
 function! airline#extensions#tabline#builder#new(context)

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -6,19 +6,16 @@ scriptencoding utf-8
 let s:prototype = {}
 
 function! s:prototype.insert_tabs(curtab) dict
-  let self._tabs_position = self.get_position()
-  let self._curtab = a:curtab
+  let self._left_tab = a:curtab
+  let self._right_tab = a:curtab + 1
+  let self._left_position = self.get_position()
+  let self._right_position = self._left_position
 endfunction
 
 function! s:prototype.build() dict
-  if has_key(self, "_tabs_position")
+  if has_key(self, '_left_position')
     let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
     let num_tabs = tabpagenr('$')
-    let curtab = self._curtab
-    let self._left_tab = curtab - 1
-    let self._right_tab = curtab + 1
-    let self._left_position = self._tabs_position
-    let self._right_position = self._tabs_position + 1
     let remaining_space = &columns - s:strchars(s:evaluate_tabline(self._build()))
 
     let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
@@ -30,12 +27,14 @@ function! s:prototype.build() dict
     let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
 
     " Add the current tab
-    let tab_title = self.get_title(tab_nr_type, curtab)
+    let tab_title = self.get_title(tab_nr_type, self._left_tab)
     let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
     " There are always two left_seps (either side of the selected tab) and all
     " other seperators are left_alt_seps.
     let remaining_space -= 2 * left_sep_size - left_alt_sep_size
-    call self.insert_section(self.get_group(curtab), tab_title, self._left_position)
+    call self.insert_section(self.get_group(self._left_tab), tab_title, self._left_position)
+    let self._right_position += 1
+    let self._left_tab -= 1
 
     if get(g:, 'airline#extensions#tabline#current_first', 0)
       " always have current tabpage first

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -87,17 +87,19 @@ function! s:prototype.build() dict
       if get(g:, 'airline#extensions#tabline#current_first', 0)
         let self._left_position -= 1
       endif
-      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, self._left_position)
+      call self.insert_raw('%#'.self.overflow_group.'#'.skipped_tabs_marker, self._left_position)
       let self._right_position += 1
     endif
 
     if self._right_tab <= self._last_tab
-      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, self._right_position)
+      call self.insert_raw('%#'.self.overflow_group.'#'.skipped_tabs_marker, self._right_position)
     endif
   endif
 
   return self._build()
 endfunction
+
+let s:prototype.overflow_group = 'airline_tab'
 
 function! s:evaluate_tabline(tabline)
   let tabline = a:tabline

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -5,8 +5,9 @@ scriptencoding utf-8
 
 let s:prototype = {}
 
-function! s:prototype.insert_tabs(curtab, numtabs) dict
-  let self._num_tabs = a:numtabs
+function! s:prototype.insert_tabs(curtab, first_tab, last_tab) dict
+  let self._first_tab = a:first_tab
+  let self._last_tab = a:last_tab
   let self._left_tab = a:curtab
   let self._right_tab = a:curtab + 1
   let self._left_position = self.get_position()
@@ -65,16 +66,16 @@ function! s:prototype.build() dict
     endif
 
     " Add the tab to the right
-    if self._right_tab <= self._num_tabs
+    if self._right_tab <= self._last_tab
       let self._right_tab +=
       \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 1)
     endif
 
     while self._remaining_space > 0
-      if self._left_tab > 0
+      if self._left_tab >= self._first_tab
         let self._left_tab -=
           \ self.try_insert_tab(self._left_tab, self._left_position, left_alt_sep_size, 0)
-      elseif self._right_tab <= self._num_tabs
+      elseif self._right_tab <= self._last_tab
         let self._right_tab +=
           \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 0)
       else
@@ -82,7 +83,7 @@ function! s:prototype.build() dict
       endif
     endwhile
 
-    if self._left_tab > 0
+    if self._left_tab >= self._first_tab
       if get(g:, 'airline#extensions#tabline#current_first', 0)
         let self._left_position -= 1
       endif
@@ -90,7 +91,7 @@ function! s:prototype.build() dict
       let self._right_position += 1
     endif
 
-    if self._right_tab <= self._num_tabs
+    if self._right_tab <= self._last_tab
       call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, self._right_position)
     endif
   endif

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -40,8 +40,8 @@ endfunction
 " object, if the title is inserted.
 function! s:prototype.try_insert_title(index, group, pos, sep_size, force) dict
   let title = self.get_title(a:index)
-  let self._remaining_space -= s:tabline_evaluated_length(title) + a:sep_size
-  if a:force || self._remaining_space >= 0
+  let title_size = s:tabline_evaluated_length(title) + a:sep_size
+  if a:force || self._remaining_space >= title_size
     let pos = a:pos
     if has_key(self, "get_pretitle")
       call self.insert_raw(self.get_pretitle(a:index), pos)
@@ -59,9 +59,8 @@ function! s:prototype.try_insert_title(index, group, pos, sep_size, force) dict
       let pos += 1
     endif
 
+    let self._remaining_space -= title_size
     return 1
-  else
-    let self._remaining_space += s:tabline_evaluated_length(title) + a:sep_size
   endif
   return 0
 endfunction

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -16,7 +16,7 @@ endfunction
 
 function! s:prototype.try_insert_title(index, group, pos, sep_size, force) dict
   let title = self.get_title(a:index)
-  let self._remaining_space -= s:strchars(s:evaluate_tabline(title)) + a:sep_size
+  let self._remaining_space -= airline#util#strchars(s:evaluate_tabline(title)) + a:sep_size
   if a:force || self._remaining_space >= 0
     let pos = a:pos
     if has_key(self, "get_pretitle")
@@ -37,7 +37,7 @@ function! s:prototype.try_insert_title(index, group, pos, sep_size, force) dict
 
     return 1
   else
-    let self._remaining_space += s:strchars(s:evaluate_tabline(title)) + a:sep_size
+    let self._remaining_space += airline#util#strchars(s:evaluate_tabline(title)) + a:sep_size
   endif
   return 0
 endfunction
@@ -58,15 +58,15 @@ endfunction
 
 function! s:prototype.build() dict
   if has_key(self, '_left_position')
-    let self._remaining_space = &columns - s:strchars(s:evaluate_tabline(self._build()))
+    let self._remaining_space = &columns - airline#util#strchars(s:evaluate_tabline(self._build()))
 
     let center_active = get(g:, 'airline#extensions#tabline#center_active', 0)
 
-    let sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
-    let alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
+    let sep_size = airline#util#strchars(s:evaluate_tabline(self._context.left_sep))
+    let alt_sep_size = airline#util#strchars(s:evaluate_tabline(self._context.left_alt_sep))
 
     let overflow_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-    let overflow_marker_size = s:strchars(s:evaluate_tabline(overflow_marker))
+    let overflow_marker_size = airline#util#strchars(s:evaluate_tabline(overflow_marker))
     " Allow space for the markers before we begin filling in titles.
     let self._remaining_space -= 2 * overflow_marker_size
 
@@ -151,16 +151,6 @@ function! s:evaluate_tabline(tabline)
     let tabline = substitute(tabline, '%@[^@]\+@', '', 'g')
   endif
   return tabline
-endfunction
-
-" Compatibility wrapper for strchars, in case this vim version does not
-" have it natively
-function! s:strchars(str)
-  if exists('*strchars')
-    return strchars(a:str)
-  else
-    return strlen(substitute(a:str, '.', 'a', 'g'))
-  endif
 endfunction
 
 function! airline#extensions#tabline#builder#new(context)

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -15,10 +15,10 @@ function! s:prototype.build() dict
     let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
     let num_tabs = tabpagenr('$')
     let curtab = self._curtab
-    let left_tab = curtab - 1
-    let right_tab = curtab + 1
-    let left_position = self._tabs_position
-    let right_position = self._tabs_position + 1
+    let self._left_tab = curtab - 1
+    let self._right_tab = curtab + 1
+    let self._left_position = self._tabs_position
+    let self._right_position = self._tabs_position + 1
     let remaining_space = &columns - s:strchars(s:evaluate_tabline(self._build()))
 
     let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
@@ -35,54 +35,54 @@ function! s:prototype.build() dict
     " There are always two left_seps (either side of the selected tab) and all
     " other seperators are left_alt_seps.
     let remaining_space -= 2 * left_sep_size - left_alt_sep_size
-    call self.insert_section(self.get_group(curtab), tab_title, left_position)
+    call self.insert_section(self.get_group(curtab), tab_title, self._left_position)
 
     if get(g:, 'airline#extensions#tabline#current_first', 0)
       " always have current tabpage first
-      let left_position += 1
+      let self._left_position += 1
     endif
 
     " Add the tab to the right
-    if right_tab <= num_tabs
-      let tab_title = self.get_title(tab_nr_type, right_tab)
+    if self._right_tab <= num_tabs
+      let tab_title = self.get_title(tab_nr_type, self._right_tab)
       let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-      call self.insert_section(self.get_group(right_tab), tab_title, right_position)
-      let right_position += 1
-      let right_tab += 1
+      call self.insert_section(self.get_group(self._right_tab), tab_title, self._right_position)
+      let self._right_position += 1
+      let self._right_tab += 1
     endif
 
     while remaining_space > 0
-      if left_tab > 0
-        let tab_title = self.get_title(tab_nr_type, left_tab)
+      if self._left_tab > 0
+        let tab_title = self.get_title(tab_nr_type, self._left_tab)
         let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
         if remaining_space >= 0
-          call self.insert_section(self.get_group(left_tab), tab_title, left_position)
-          let right_position += 1
-          let left_tab -= 1
+          call self.insert_section(self.get_group(self._left_tab), tab_title, self._left_position)
+          let self._right_position += 1
+          let self._left_tab -= 1
         endif
-      elseif right_tab <= num_tabs
-        let tab_title = self.get_title(tab_nr_type, right_tab)
+      elseif self._right_tab <= num_tabs
+        let tab_title = self.get_title(tab_nr_type, self._right_tab)
         let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
         if remaining_space >= 0
-          call self.insert_section(self.get_group(right_tab), tab_title, right_position)
-          let right_position += 1
-          let right_tab += 1
+          call self.insert_section(self.get_group(self._right_tab), tab_title, self._right_position)
+          let self._right_position += 1
+          let self._right_tab += 1
         endif
       else
         break
       endif
     endwhile
 
-    if left_tab > 0
+    if self._left_tab > 0
       if get(g:, 'airline#extensions#tabline#current_first', 0)
-        let left_position -= 1
+        let self._left_position -= 1
       endif
-      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, left_position)
-      let right_position += 1
+      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, self._left_position)
+      let self._right_position += 1
     endif
 
-    if right_tab <= num_tabs
-      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, right_position)
+    if self._right_tab <= num_tabs
+      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, self._right_position)
     endif
   endif
 

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -1,0 +1,12 @@
+" MIT License. Copyright (c) 2013-2018 Bailey Ling et al.
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+let s:prototype = {}
+
+function! airline#extensions#tabline#builder#new(context)
+  let builder = airline#builder#new(a:context)
+  call extend(builder, s:prototype, 'force')
+  return builder
+endfunction

--- a/autoload/airline/extensions/tabline/builder.vim
+++ b/autoload/airline/extensions/tabline/builder.vim
@@ -12,8 +12,8 @@ function! s:prototype.insert_tabs(curtab) dict
   let self._right_position = self._left_position
 endfunction
 
-function! s:prototype.try_insert_tab(tab, pos, tab_nr_type, sep_size, force) dict
-  let tab_title = self.get_title(a:tab_nr_type, a:tab)
+function! s:prototype.try_insert_tab(tab, pos, sep_size, force) dict
+  let tab_title = self.get_title(a:tab)
   let self._remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + a:sep_size
   if a:force || self._remaining_space >= 0
     call self.insert_section(self.get_group(a:tab), tab_title, a:pos)
@@ -25,7 +25,6 @@ endfunction
 
 function! s:prototype.build() dict
   if has_key(self, '_left_position')
-    let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
     let num_tabs = tabpagenr('$')
     let self._remaining_space = &columns - s:strchars(s:evaluate_tabline(self._build()))
 
@@ -43,7 +42,7 @@ function! s:prototype.build() dict
 
     " Add the current tab
     let self._left_tab -=
-      \ self.try_insert_tab(self._left_tab, self._left_position, tab_nr_type, left_sep_size, 1)
+      \ self.try_insert_tab(self._left_tab, self._left_position, left_sep_size, 1)
 
     if get(g:, 'airline#extensions#tabline#current_first', 0)
       " always have current tabpage first
@@ -53,16 +52,16 @@ function! s:prototype.build() dict
     " Add the tab to the right
     if self._right_tab <= num_tabs
       let self._right_tab +=
-      \ self.try_insert_tab(self._right_tab, self._right_position, tab_nr_type, left_alt_sep_size, 1)
+      \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 1)
     endif
 
     while self._remaining_space > 0
       if self._left_tab > 0
         let self._left_tab -=
-          \ self.try_insert_tab(self._left_tab, self._left_position, tab_nr_type, left_alt_sep_size, 0)
+          \ self.try_insert_tab(self._left_tab, self._left_position, left_alt_sep_size, 0)
       elseif self._right_tab <= num_tabs
         let self._right_tab +=
-          \ self.try_insert_tab(self._right_tab, self._right_position, tab_nr_type, left_alt_sep_size, 0)
+          \ self.try_insert_tab(self._right_tab, self._right_position, left_alt_sep_size, 0)
       else
         break
       endif

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -31,7 +31,7 @@ function! s:evaluate_tabline(tabline)
   let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
   let tabline = substitute(tabline, '%(\([^)]\+\)%)', '\1', 'g')
   let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
-  let tabline = substitute(tabline, '%=', '  ', 'g')
+  let tabline = substitute(tabline, '%=', '', 'g')
   let tabline = substitute(tabline, '%\d*\*', '', 'g')
   return tabline
 endfunction

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -25,27 +25,6 @@ function! airline#extensions#tabline#tabs#invalidate()
   let s:current_bufnr = -1
 endfunction
 
-function! s:evaluate_tabline(tabline)
-  let tabline = a:tabline
-  let tabline = substitute(tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
-  let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
-  let tabline = substitute(tabline, '%(\([^)]\+\)%)', '\1', 'g')
-  let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
-  let tabline = substitute(tabline, '%=', '', 'g')
-  let tabline = substitute(tabline, '%\d*\*', '', 'g')
-  return tabline
-endfunction
-
-" Compatibility wrapper for strchars, in case this vim version does not
-" have it natively
-function! s:strchars(str)
-  if exists('*strchars')
-    return strchars(a:str)
-  else
-    return strlen(substitute(a:str, '.', 'a', 'g'))
-  endif
-endfunction
-
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -111,79 +90,6 @@ function! airline#extensions#tabline#tabs#get()
     return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
   endfunction
 
-  function! b.insert_tabs(tabs_position, curtab) dict
-    let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
-    let num_tabs = tabpagenr('$')
-    let left_tab = a:curtab - 1
-    let right_tab = a:curtab + 1
-    let left_position = a:tabs_position
-    let right_position = a:tabs_position + 1
-    let remaining_space = &columns - s:strchars(s:evaluate_tabline(self.build()))
-
-    let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
-    let left_alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
-
-    let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-    let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
-    " The left marker will have left_alt_sep, and the right will have left_sep.
-    let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
-
-    " Add the current tab
-    let tab_title = self.get_title(tab_nr_type, a:curtab)
-    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
-    " There are always two left_seps (either side of the selected tab) and all
-    " other seperators are left_alt_seps.
-    let remaining_space -= 2 * left_sep_size - left_alt_sep_size
-    call self.insert_section(self.get_group(a:curtab), tab_title, left_position)
-
-    if get(g:, 'airline#extensions#tabline#current_first', 0)
-      " always have current tabpage first
-      let left_position += 1
-    endif
-
-    " Add the tab to the right
-    if right_tab <= num_tabs
-      let tab_title = self.get_title(tab_nr_type, right_tab)
-      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-      call self.insert_section(self.get_group(right_tab), tab_title, right_position)
-      let right_position += 1
-      let right_tab += 1
-    endif
-
-    while remaining_space > 0
-      if left_tab > 0
-        let tab_title = self.get_title(tab_nr_type, left_tab)
-        let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-        if remaining_space >= 0
-          call self.insert_section(self.get_group(left_tab), tab_title, left_position)
-          let right_position += 1
-          let left_tab -= 1
-        endif
-      elseif right_tab <= num_tabs
-        let tab_title = self.get_title(tab_nr_type, right_tab)
-        let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-        if remaining_space >= 0
-          call self.insert_section(self.get_group(right_tab), tab_title, right_position)
-          let right_position += 1
-          let right_tab += 1
-        endif
-      else
-        break
-      endif
-    endwhile
-
-    if left_tab > 0
-      if get(g:, 'airline#extensions#tabline#current_first', 0)
-        let left_position -= 1
-      endif
-      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, left_position)
-      let right_position += 1
-    endif
-
-    if right_tab <= num_tabs
-      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, right_position)
-    endif
-  endfunction
   call b.insert_tabs(tabs_position, curtab)
 
   let s:current_bufnr = curbuf

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -105,7 +105,7 @@ function! airline#extensions#tabline#tabs#get()
   call airline#extensions#tabline#add_label(b, 'tabs')
   for i in s:get_visible_tabs()
     if i < 0
-      call b.add_raw('%#airline_tabhid#...')
+      call b.add_raw('%#airline_tab#...')
       continue
     endif
     if i == curtab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -60,11 +60,12 @@ function! airline#extensions#tabline#tabs#get()
     return group
   endfunction
 
-  function! b.get_title(tab_nr_type, i) dict
+  function! b.get_title(i) dict
     let val = '%('
 
     if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
-      let val .= airline#extensions#tabline#tabs#tabnr_formatter(a:tab_nr_type, a:i)
+      let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
+      let val .= airline#extensions#tabline#tabs#tabnr_formatter(tab_nr_type, a:i)
     endif
 
     return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -46,6 +46,16 @@ function! s:get_title(tab_nr_type, i)
   return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
 endfunction
 
+" Compatibility wrapper for strchars, in case this vim version does not
+" have it natively
+function! s:strchars(str)
+  if exists('*strchars')
+    return strchars(a:str)
+  else
+    return strlen(substitute(a:str, '.', 'a', 'g'))
+  endif
+endfunction
+
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -91,14 +101,14 @@ function! airline#extensions#tabline#tabs#get()
   let right_tab = curtab + 1
   let left_position = tabs_position
   let right_position = tabs_position + 1
-  let remaining_space = &columns - strlen(s:evaluate_tabline(b.build()))
+  let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
 
   let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#skipped_tabs_marker', '...')
-  let remaining_space -= 4 + 2 * strlen(s:evaluate_tabline(skipped_tabs_marker))
+  let remaining_space -= 4 + 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
 
   " Add the current tab
   let tab_title = s:get_title(tab_nr_type, curtab)
-  let remaining_space -= strlen(s:evaluate_tabline(tab_title)) + 1
+  let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
   let group = 'airline_tabsel'
   if g:airline_detect_modified
     for bi in tabpagebuflist(curtab)
@@ -118,7 +128,7 @@ function! airline#extensions#tabline#tabs#get()
   " Add the tab to the right
   if right_tab <= num_tabs
     let tab_title = s:get_title(tab_nr_type, right_tab)
-    let remaining_space -= strlen(s:evaluate_tabline(tab_title)) + 1
+    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
     call b.insert_section('airline_tab', tab_title, right_position)
     let right_position += 1
     let right_tab += 1
@@ -127,7 +137,7 @@ function! airline#extensions#tabline#tabs#get()
   while remaining_space > 0
     if left_tab > 0
       let tab_title = s:get_title(tab_nr_type, left_tab)
-      let remaining_space -= strlen(s:evaluate_tabline(tab_title)) + 1
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
       if remaining_space >= 0
         call b.insert_section('airline_tab', tab_title, left_position)
         let right_position += 1
@@ -135,7 +145,7 @@ function! airline#extensions#tabline#tabs#get()
       endif
     elseif right_tab <= num_tabs
       let tab_title = s:get_title(tab_nr_type, right_tab)
-      let remaining_space -= strlen(s:evaluate_tabline(tab_title)) + 1
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
       if remaining_space >= 0
         call b.insert_section('airline_tab', tab_title, right_position)
         let right_position += 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -29,7 +29,7 @@ function! s:evaluate_tabline(tabline)
   let tabline = a:tabline
   let tabline = substitute(tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
   let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
-  let tabline = substitute(tabline, '%(\([^)]\+\))', '\1', 'g')
+  let tabline = substitute(tabline, '%(\([^)]\+\)%)', '\1', 'g')
   let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
   let tabline = substitute(tabline, '%=', '  ', 'g')
   let tabline = substitute(tabline, '%\d*\*', '', 'g')

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -31,7 +31,7 @@ function! s:evaluate_tabline(tabline)
   let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
   let tabline = substitute(tabline, '%(\([^)]\+\))', '\1', 'g')
   let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
-  let tabline = substitute(tabline, '%=', '', 'g')
+  let tabline = substitute(tabline, '%=', '  ', 'g')
   let tabline = substitute(tabline, '%\d*\*', '', 'g')
   return tabline
 endfunction
@@ -91,7 +91,10 @@ function! airline#extensions#tabline#tabs#get()
   let right_tab = curtab + 1
   let left_position = tabs_position
   let right_position = tabs_position + 1
-  let remaining_space = &columns - strlen(s:evaluate_tabline(b.build())) - 8
+  let remaining_space = &columns - strlen(s:evaluate_tabline(b.build()))
+
+  let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#skipped_tabs_marker', '...')
+  let remaining_space -= 4 + 2 * strlen(s:evaluate_tabline(skipped_tabs_marker))
 
   " Add the current tab
   let tab_title = s:get_title(tab_nr_type, curtab)
@@ -147,12 +150,12 @@ function! airline#extensions#tabline#tabs#get()
     if get(g:, 'airline#extensions#tabline#current_first', 0)
       let left_position -= 1
     endif
-    call b.insert_raw('%#airline_tab#...', left_position)
+    call b.insert_raw('%#airline_tab#'.skipped_tabs_marker, left_position)
     let right_position += 1
   endif
 
   if right_tab <= num_tabs
-    call b.insert_raw('%#airline_tab#...', right_position)
+    call b.insert_raw('%#airline_tab#'.skipped_tabs_marker, right_position)
   endif
 
   let s:current_bufnr = curbuf

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -98,6 +98,16 @@ function! s:evaluate_tabline(tabline)
   return tabline
 endfunction
 
+function! s:get_title(tab_nr_type, i)
+  let val = '%('
+
+  if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
+    let val .= airline#extensions#tabline#tabs#tabnr_formatter(a:tab_nr_type, a:i)
+  endif
+
+  return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
+endfunction
+
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -141,13 +151,7 @@ function! airline#extensions#tabline#tabs#get()
 
   let tab_titles = []
   for i in range(1, tabpagenr('$'))
-    let val = '%('
-
-    if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
-      let val .= airline#extensions#tabline#tabs#tabnr_formatter(tab_nr_type, i)
-    endif
-
-    call add(tab_titles, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)')
+    call add(tab_titles, s:get_title(tab_nr_type, i))
   endfor
 
   for i in s:get_visible_tabs(&columns - strlen(b_tabline), tab_titles)

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -102,9 +102,31 @@ function! airline#extensions#tabline#tabs#get()
   let b = airline#extensions#tabline#new_builder()
 
   call airline#extensions#tabline#add_label(b, 'tabs')
+
+  let tabs_position = b.get_position()
+
+  call b.add_section('airline_tabfill', '')
+  call b.split()
+  call b.add_section('airline_tabfill', '')
+
+  if get(g:, 'airline#extensions#tabline#show_close_button', 1)
+    call b.add_section('airline_tab_right', ' %999X'.
+          \ get(g:, 'airline#extensions#tabline#close_symbol', 'X').' ')
+  endif
+
+  if get(g:, 'airline#extensions#tabline#show_splits', 1) == 1
+    let buffers = tabpagebuflist(curtab)
+    for nr in buffers
+      let group = airline#extensions#tabline#group_of_bufnr(buffers, nr) . "_right"
+      call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
+    endfor
+    call airline#extensions#tabline#add_label(b, 'buffers')
+  endif
+
   for i in s:get_visible_tabs(&columns)
     if i < 0
-      call b.add_raw('%#airline_tab#...')
+      call b.insert_raw('%#airline_tab#...', tabs_position)
+      let tabs_position += 1
       continue
     endif
     if i == curtab
@@ -125,26 +147,9 @@ function! airline#extensions#tabline#tabs#get()
     if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
       let val .= airline#extensions#tabline#tabs#tabnr_formatter(tab_nr_type, i)
     endif
-    call b.add_section(group, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)')
+    call b.insert_section(group, val.'%'.i.'T %{airline#extensions#tabline#title('.i.')} %)', tabs_position)
+    let tabs_position += 1
   endfor
-
-  call b.add_section('airline_tabfill', '')
-  call b.split()
-  call b.add_section('airline_tabfill', '')
-
-  if get(g:, 'airline#extensions#tabline#show_close_button', 1)
-    call b.add_section('airline_tab_right', ' %999X'.
-          \ get(g:, 'airline#extensions#tabline#close_symbol', 'X').' ')
-  endif
-
-  if get(g:, 'airline#extensions#tabline#show_splits', 1) == 1
-    let buffers = tabpagebuflist(curtab)
-    for nr in buffers
-      let group = airline#extensions#tabline#group_of_bufnr(buffers, nr) . "_right"
-      call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
-    endfor
-    call airline#extensions#tabline#add_label(b, 'buffers')
-  endif
 
   let s:current_bufnr = curbuf
   let s:current_tabnr = curtab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -25,7 +25,7 @@ function! airline#extensions#tabline#tabs#invalidate()
   let s:current_bufnr = -1
 endfunction
 
-function! s:get_visible_tabs()
+function! s:get_visible_tabs(width)
   let tablist = range(1, tabpagenr('$'))
   let curbuf = bufnr('%')
 
@@ -48,13 +48,12 @@ function! s:get_visible_tabs()
 
   " only show current and surrounding tabs if there are too many tabs
   let position  = index(tablist, curbuf)
-  let vimwidth = &columns
-  if total_width > vimwidth && position > -1
+  if total_width > a:width && position > -1
     let tab_count = len(tablist)
 
     " determine how many tabs to show based on the longest tab width,
     " use one on the right side and put the rest on the left
-    let tab_max   = vimwidth / max_width
+    let tab_max   = a:width / max_width
     let tab_right = 1
     let tab_left  = max([0, tab_max - tab_right])
 
@@ -103,7 +102,7 @@ function! airline#extensions#tabline#tabs#get()
   let b = airline#extensions#tabline#new_builder()
 
   call airline#extensions#tabline#add_label(b, 'tabs')
-  for i in s:get_visible_tabs()
+  for i in s:get_visible_tabs(&columns)
     if i < 0
       call b.add_raw('%#airline_tab#...')
       continue

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -104,7 +104,7 @@ function! airline#extensions#tabline#tabs#get()
   let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
 
   let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-  let remaining_space -= 4 + 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+  let remaining_space -= 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
 
   " Add the current tab
   let tab_title = s:get_title(tab_nr_type, curtab)

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -71,7 +71,7 @@ function! airline#extensions#tabline#tabs#get()
     return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
   endfunction
 
-  call b.insert_tabs(curtab, 1, tabpagenr('$'))
+  call b.insert_titles(curtab, 1, tabpagenr('$'))
 
   call b.add_section('airline_tabfill', '')
   call b.split()

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -123,7 +123,15 @@ function! airline#extensions#tabline#tabs#get()
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
 
-  for i in s:get_visible_tabs(&columns)
+  let b_tabline = b.build()
+  let b_tabline = substitute(b_tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
+  let b_tabline = substitute(b_tabline, '%#[^#]\+#', '', 'g')
+  let b_tabline = substitute(b_tabline, '%(\([^)]\+\))', '\1', 'g')
+  let b_tabline = substitute(b_tabline, '%\d\+[TX]', '', 'g')
+  let b_tabline = substitute(b_tabline, '%=', '', 'g')
+  let b_tabline = substitute(b_tabline, '%\d*\*', '', 'g')
+
+  for i in s:get_visible_tabs(&columns - strlen(b_tabline))
     if i < 0
       call b.insert_raw('%#airline_tab#...', tabs_position)
       let tabs_position += 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -46,14 +46,17 @@ function! s:get_visible_tabs(width, titles)
     let max_width = max([max_width, width])
   endfor
 
+  " leave space for end ellipsis (...) and the left/right split (2 spaces)
+  let tab_columns = a:width - 8
+
   " only show current and surrounding tabs if there are too many tabs
   let position  = index(tablist, curbuf)
-  if total_width > a:width && position > -1
+  if total_width > tab_columns && position > -1
     let tab_count = len(tablist)
 
     " determine how many tabs to show based on the longest tab width,
     " use one on the right side and put the rest on the left
-    let tab_max   = a:width / max_width
+    let tab_max   = tab_columns / max_width
     let tab_right = 1
     let tab_left  = max([0, tab_max - tab_right])
 

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -103,7 +103,7 @@ function! airline#extensions#tabline#tabs#get()
   let right_position = tabs_position + 1
   let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
 
-  let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#skipped_tabs_marker', '...')
+  let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
   let remaining_space -= 4 + 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
 
   " Add the current tab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -103,12 +103,20 @@ function! airline#extensions#tabline#tabs#get()
   let right_position = tabs_position + 1
   let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
 
+  let left_sep_size = s:strchars(s:evaluate_tabline(b._context.left_sep))
+  let left_alt_sep_size = s:strchars(s:evaluate_tabline(b._context.left_alt_sep))
+
   let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-  let remaining_space -= 2 * s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+  let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+  " The left marker will have left_alt_sep, and the right will have left_sep.
+  let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
 
   " Add the current tab
   let tab_title = s:get_title(tab_nr_type, curtab)
-  let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
+  let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
+  " There are always two left_seps (either side of the selected tab) and all
+  " other seperators are left_alt_seps.
+  let remaining_space -= 2 * left_sep_size - left_alt_sep_size
   let group = 'airline_tabsel'
   if g:airline_detect_modified
     for bi in tabpagebuflist(curtab)
@@ -128,7 +136,7 @@ function! airline#extensions#tabline#tabs#get()
   " Add the tab to the right
   if right_tab <= num_tabs
     let tab_title = s:get_title(tab_nr_type, right_tab)
-    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
+    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
     call b.insert_section('airline_tab', tab_title, right_position)
     let right_position += 1
     let right_tab += 1
@@ -137,7 +145,7 @@ function! airline#extensions#tabline#tabs#get()
   while remaining_space > 0
     if left_tab > 0
       let tab_title = s:get_title(tab_nr_type, left_tab)
-      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
       if remaining_space >= 0
         call b.insert_section('airline_tab', tab_title, left_position)
         let right_position += 1
@@ -145,7 +153,7 @@ function! airline#extensions#tabline#tabs#get()
       endif
     elseif right_tab <= num_tabs
       let tab_title = s:get_title(tab_nr_type, right_tab)
-      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + 1
+      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
       if remaining_space >= 0
         call b.insert_section('airline_tab', tab_title, right_position)
         let right_position += 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -71,7 +71,7 @@ function! airline#extensions#tabline#tabs#get()
     return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
   endfunction
 
-  call b.insert_tabs(curtab, tabpagenr('$'))
+  call b.insert_tabs(curtab, 1, tabpagenr('$'))
 
   call b.add_section('airline_tabfill', '')
   call b.split()

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -36,6 +36,23 @@ function! s:evaluate_tabline(tabline)
   return tabline
 endfunction
 
+function! s:get_group(i)
+  let curtab = tabpagenr()
+  let group = 'airline_tab'
+  if a:i == curtab
+    let group = 'airline_tabsel'
+    if g:airline_detect_modified
+      for bi in tabpagebuflist(curtab)
+        if getbufvar(bi, '&modified')
+          let group = 'airline_tabmod'
+        endif
+      endfor
+    endif
+    let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
+  endif
+  return group
+endfunction
+
 function! s:get_title(tab_nr_type, i)
   let val = '%('
 
@@ -116,16 +133,7 @@ function! airline#extensions#tabline#tabs#get()
   " There are always two left_seps (either side of the selected tab) and all
   " other seperators are left_alt_seps.
   let remaining_space -= 2 * left_sep_size - left_alt_sep_size
-  let group = 'airline_tabsel'
-  if g:airline_detect_modified
-    for bi in tabpagebuflist(curtab)
-      if getbufvar(bi, '&modified')
-        let group = 'airline_tabmod'
-      endif
-    endfor
-  endif
-  let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
-  call b.insert_section(group, tab_title, left_position)
+  call b.insert_section(s:get_group(curtab), tab_title, left_position)
 
   if get(g:, 'airline#extensions#tabline#current_first', 0)
     " always have current tabpage first
@@ -136,7 +144,7 @@ function! airline#extensions#tabline#tabs#get()
   if right_tab <= num_tabs
     let tab_title = s:get_title(tab_nr_type, right_tab)
     let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-    call b.insert_section('airline_tab', tab_title, right_position)
+    call b.insert_section(s:get_group(right_tab), tab_title, right_position)
     let right_position += 1
     let right_tab += 1
   endif
@@ -146,7 +154,7 @@ function! airline#extensions#tabline#tabs#get()
       let tab_title = s:get_title(tab_nr_type, left_tab)
       let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
       if remaining_space >= 0
-        call b.insert_section('airline_tab', tab_title, left_position)
+        call b.insert_section(s:get_group(left_tab), tab_title, left_position)
         let right_position += 1
         let left_tab -= 1
       endif
@@ -154,7 +162,7 @@ function! airline#extensions#tabline#tabs#get()
       let tab_title = s:get_title(tab_nr_type, right_tab)
       let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
       if remaining_space >= 0
-        call b.insert_section('airline_tab', tab_title, right_position)
+        call b.insert_section(s:get_group(right_tab), tab_title, right_position)
         let right_position += 1
         let right_tab += 1
       endif

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -25,6 +25,20 @@ function! airline#extensions#tabline#tabs#invalidate()
   let s:current_bufnr = -1
 endfunction
 
+function! s:get_tabs()
+  let tablist = range(1, tabpagenr('$'))
+  let curbuf = bufnr('%')
+
+  if get(g:, 'airline#extensions#tabline#current_first', 0)
+    " always have current tabpage first
+    if index(tablist, curtab) > -1
+      call remove(tablist, index(tablist, curtab))
+    endif
+    let tablist = [curtab] + tablist
+  endif
+  return tablist
+endfunction
+
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -43,15 +57,7 @@ function! airline#extensions#tabline#tabs#get()
   let b = airline#extensions#tabline#new_builder()
 
   call airline#extensions#tabline#add_label(b, 'tabs')
-  " always have current tabpage first
-  let tablist = range(1, tabpagenr('$'))
-  if get(g:, 'airline#extensions#tabline#current_first', 0)
-    if index(tablist, curtab) > -1
-      call remove(tablist, index(tablist, curtab))
-    endif
-    let tablist = [curtab] + tablist
-  endif
-  for i in tablist
+  for i in s:get_tabs()
     if i == curtab
       let group = 'airline_tabsel'
       if g:airline_detect_modified

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -43,26 +43,6 @@ function! airline#extensions#tabline#tabs#get()
 
   call airline#extensions#tabline#add_label(b, 'tabs')
 
-  let tabs_position = b.get_position()
-
-  call b.add_section('airline_tabfill', '')
-  call b.split()
-  call b.add_section('airline_tabfill', '')
-
-  if get(g:, 'airline#extensions#tabline#show_close_button', 1)
-    call b.add_section('airline_tab_right', ' %999X'.
-          \ get(g:, 'airline#extensions#tabline#close_symbol', 'X').' ')
-  endif
-
-  if get(g:, 'airline#extensions#tabline#show_splits', 1) == 1
-    let buffers = tabpagebuflist(curtab)
-    for nr in buffers
-      let group = airline#extensions#tabline#group_of_bufnr(buffers, nr) . "_right"
-      call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
-    endfor
-    call airline#extensions#tabline#add_label(b, 'buffers')
-  endif
-
   function! b.get_group(i) dict
     let curtab = tabpagenr()
     let group = 'airline_tab'
@@ -90,7 +70,25 @@ function! airline#extensions#tabline#tabs#get()
     return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
   endfunction
 
-  call b.insert_tabs(tabs_position, curtab)
+  call b.insert_tabs(curtab)
+
+  call b.add_section('airline_tabfill', '')
+  call b.split()
+  call b.add_section('airline_tabfill', '')
+
+  if get(g:, 'airline#extensions#tabline#show_close_button', 1)
+    call b.add_section('airline_tab_right', ' %999X'.
+          \ get(g:, 'airline#extensions#tabline#close_symbol', 'X').' ')
+  endif
+
+  if get(g:, 'airline#extensions#tabline#show_splits', 1) == 1
+    let buffers = tabpagebuflist(curtab)
+    for nr in buffers
+      let group = airline#extensions#tabline#group_of_bufnr(buffers, nr) . "_right"
+      call b.add_section_spaced(group, '%(%{airline#extensions#tabline#get_buffer_name('.nr.')}%)')
+    endfor
+    call airline#extensions#tabline#add_label(b, 'buffers')
+  endif
 
   let s:current_bufnr = curbuf
   let s:current_tabnr = curtab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -36,33 +36,6 @@ function! s:evaluate_tabline(tabline)
   return tabline
 endfunction
 
-function! s:get_group(i)
-  let curtab = tabpagenr()
-  let group = 'airline_tab'
-  if a:i == curtab
-    let group = 'airline_tabsel'
-    if g:airline_detect_modified
-      for bi in tabpagebuflist(curtab)
-        if getbufvar(bi, '&modified')
-          let group = 'airline_tabmod'
-        endif
-      endfor
-    endif
-    let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
-  endif
-  return group
-endfunction
-
-function! s:get_title(tab_nr_type, i)
-  let val = '%('
-
-  if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
-    let val .= airline#extensions#tabline#tabs#tabnr_formatter(a:tab_nr_type, a:i)
-  endif
-
-  return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
-endfunction
-
 " Compatibility wrapper for strchars, in case this vim version does not
 " have it natively
 function! s:strchars(str)
@@ -111,6 +84,33 @@ function! airline#extensions#tabline#tabs#get()
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
 
+  function! b.get_group(i) dict
+    let curtab = tabpagenr()
+    let group = 'airline_tab'
+    if a:i == curtab
+      let group = 'airline_tabsel'
+      if g:airline_detect_modified
+        for bi in tabpagebuflist(curtab)
+          if getbufvar(bi, '&modified')
+            let group = 'airline_tabmod'
+          endif
+        endfor
+      endif
+      let s:current_modified = (group == 'airline_tabmod') ? 1 : 0
+    endif
+    return group
+  endfunction
+
+  function! b.get_title(tab_nr_type, i) dict
+    let val = '%('
+
+    if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
+      let val .= airline#extensions#tabline#tabs#tabnr_formatter(a:tab_nr_type, a:i)
+    endif
+
+    return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
+  endfunction
+
   function! b.insert_tabs(tabs_position, curtab) dict
     let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
     let num_tabs = tabpagenr('$')
@@ -129,12 +129,12 @@ function! airline#extensions#tabline#tabs#get()
     let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
 
     " Add the current tab
-    let tab_title = s:get_title(tab_nr_type, a:curtab)
+    let tab_title = self.get_title(tab_nr_type, a:curtab)
     let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
     " There are always two left_seps (either side of the selected tab) and all
     " other seperators are left_alt_seps.
     let remaining_space -= 2 * left_sep_size - left_alt_sep_size
-    call self.insert_section(s:get_group(a:curtab), tab_title, left_position)
+    call self.insert_section(self.get_group(a:curtab), tab_title, left_position)
 
     if get(g:, 'airline#extensions#tabline#current_first', 0)
       " always have current tabpage first
@@ -143,27 +143,27 @@ function! airline#extensions#tabline#tabs#get()
 
     " Add the tab to the right
     if right_tab <= num_tabs
-      let tab_title = s:get_title(tab_nr_type, right_tab)
+      let tab_title = self.get_title(tab_nr_type, right_tab)
       let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-      call self.insert_section(s:get_group(right_tab), tab_title, right_position)
+      call self.insert_section(self.get_group(right_tab), tab_title, right_position)
       let right_position += 1
       let right_tab += 1
     endif
 
     while remaining_space > 0
       if left_tab > 0
-        let tab_title = s:get_title(tab_nr_type, left_tab)
+        let tab_title = self.get_title(tab_nr_type, left_tab)
         let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
         if remaining_space >= 0
-          call self.insert_section(s:get_group(left_tab), tab_title, left_position)
+          call self.insert_section(self.get_group(left_tab), tab_title, left_position)
           let right_position += 1
           let left_tab -= 1
         endif
       elseif right_tab <= num_tabs
-        let tab_title = s:get_title(tab_nr_type, right_tab)
+        let tab_title = self.get_title(tab_nr_type, right_tab)
         let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
         if remaining_space >= 0
-          call self.insert_section(s:get_group(right_tab), tab_title, right_position)
+          call self.insert_section(self.get_group(right_tab), tab_title, right_position)
           let right_position += 1
           let right_tab += 1
         endif

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -95,7 +95,6 @@ function! airline#extensions#tabline#tabs#get()
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
 
-  let b_tabline = s:evaluate_tabline(b.build())
   let num_tabs = tabpagenr('$')
   let left_tab = curtab - 1
   let right_tab = curtab + 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -87,7 +87,6 @@ function! airline#extensions#tabline#tabs#get()
     endif
   endif
 
-  let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
   let b = airline#extensions#tabline#new_builder()
 
   call airline#extensions#tabline#add_label(b, 'tabs')
@@ -112,76 +111,80 @@ function! airline#extensions#tabline#tabs#get()
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
 
-  let num_tabs = tabpagenr('$')
-  let left_tab = curtab - 1
-  let right_tab = curtab + 1
-  let left_position = tabs_position
-  let right_position = tabs_position + 1
-  let remaining_space = &columns - s:strchars(s:evaluate_tabline(b.build()))
+  function! b.insert_tabs(tabs_position, curtab) dict
+    let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
+    let num_tabs = tabpagenr('$')
+    let left_tab = a:curtab - 1
+    let right_tab = a:curtab + 1
+    let left_position = a:tabs_position
+    let right_position = a:tabs_position + 1
+    let remaining_space = &columns - s:strchars(s:evaluate_tabline(self.build()))
 
-  let left_sep_size = s:strchars(s:evaluate_tabline(b._context.left_sep))
-  let left_alt_sep_size = s:strchars(s:evaluate_tabline(b._context.left_alt_sep))
+    let left_sep_size = s:strchars(s:evaluate_tabline(self._context.left_sep))
+    let left_alt_sep_size = s:strchars(s:evaluate_tabline(self._context.left_alt_sep))
 
-  let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
-  let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
-  " The left marker will have left_alt_sep, and the right will have left_sep.
-  let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
+    let skipped_tabs_marker = get(g:, 'airline#extensions#tabline#overflow_marker', g:airline_symbols.ellipsis)
+    let skipped_tabs_marker_size = s:strchars(s:evaluate_tabline(skipped_tabs_marker))
+    " The left marker will have left_alt_sep, and the right will have left_sep.
+    let remaining_space -= 2 * skipped_tabs_marker_size + left_sep_size + left_alt_sep_size
 
-  " Add the current tab
-  let tab_title = s:get_title(tab_nr_type, curtab)
-  let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
-  " There are always two left_seps (either side of the selected tab) and all
-  " other seperators are left_alt_seps.
-  let remaining_space -= 2 * left_sep_size - left_alt_sep_size
-  call b.insert_section(s:get_group(curtab), tab_title, left_position)
+    " Add the current tab
+    let tab_title = s:get_title(tab_nr_type, a:curtab)
+    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title))
+    " There are always two left_seps (either side of the selected tab) and all
+    " other seperators are left_alt_seps.
+    let remaining_space -= 2 * left_sep_size - left_alt_sep_size
+    call self.insert_section(s:get_group(a:curtab), tab_title, left_position)
 
-  if get(g:, 'airline#extensions#tabline#current_first', 0)
-    " always have current tabpage first
-    let left_position += 1
-  endif
+    if get(g:, 'airline#extensions#tabline#current_first', 0)
+      " always have current tabpage first
+      let left_position += 1
+    endif
 
-  " Add the tab to the right
-  if right_tab <= num_tabs
-    let tab_title = s:get_title(tab_nr_type, right_tab)
-    let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-    call b.insert_section(s:get_group(right_tab), tab_title, right_position)
-    let right_position += 1
-    let right_tab += 1
-  endif
-
-  while remaining_space > 0
-    if left_tab > 0
-      let tab_title = s:get_title(tab_nr_type, left_tab)
-      let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-      if remaining_space >= 0
-        call b.insert_section(s:get_group(left_tab), tab_title, left_position)
-        let right_position += 1
-        let left_tab -= 1
-      endif
-    elseif right_tab <= num_tabs
+    " Add the tab to the right
+    if right_tab <= num_tabs
       let tab_title = s:get_title(tab_nr_type, right_tab)
       let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
-      if remaining_space >= 0
-        call b.insert_section(s:get_group(right_tab), tab_title, right_position)
-        let right_position += 1
-        let right_tab += 1
+      call self.insert_section(s:get_group(right_tab), tab_title, right_position)
+      let right_position += 1
+      let right_tab += 1
+    endif
+
+    while remaining_space > 0
+      if left_tab > 0
+        let tab_title = s:get_title(tab_nr_type, left_tab)
+        let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
+        if remaining_space >= 0
+          call self.insert_section(s:get_group(left_tab), tab_title, left_position)
+          let right_position += 1
+          let left_tab -= 1
+        endif
+      elseif right_tab <= num_tabs
+        let tab_title = s:get_title(tab_nr_type, right_tab)
+        let remaining_space -= s:strchars(s:evaluate_tabline(tab_title)) + left_alt_sep_size
+        if remaining_space >= 0
+          call self.insert_section(s:get_group(right_tab), tab_title, right_position)
+          let right_position += 1
+          let right_tab += 1
+        endif
+      else
+        break
       endif
-    else
-      break
-    endif
-  endwhile
+    endwhile
 
-  if left_tab > 0
-    if get(g:, 'airline#extensions#tabline#current_first', 0)
-      let left_position -= 1
+    if left_tab > 0
+      if get(g:, 'airline#extensions#tabline#current_first', 0)
+        let left_position -= 1
+      endif
+      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, left_position)
+      let right_position += 1
     endif
-    call b.insert_raw('%#airline_tab#'.skipped_tabs_marker, left_position)
-    let right_position += 1
-  endif
 
-  if right_tab <= num_tabs
-    call b.insert_raw('%#airline_tab#'.skipped_tabs_marker, right_position)
-  endif
+    if right_tab <= num_tabs
+      call self.insert_raw('%#airline_tab#'.skipped_tabs_marker, right_position)
+    endif
+  endfunction
+  call b.insert_tabs(tabs_position, curtab)
 
   let s:current_bufnr = curbuf
   let s:current_tabnr = curtab

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -84,6 +84,17 @@ function! s:get_visible_tabs(width)
   return tablist
 endfunction
 
+function! s:evaluate_tabline(tabline)
+  let tabline = a:tabline
+  let tabline = substitute(tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
+  let tabline = substitute(tabline, '%#[^#]\+#', '', 'g')
+  let tabline = substitute(tabline, '%(\([^)]\+\))', '\1', 'g')
+  let tabline = substitute(tabline, '%\d\+[TX]', '', 'g')
+  let tabline = substitute(tabline, '%=', '', 'g')
+  let tabline = substitute(tabline, '%\d*\*', '', 'g')
+  return tabline
+endfunction
+
 function! airline#extensions#tabline#tabs#get()
   let curbuf = bufnr('%')
   let curtab = tabpagenr()
@@ -123,13 +134,7 @@ function! airline#extensions#tabline#tabs#get()
     call airline#extensions#tabline#add_label(b, 'buffers')
   endif
 
-  let b_tabline = b.build()
-  let b_tabline = substitute(b_tabline, '%{\([^}]\+\)}', '\=eval(submatch(1))', 'g')
-  let b_tabline = substitute(b_tabline, '%#[^#]\+#', '', 'g')
-  let b_tabline = substitute(b_tabline, '%(\([^)]\+\))', '\1', 'g')
-  let b_tabline = substitute(b_tabline, '%\d\+[TX]', '', 'g')
-  let b_tabline = substitute(b_tabline, '%=', '', 'g')
-  let b_tabline = substitute(b_tabline, '%\d*\*', '', 'g')
+  let b_tabline = s:evaluate_tabline(b.build())
 
   for i in s:get_visible_tabs(&columns - strlen(b_tabline))
     if i < 0

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -71,7 +71,7 @@ function! airline#extensions#tabline#tabs#get()
     return val.'%'.a:i.'T %{airline#extensions#tabline#title('.a:i.')} %)'
   endfunction
 
-  call b.insert_tabs(curtab)
+  call b.insert_tabs(curtab, tabpagenr('$'))
 
   call b.add_section('airline_tabfill', '')
   call b.split()

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -64,7 +64,7 @@ function! airline#extensions#tabline#tabs#get()
   catch
     " no-op
   endtry
-  if curbuf == s:current_bufnr && curtab == s:current_tabnr
+  if curbuf == s:current_bufnr && curtab == s:current_tabnr && &columns == s:column_width
     if !g:airline_detect_modified || getbufvar(curbuf, '&modified') == s:current_modified
       return s:current_tabline
     endif
@@ -170,6 +170,7 @@ function! airline#extensions#tabline#tabs#get()
 
   let s:current_bufnr = curbuf
   let s:current_tabnr = curtab
+  let s:column_width = &columns
   let s:current_tabline = b.build()
   return s:current_tabline
 endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -70,7 +70,8 @@ function! airline#init#bootstrap()
           \ 'spell': 'SPELL',
           \ 'modified': '+',
           \ 'space': ' ',
-          \ 'keymap': 'Keymap:'
+          \ 'keymap': 'Keymap:',
+          \ 'ellipsis': '...'
           \  }, 'keep')
 
   if get(g:, 'airline_powerline_fonts', 0)

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -86,3 +86,13 @@ else
     return 0
   endfunction
 endif
+
+" Compatibility wrapper for strchars, in case this vim version does not
+" have it natively
+function! airline#util#strchars(str)
+  if exists('*strchars')
+    return strchars(a:str)
+  else
+    return strlen(substitute(a:str, '.', 'a', 'g'))
+  endif
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -709,6 +709,9 @@ with the middle mouse button to delete that buffer.
 * rename label for tabs (default: 'tabs') (c) >
   let g:airline#extensions#tabline#tabs_label = 't'
 
+* change the symbol for skipped tabs/buffers (default '...') >
+  let g:airline#extensions#tabline#skipped_tabs_marker = '…'
+
 * always show current tabpage/buffer first >
   let airline#extensions#tabline#current_first = 1
 <  default: 0

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -710,7 +710,7 @@ with the middle mouse button to delete that buffer.
   let g:airline#extensions#tabline#tabs_label = 't'
 
 * change the symbol for skipped tabs/buffers (default '...') >
-  let g:airline#extensions#tabline#skipped_tabs_marker = '…'
+  let g:airline#extensions#tabline#overflow_marker = '…'
 
 * always show current tabpage/buffer first >
   let airline#extensions#tabline#current_first = 1


### PR DESCRIPTION
This PR is a continuation of #1684. It fixes #1468 (and the now-closed #488).

The main work is done in the new file (`autoload/airline/extensions/tabline/builder.vim`), which extends the interface defined in `autoload/airline/builder.vim`. The code uses new variables:
* `g:airline#extensions#tabline#overflow_marker` - the symbol to show to the side of the tab/buffer titles when there are more that don't fit. This defaults to `g:airline_symbols.ellipsis`.
* `g:airline_symbols.ellipsis` - this defaults to `...`
* `g:airline#extensions#tabline#center_active` - whether to show the active tab/buffer in the middle(-ish) of the tabline (as in #1674), or to the right. This defaults to 0 (keeping roughly the old behaviour for buffers).

Currently, this brings several improvements on the old version:
* the tabline now scrolls when tabs are showing, so that the selected tab is always visible
* it should be able to handle any dividers, even if they are different widths
* it (tries to) expand the rest of the tabline to get the actual non-title contents
  - this makes supporting content around the titles much easier (e.g. for tabs)
  - this also means that the divider, ellipsis, etc. can be any *expression* and the spacing should still work
* it supports tabs and buffers equally well, and they now use the same code (via the new class)
* the currently active tab can be placed in the middle of the tabline (by setting `g:airline#extensions#tabline#center_active` to `1`)
  - I've left it off by default to make this PR less disruptive; it would be simple to switch the default and/or remove the option completely if this is the way to go

There are a few limitations:
* this code is much more complicated than the original and #1674
* I haven't been able to find a nice way to include [@ruipgpinheiro's formatting fix](https://github.com/vim-airline/vim-airline/pull/1674#issuecomment-369201852) from #1674 yet
* some of the expressions defined in `:help 'statusline'` aren't supported by the tabline expansion
* the class doesn't handle splits next to/before the title list properly
  - these cases don't come up in the tabs/buffer code at the moment

### Screenshots (tabs):
* first tab
![first tab](https://user-images.githubusercontent.com/1847343/37314251-01ce9ea4-264b-11e8-9acd-802cae387fcd.png)
* tab in the initial strip
![tab in the initial strip](https://user-images.githubusercontent.com/1847343/37314252-0217a5ea-264b-11e8-83e5-97b276872477.png)
* tab in the middle
![tab in the middle](https://user-images.githubusercontent.com/1847343/37314253-023f348e-264b-11e8-9cae-ccbff45e5793.png)
* tab with long names (overflow)
![tab with long names (overflow)](https://user-images.githubusercontent.com/1847343/37314254-026e97e2-264b-11e8-9372-b53a12be86b7.png)
* tab in the final strip
![tab in the final strip](https://user-images.githubusercontent.com/1847343/37314255-02924264-264b-11e8-9003-8d15c456c5a4.png)
* last tab
![last tab](https://user-images.githubusercontent.com/1847343/37314256-02b3a5d0-264b-11e8-8020-47491c366c4a.png)
* `let g:airline_powerline_fonts=1`
![let g:airline_powerline_fonts=1](https://user-images.githubusercontent.com/1847343/37625549-478e88fe-2bc4-11e8-8147-520f48b9c1f5.png)
* wider terminal (`g:airline#extensions#tabline#center_active=1`)
![wider terminal center_active=1](https://user-images.githubusercontent.com/1847343/37626002-201962ce-2bc6-11e8-93ae-e42e25dc1e82.png)
* wider terminal (`g:airline#extensions#tabline#center_active=0`) 
![wider terminal center_active=0](https://user-images.githubusercontent.com/1847343/37626082-63d64f9a-2bc6-11e8-88a3-bbe2991a04ee.png)
* dividers of different non-1 widths
![dividers of different non-1 widths](https://user-images.githubusercontent.com/1847343/37625642-a9f70d72-2bc4-11e8-84fd-cdeea82d1094.png)


Original:
* tab not in the final strip
![tab not in the final strip](https://user-images.githubusercontent.com/1847343/37314411-d74fa67c-264b-11e8-9356-501c969b24f4.png)
* tab in the final strip
![tab in the final strip](https://user-images.githubusercontent.com/1847343/37314396-c9abbfd8-264b-11e8-8cf7-84c7c36d8aac.png)

### Screenshots (buffers):
* first
![first](https://user-images.githubusercontent.com/1847343/37625738-03a29f4e-2bc5-11e8-97da-f5032d3b63bf.png)
* middle
![middle](https://user-images.githubusercontent.com/1847343/37625691-ddd666c4-2bc4-11e8-81ce-7b052ae280a9.png)
* last 
![last](https://user-images.githubusercontent.com/1847343/37625769-212417c8-2bc5-11e8-80d5-7b52c7cc7021.png)
* wide
![wide](https://user-images.githubusercontent.com/1847343/37625895-b8c3178c-2bc5-11e8-8e72-44dda6d34be1.png)

Original:
* ![original](https://user-images.githubusercontent.com/1847343/37625864-90bfa5f2-2bc5-11e8-9a79-53a579d0201d.png)


cc/ @ruipgpinheiro