### PR TITLE
airline#extensions#xkblayout#short_codes changed to global for easily…

### DIFF
--- a/autoload/airline/extensions/xkblayout.vim
+++ b/autoload/airline/extensions/xkblayout.vim
@@ -10,7 +10,7 @@ endif
 function! airline#extensions#xkblayout#status()
   let keyboard_layout = libcall(g:XkbSwitchLib, 'Xkb_Switch_getXkbLayout', '')
   let keyboard_layout = split(keyboard_layout, '\.')[-1]
-  let short_codes = {'2SetKorean': 'KR', 'Chinese': 'CN', 'Japanese': 'JP'}
+  let short_codes = get(g:, 'airline#extensions#xkblayout#short_codes', {'2SetKorean': 'KR', 'Chinese': 'CN', 'Japanese': 'JP'})
 
   if has_key(short_codes, keyboard_layout)
     let keyboard_layout = short_codes[keyboard_layout]

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -999,6 +999,15 @@ vim-xkblayout
 * enable/disable vim-xkblayout extension >
   let g:airline#extensions#xkblayout#enabled = 1
 
+* redefine keyboard layout short codes to shown in status >
+  let g:airline#extensions#xkblayout#short_codes = {'Russian-Phonetic': 'RU', 'ABC': 'EN'}
+<  
+  'RU' instead of system 'Russian-Phonetic',
+  'EN' instead of system 'ABC'.
+
+  Default: >
+  let g:airline#extensions#xkblayout#short_codes = {'2SetKorean': 'KR', 'Chinese': 'CN', 'Japanese': 'JP'}
+
 * define path to the backend switcher library
   Linux (Install https://github.com/ierton/xkb-switch): >
    let g:XkbSwitchLib = '/usr/local/lib/libxkbswitch.so'


### PR DESCRIPTION
… redefine long named keyboard layout,
for example in .vimrc:

let g:airline#extensions#xkblayout#short_codes = {'Russian-Phonetic': 'RU', 'ABC': 'EN'}