### PR TITLE
Support typescript in jsformatter

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/jsformatter.vim
+++ b/autoload/airline/extensions/tabline/formatters/jsformatter.vim
@@ -7,7 +7,7 @@ function! airline#extensions#tabline#formatters#jsformatter#format(bufnr, buffer
   let buf = bufname(a:bufnr)
   let filename = fnamemodify(buf, ':t')
 
-  if filename == 'index.js' || filename == 'index.jsx'
+  if filename == 'index.js' || filename == 'index.jsx' || filename == 'index.ts' || filename == 'index.tsx'
     return fnamemodify(buf, ':p:h:t') . '/i'
   else
     return airline#extensions#tabline#formatters#unique_tail_improved#format(a:bufnr, a:buffers)


### PR DESCRIPTION
Add `.ts` and `.tsx` extensions to supported jsformatter files