### PR TITLE
Add support for nerdtree status line option

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -28,7 +28,7 @@ else
 endif
 
 let s:filetype_overrides = {
-			\ 'nerdtree': [ s:nerdStatusLine, '' ],
+      \ 'nerdtree': [ s:nerdStatusLine, '' ],
       \ 'gundo': [ 'Gundo', '' ],
       \ 'vimfiler': [ 'vimfiler', '%{vimfiler#get_status_string()}' ],
       \ 'minibufexpl': [ 'MiniBufExplorer', '' ],

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -21,8 +21,14 @@ endfunction
 
 let s:script_path = tolower(resolve(expand('<sfile>:p:h')))
 
+if exists('g:NERDTreeStatusline')
+  let s:nerdStatusLine = g:NERDTreeStatusline
+else
+  let s:nerdStatusLine = 'NERD'
+endif
+
 let s:filetype_overrides = {
-      \ 'nerdtree': [ 'NERD', '' ],
+			\ 'nerdtree': [ s:nerdStatusLine, '' ],
       \ 'gundo': [ 'Gundo', '' ],
       \ 'vimfiler': [ 'vimfiler', '%{vimfiler#get_status_string()}' ],
       \ 'minibufexpl': [ 'MiniBufExplorer', '' ],


### PR DESCRIPTION
This pull request is based on issue #271. 

This can be useful in a lot of cases, for example, like was mentioned in the comments:

* display current branch
* display file name, without full path
* display file/folder permissions
* display no info at all
* etc

If a user didn't specify `g:NERDTreeStatusline` variable - 'NERD' text will be used. 