### PR TITLE
Fix buffer numbering to start from 1 with buffer_idx_mode

### DIFF
--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -58,7 +58,6 @@ function! airline#extensions#tabline#buffers#get()
     endif
   endif
 
-  let index = 1
   let b = airline#extensions#tabline#new_builder()
   let tab_bufs = tabpagebuflist(tabpagenr())
   let show_buf_label_first = 0
@@ -116,9 +115,9 @@ function! airline#extensions#tabline#buffers#get()
 
     if get(g:, 'airline#extensions#tabline#buffer_idx_mode', 0)
       if len(s:number_map) > 0
-        return space. get(s:number_map, a:i, '') . '%(%{airline#extensions#tabline#get_buffer_name('.bufnum.')}%)' . s:spc
+        return space. get(s:number_map, a:i+1, '') . '%(%{airline#extensions#tabline#get_buffer_name('.bufnum.')}%)' . s:spc
       else
-        return '['.a:i.s:spc.'%(%{airline#extensions#tabline#get_buffer_name('.bufnum.')}%)'.']'
+        return '['.(a:i+1).s:spc.'%(%{airline#extensions#tabline#get_buffer_name('.bufnum.')}%)'.']'
       endif
     else
       return space.'%(%{airline#extensions#tabline#get_buffer_name('.bufnum.')}%)'.s:spc


### PR DESCRIPTION
This is a follow-on bugfix PR for #1693. See [this comment](https://github.com/vim-airline/vim-airline/pull/1693#issuecomment-377824978) for the bug.

275ec4fe63d9776a2c2cbf72b1f371b9e01273b8 broke this so that numbering started from 0 instead of 1 with `g:airline#extensions#tabline#buffer_idx_mode = 1`

Specifically, I overlooked that `index` actually tracked the index of the current buffer in the buffer list *as if it started from 1*, whereas I assumed it tracked the true index (starting from 0).

cc/ @slabua