### PR TITLE
More reliable checking for the presence of ALE

### DIFF
--- a/autoload/airline/extensions/ale.vim
+++ b/autoload/airline/extensions/ale.vim
@@ -33,7 +33,7 @@ function! s:airline_ale_get_line_number(cnt, type) abort
 endfunction
 
 function! airline#extensions#ale#get(type)
-  if !exists(':ALELint')
+  if !get(g:, 'loaded_ale_dont_use_this_in_other_plugins_please', 0)
     return ''
   endif
 


### PR DESCRIPTION
Checking the presence of `ALELint` is unreliable if ALE is lazy loaded and has `ALELint` as the trigger.