### PR TITLE
Add extension for vim-localsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ vim-airline integrates with a variety of plugins out of the box.  These extensio
 #### [vimtex][53]
 ![image](https://cloud.githubusercontent.com/assets/1798172/25799740/e77d5c2e-33ee-11e7-8660-d34ce4c5f13f.png)
 
+#### [localsearch][54]
+![image](https://raw.githubusercontent.com/mox-mox/vim-localsearch/master/vim-airline-localsearch-indicator.png)
+
 ## Extras
 
 vim-airline also supplies some supplementary stand-alone extensions.  In addition to the tabline extension mentioned earlier, there is also:
@@ -233,7 +236,7 @@ This plugin follows the standard runtime path structure, and as such it can be i
 | [Plug][40] | `Plug 'vim-airline/vim-airline'` |
 | [VAM][22] | `call vam#ActivateAddons([ 'vim-airline' ])` |
 | [Dein][52] | `call dein#add('vim-airline/vim-airline')` |
-| [minpac][54] | `call minpac#add('vim-airline/vim-airline')` |
+| [minpac][55] | `call minpac#add('vim-airline/vim-airline')` |
 | pack feature (native Vim 8 package feature)| `git clone https://github.com/vim-airline/vim-airline ~/.vim/pack/dist/start/vim-airline`<br/>Remember to run `:helptags` to generate help tags |
 | manual | copy all of the files into your `~/.vim` directory |
 
@@ -265,7 +268,7 @@ If you don't want all the bells and whistles enabled by default, you can define 
 
 Also, you can enable caching of the various syntax highlighting groups. This will try to prevent some of the more expensive `:hi` calls in Vim, which seem to be expensive in the Vim core at the expense of possibly not being hunderet percent correct all the times (especially if you often change highlighting groups yourself using `:hi` commands). To set this up do `:let g:airline_highlighting_cache = 1`. A `:AirlineRefresh` will however clear the cache.
 
-In addition you might want to check out the [dark_minimal theme][55], which does not change highlighting groups once they are defined. Also please check the [FAQ][27] for more information on how to diagnose and fix the problem.
+In addition you might want to check out the [dark_minimal theme][56], which does not change highlighting groups once they are defined. Also please check the [FAQ][27] for more information on how to diagnose and fix the problem.
 
 # Screenshots
 
@@ -334,5 +337,6 @@ MIT License. Copyright (c) 2013-2017 Bailey Ling & Contributors.
 [51]: https://github.com/Shougo/denite.nvim
 [52]: https://github.com/Shougo/dein.vim
 [53]: https://github.com/lervag/vimtex
-[54]: https://github.com/k-takata/minpac/
-[55]: https://github.com/vim-airline/vim-airline-themes/blob/master/autoload/airline/themes/dark_minimal.vim
+[54]: https://github.com/mox-mox/vim-localsearch
+[55]: https://github.com/k-takata/minpac/
+[56]: https://github.com/vim-airline/vim-airline-themes/blob/master/autoload/airline/themes/dark_minimal.vim

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -172,6 +172,11 @@ function! airline#extensions#load()
     call add(loaded_ext, 'ctrlp')
   endif
 
+  if get(g:, 'loaded_localsearch', 0)
+    call airline#extensions#localsearch#init(s:ext)
+    call add(loaded_ext, 'localsearch')
+  endif
+
   if get(g:, 'CtrlSpaceLoaded', 0)
     call airline#extensions#ctrlspace#init(s:ext)
     call add(loaded_ext, 'ctrlspace')

--- a/autoload/airline/extensions/localsearch.vim
+++ b/autoload/airline/extensions/localsearch.vim
@@ -1,0 +1,35 @@
+" MIT License. Copyright (c) 2018 mox
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+let s:enabled = get(g:, 'airline#extensions#localsearch#enabled', 1)
+if !get(g:, 'loaded_localsearch', 0) || !s:enabled || get(g:, 'airline#extensions#localsearch#loaded', 0)
+  finish
+endif
+let g:airline#extensions#localsearch#loaded = 001
+
+let s:spc = g:airline_symbols.space
+
+function! airline#extensions#localsearch#load_theme(palette)
+  call airline#highlighter#exec('localsearch_dark', [ '#ffffff' , '#000000' , 15  , 1 , ''])
+endfunction
+
+
+function! airline#extensions#localsearch#init(ext)
+	call a:ext.add_theme_func('airline#extensions#localsearch#load_theme')
+	call a:ext.add_statusline_func('airline#extensions#localsearch#apply')
+endfunction
+
+
+function! airline#extensions#localsearch#apply(...)
+  " first variable is the statusline builder
+  let builder = a:1
+
+  """"" WARNING: the API for the builder is not finalized and may change
+  if exists('#localsearch#WinEnter') " If localsearch mode is enabled
+    call builder.add_section('localsearch_dark', s:spc.airline#section#create('LS').s:spc)
+  endif
+  return 0
+endfunction
+

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1003,7 +1003,7 @@ State indicators:
 * single compilation is running >
   let g:airline#extensions#vimtex#compiled = "c₁"
 
-* continuousr compilation is running >
+* continuous compilation is running >
   let g:airline#extensions#vimtex#continuous = "c"
 
 * viewer is opened >
@@ -1039,6 +1039,12 @@ neomake <https://github.com/neomake/neomake>
 * neomake warning >
   let airline#extensions#neomake#warning_symbol = 'W:'
 <
+-------------------------------------                    *airline-localsearch*
+localsearch <https://github.com/mox-mox/localsearch>
+
+* enable/disable localsearch indicator integration >
+  let g:airline#extensions#localsearch#enabled = 1
+
 -------------------------------------                    *airline-cursormode*
 cursormode <https://github.com/vheon/vim-cursormode>
 


### PR DESCRIPTION
Hi,

I wrote a vim plugin and an extension to vim-airline to show its state.
Localsearch makes the searchterm `@/` a window-local state so you can search different things in different windows/tabs/splits. When localsearch is activated (via a mapping), the airline extension will add a red segment saying "LS" to the statusline.
Please see [the plugin readme](https://github.com/mox-mox/vim-localsearch) for a description of localsearch and a use-case.
Could you please merge this pull request or let me know if there is anything I can improve?

Best regards,
mox

