### PR TITLE
airline#extension#ctrlspace: Fix tabline didn't update when enable both buffers and tabs

### DIFF
--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -4,6 +4,7 @@
 scriptencoding utf-8
 
 let s:current_bufnr = -1
+let s:current_modified = 0
 let s:current_tabnr = -1
 let s:current_tabline = ''
 let s:highlight_groups = ['hid', 0, '', 'sel', 'mod_unsel', 0, 'mod_unsel', 'mod']
@@ -39,6 +40,8 @@ function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_t
     return 0
   endif
 
+  let s:current_modified = getbufvar(a:cur_buf, '&modified')
+
   for buffer in buffer_list
     let group = 'airline_tab'
           \ .s:highlight_groups[(4 * buffer.modified) + (2 * buffer.visible) + (a:cur_buf == buffer.index)]
@@ -52,6 +55,7 @@ function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_t
 
     call a:builder.add_section_spaced(group, buf_name)
   endfor
+
   " add by tenfy(tenfyzhong@qq.com)
   " if the selected buffer was updated
   " return true
@@ -84,7 +88,9 @@ function! airline#extensions#tabline#ctrlspace#get()
   let cur_tab = tabpagenr()
 
   if cur_buf == s:current_bufnr && cur_tab == s:current_tabnr
-    return s:current_tabline
+    if !g:airline_detect_modified || getbufvar(cur_buf, '&modified') == s:current_modified
+      return s:current_tabline
+    endif
   endif
 
   let builder = airline#extensions#tabline#new_builder()


### PR DESCRIPTION
### Problem

I found that tabline cannot be updated correctly when joint `vim-ctrlspace`: **Tabline only refreshed when current tab or buffer has been changed.**

So I fixed it (๑ơ ω ơ)

### Demo

Demo 1 (unexpected): [https://youtu.be/lWol5k_NWCo](https://youtu.be/lWol5k_NWCo)
Demo 2 (fixed): [https://youtu.be/f-wxK5MtHtE](https://youtu.be/f-wxK5MtHtE)

### Minimum setup to reproduce demo 1:

> [Vim-plug](https://github.com/junegunn/vim-plug) must be installed before

```vim
if &compatible
  set nocompatible
endif

set hidden

" ======== Plugins ======== {{{
call plug#begin('~/.vim/plugged')

" Airline: https://github.com/vim-airline/vim-airline
Plug 'vim-airline/vim-airline'
" Fixed in my pull request
" Plug 'shirohana/vim-airline', { 'branch': 'fix/integrate-with-ctrlspace' }
Plug 'vim-airline/vim-airline-themes'

" CtrlSpace: https://github.com/vim-ctrlspace/vim-ctrlspace
Plug 'vim-ctrlspace/vim-ctrlspace'

call plug#end()
" }}}

" ======== Airline ======== {{{
" Use unicode characters
let g:airline_powerline_fonts = 1

" airline # extensions # airline
let g:airline#extensions#tabline#enabled = 1

" airline # extensions # ctrlspace
let g:airline#extensions#ctrlspace#enabled = 1
" }}}

" ======== CtrlSpace ======== {{{
" Disable default mappings
let g:CtrlSpaceSetDefaultMapping = 0
" }}}
```