### PR TITLE
airline#extensions#ctrlspace: Fix tabline didn't update when switch to tab which focused on non-listed buffer

### DIFF
--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -99,9 +99,8 @@ function! airline#extensions#tabline#ctrlspace#get()
 
   try
     call airline#extensions#tabline#tabs#map_keys()
-  catch
-    " no-op
   endtry
+
   let s:tab_list = ctrlspace#api#TabList()
   for tab in s:tab_list
     if tab.current

--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -34,7 +34,7 @@ function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_t
   " return false and no redraw tabline.
   " Fixes #1515. if there a BufEnter autocmd execute redraw. The tabline may no update.
   let bufnr_list = map(copy(s:buffer_list), 'v:val["index"]')
-  if index(bufnr_list, a:cur_buf) == -1
+  if index(bufnr_list, a:cur_buf) == -1 && a:cur_tab == s:current_tabnr
     return 0
   endif
 

--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -25,10 +25,8 @@ function! airline#extensions#tabline#ctrlspace#invalidate()
   let s:current_tabnr = -1
 endfunction
 
-function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, pos)
-  let pos_extension = (a:pos == 0)
-        \ ? ''
-        \ : '_right'
+function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, pull_right)
+  let pos_extension = (a:pull_right ? '_right' : '')
 
   let s:buffer_list = ctrlspace#api#BufferList(a:cur_tab)
   " add by tenfy(tenfyzhong@qq.com)
@@ -71,10 +69,8 @@ function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_t
   return 1
 endfunction
 
-function! airline#extensions#tabline#ctrlspace#add_tab_section(builder, pos)
-  let pos_extension = (a:pos == 0)
-        \ ? ''
-        \ : '_right'
+function! airline#extensions#tabline#ctrlspace#add_tab_section(builder, pull_right)
+  let pos_extension = (a:pull_right ? '_right' : '')
 
   for tab in s:tab_list
     if tab.current

--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -6,6 +6,7 @@ scriptencoding utf-8
 let s:current_bufnr = -1
 let s:current_tabnr = -1
 let s:current_tabline = ''
+let s:highlight_groups = ['hid', 0, '', 'sel', 'mod_unsel', 0, 'mod_unsel', 'mod']
 
 function! airline#extensions#tabline#ctrlspace#off()
   augroup airline_tabline_ctrlspace
@@ -27,33 +28,21 @@ endfunction
 
 function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, pull_right)
   let pos_extension = (a:pull_right ? '_right' : '')
+  let buffer_list = ctrlspace#api#BufferList(a:cur_tab)
 
-  let s:buffer_list = ctrlspace#api#BufferList(a:cur_tab)
   " add by tenfy(tenfyzhong@qq.com)
   " if the current buffer no in the buffer list
   " return false and no redraw tabline.
   " Fixes #1515. if there a BufEnter autocmd execute redraw. The tabline may no update.
-  let bufnr_list = map(copy(s:buffer_list), 'v:val["index"]')
+  let bufnr_list = map(copy(buffer_list), 'v:val["index"]')
   if index(bufnr_list, a:cur_buf) == -1 && a:cur_tab == s:current_tabnr
     return 0
   endif
 
-  for buffer in s:buffer_list
-    if a:cur_buf == buffer.index
-      if buffer.modified
-        let group = 'airline_tabmod'.pos_extension
-      else
-        let group = 'airline_tabsel'.pos_extension
-      endif
-    else
-      if buffer.modified
-        let group = 'airline_tabmod_unsel'.pos_extension
-      elseif buffer.visible
-        let group = 'airline_tab'.pos_extension
-      else
-        let group = 'airline_tabhid'.pos_extension
-      endif
-    endif
+  for buffer in buffer_list
+    let group = 'airline_tab'
+          \ .s:highlight_groups[(4 * buffer.modified) + (2 * buffer.visible) + (a:cur_buf == buffer.index)]
+          \ .pos_extension
 
     let buf_name = '%(%{airline#extensions#tabline#get_buffer_name('.buffer.index.')}%)'
 
@@ -71,21 +60,12 @@ endfunction
 
 function! airline#extensions#tabline#ctrlspace#add_tab_section(builder, pull_right)
   let pos_extension = (a:pull_right ? '_right' : '')
+  let tab_list = ctrlspace#api#TabList()
 
-  for tab in s:tab_list
-    if tab.current
-      if tab.modified
-        let group = 'airline_tabmod'.pos_extension
-      else
-        let group = 'airline_tabsel'.pos_extension
-      endif
-    else
-      if tab.modified
-        let group = 'airline_tabmod_unsel'.pos_extension
-      else
-        let group = 'airline_tabhid'.pos_extension
-      endif
-    endif
+  for tab in tab_list
+    let group = 'airline_tab'
+          \ .s:highlight_groups[(4 * tab.modified) + (3 * tab.current)]
+          \ .pos_extension
 
     call a:builder.add_section_spaced(group, '%'.tab.index.'T'.tab.title.ctrlspace#api#TabBuffersNumber(tab.index).'%T')
   endfor
@@ -101,12 +81,7 @@ function! airline#extensions#tabline#ctrlspace#get()
     call airline#extensions#tabline#tabs#map_keys()
   endtry
 
-  let s:tab_list = ctrlspace#api#TabList()
-  for tab in s:tab_list
-    if tab.current
-      let cur_tab = tab.index
-    endif
-  endfor
+  let cur_tab = tabpagenr()
 
   if cur_buf == s:current_bufnr && cur_tab == s:current_tabnr
     return s:current_tabline
@@ -114,51 +89,56 @@ function! airline#extensions#tabline#ctrlspace#get()
 
   let builder = airline#extensions#tabline#new_builder()
 
+  let show_buffers = get(g:, 'airline#extensions#tabline#show_buffers', 1)
+  let show_tabs = get(g:, 'airline#extensions#tabline#show_tabs', 1)
+
+  let AppendBuffers = function('airline#extensions#tabline#ctrlspace#add_buffer_section', [builder, cur_tab, cur_buf])
+  let AppendTabs = function('airline#extensions#tabline#ctrlspace#add_tab_section', [builder])
+  let AppendLabel = function(builder.add_section_spaced, ['airline_tabtype'], builder)
+
+  " <= 1: |{Tabs}                      <tab|
+  " == 2: |{Buffers}               <buffers|
+  " == 3: |buffers> {Buffers}  {Tabs} <tabs|
+  let showing_mode = (2 * show_buffers) + (show_tabs)
+  let ignore_update = 0
+
   " Add left tabline content
-  if get(g:, 'airline#extensions#tabline#show_buffers', 1) == 0
-    call airline#extensions#tabline#ctrlspace#add_tab_section(builder, 0)
-  elseif get(g:, 'airline#extensions#tabline#show_tabs', 1) == 0
-    " add by tenfy(tenfyzhong@qq.com)
-    " if current buffer no in the buffer list, does't update tabline
-    if airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, 0) == 0
-      return s:current_tabline
-    endif
+  if showing_mode <= 1 " Tabs only mode
+    call AppendTabs(0)
+  elseif showing_mode == 2 " Buffers only mode
+    let ignore_update = !AppendBuffers(0)
   else
-    if switch_buffers_and_tabs == 0
-      call builder.add_section_spaced('airline_tabtype', buffer_label)
-      " add by tenfy(tenfyzhong@qq.com)
-      " if current buffer no in the buffer list, does't update tabline
-      if airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, 0) == 0
-        return s:current_tabline
-      endif
+    if !switch_buffers_and_tabs
+      call AppendLabel(buffer_label)
+      let ignore_update = !AppendBuffers(0)
     else
-      call builder.add_section_spaced('airline_tabtype', tab_label)
-      call airline#extensions#tabline#ctrlspace#add_tab_section(builder, 0)
+      call AppendLabel(tab_label)
+      call AppendTabs(0)
     endif
   endif
+
+  if ignore_update | return s:current_tabline | endif
 
   call builder.add_section('airline_tabfill', '')
   call builder.split()
   call builder.add_section('airline_tabfill', '')
 
   " Add right tabline content
-  if get(g:, 'airline#extensions#tabline#show_buffers', 1) == 0
-    call builder.add_section_spaced('airline_tabtype', tab_label)
-  elseif get(g:, 'airline#extensions#tabline#show_tabs', 1) == 0
-    call builder.add_section_spaced('airline_tabtype', buffer_label)
+  if showing_mode <= 1 " Tabs only mode
+    call AppendLabel(tab_label)
+  elseif showing_mode == 2 " Buffers only mode
+    call AppendLabel(buffer_label)
   else
-    if switch_buffers_and_tabs == 0
-      call airline#extensions#tabline#ctrlspace#add_tab_section(builder, 1)
-      call builder.add_section_spaced('airline_tabtype', tab_label)
+    if !switch_buffers_and_tabs
+      call AppendTabs(1)
+      call AppendLabel(tab_label)
     else
-      " add by tenfy(tenfyzhong@qq.com)
-      " if current buffer no in the buffer list, does't update tabline
-      if airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, 1) == 0
-        return s:current_tabline
-      endif
-      call builder.add_section_spaced('airline_tabtype', buffer_label)
+      let ignore_update = AppendBuffers(1)
+      call AppendLabel(buffer_label)
     endif
   endif
+
+  if ignore_update | return s:current_tabline | endif
 
   let s:current_bufnr = cur_buf
   let s:current_tabnr = cur_tab

--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -39,29 +39,29 @@ function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_t
   endif
 
   for buffer in s:buffer_list
-      if a:cur_buf == buffer.index
-        if buffer.modified
-          let group = 'airline_tabmod'.pos_extension
-        else
-          let group = 'airline_tabsel'.pos_extension
-        endif
+    if a:cur_buf == buffer.index
+      if buffer.modified
+        let group = 'airline_tabmod'.pos_extension
       else
-        if buffer.modified
-          let group = 'airline_tabmod_unsel'.pos_extension
-        elseif buffer.visible
-          let group = 'airline_tab'.pos_extension
-        else
-          let group = 'airline_tabhid'.pos_extension
-        endif
+        let group = 'airline_tabsel'.pos_extension
       endif
-
-      let buf_name = '%(%{airline#extensions#tabline#get_buffer_name('.buffer.index.')}%)'
-
-      if has("tablineat")
-        let buf_name = '%'.buffer.index.'@airline#extensions#tabline#buffers#clickbuf@'.buf_name.'%X'
+    else
+      if buffer.modified
+        let group = 'airline_tabmod_unsel'.pos_extension
+      elseif buffer.visible
+        let group = 'airline_tab'.pos_extension
+      else
+        let group = 'airline_tabhid'.pos_extension
       endif
+    endif
 
-      call a:builder.add_section_spaced(group, buf_name)
+    let buf_name = '%(%{airline#extensions#tabline#get_buffer_name('.buffer.index.')}%)'
+
+    if has("tablineat")
+      let buf_name = '%'.buffer.index.'@airline#extensions#tabline#buffers#clickbuf@'.buf_name.'%X'
+    endif
+
+    call a:builder.add_section_spaced(group, buf_name)
   endfor
   " add by tenfy(tenfyzhong@qq.com)
   " if the selected buffer was updated
@@ -117,13 +117,13 @@ function! airline#extensions#tabline#ctrlspace#get()
 
   " Add left tabline content
   if get(g:, 'airline#extensions#tabline#show_buffers', 1) == 0
-      call airline#extensions#tabline#ctrlspace#add_tab_section(builder, 0)
+    call airline#extensions#tabline#ctrlspace#add_tab_section(builder, 0)
   elseif get(g:, 'airline#extensions#tabline#show_tabs', 1) == 0
-      " add by tenfy(tenfyzhong@qq.com)
-      " if current buffer no in the buffer list, does't update tabline
-      if airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, 0) == 0
-        return s:current_tabline
-      endif
+    " add by tenfy(tenfyzhong@qq.com)
+    " if current buffer no in the buffer list, does't update tabline
+    if airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, 0) == 0
+      return s:current_tabline
+    endif
   else
     if switch_buffers_and_tabs == 0
       call builder.add_section_spaced('airline_tabtype', buffer_label)
@@ -144,9 +144,9 @@ function! airline#extensions#tabline#ctrlspace#get()
 
   " Add right tabline content
   if get(g:, 'airline#extensions#tabline#show_buffers', 1) == 0
-      call builder.add_section_spaced('airline_tabtype', tab_label)
+    call builder.add_section_spaced('airline_tabtype', tab_label)
   elseif get(g:, 'airline#extensions#tabline#show_tabs', 1) == 0
-      call builder.add_section_spaced('airline_tabtype', buffer_label)
+    call builder.add_section_spaced('airline_tabtype', buffer_label)
   else
     if switch_buffers_and_tabs == 0
       call airline#extensions#tabline#ctrlspace#add_tab_section(builder, 1)

--- a/autoload/airline/extensions/tabline/ctrlspace.vim
+++ b/autoload/airline/extensions/tabline/ctrlspace.vim
@@ -26,16 +26,14 @@ function! airline#extensions#tabline#ctrlspace#invalidate()
 endfunction
 
 function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_tab, cur_buf, pos)
-  if a:pos == 0
-    let pos_extension = ''
-  else
-    let pos_extension = '_right'
-  endif
+  let pos_extension = (a:pos == 0)
+        \ ? ''
+        \ : '_right'
 
   let s:buffer_list = ctrlspace#api#BufferList(a:cur_tab)
   " add by tenfy(tenfyzhong@qq.com)
   " if the current buffer no in the buffer list
-  " return false and no redraw tabline. 
+  " return false and no redraw tabline.
   " Fixes #1515. if there a BufEnter autocmd execute redraw. The tabline may no update.
   let bufnr_list = map(copy(s:buffer_list), 'v:val["index"]')
   if index(bufnr_list, a:cur_buf) == -1
@@ -74,11 +72,9 @@ function! airline#extensions#tabline#ctrlspace#add_buffer_section(builder, cur_t
 endfunction
 
 function! airline#extensions#tabline#ctrlspace#add_tab_section(builder, pos)
-  if a:pos == 0
-    let pos_extension = ''
-  else
-    let pos_extension = '_right'
-  endif
+  let pos_extension = (a:pos == 0)
+        \ ? ''
+        \ : '_right'
 
   for tab in s:tab_list
     if tab.current


### PR DESCRIPTION
### Problem

When a tab which focused on a non-listed buffer (e.g. `NERDTree`), tabline do not update as expect.

I also rewrite some algorithms, hope you like it (๑ơ ω ơ)
### Demo

Demo 1 (unexpected): https://youtu.be/suMy0LtlnKE
Demo 2(fixed): https://youtu.be/CkWZr37-npE

### Minimum setup to reproduce demo 1:

> [Vim-plug](https://github.com/junegunn/vim-plug) must be installed before

```vim
if &compatible
  set nocompatible
endif

set hidden

" ======== Plugins ======== {{{
call plug#begin('~/.vim/plugged')

" Airline: https://github.com/vim-airline/vim-airline
Plug 'vim-airline/vim-airline'
" Fixed in my pull request
" Plug 'shirohana/vim-airline', { 'branch': 'fix/integrate-with-ctrlspace' }
Plug 'vim-airline/vim-airline-themes'

" CtrlSpace: https://github.com/vim-ctrlspace/vim-ctrlspace
Plug 'vim-ctrlspace/vim-ctrlspace'

" NERDTree: https://github.com/scrooloose/nerdtree
Plug 'scrooloose/nerdtree'

call plug#end()
" }}}

" ======== Airline ======== {{{
" Use unicode characters
let g:airline_powerline_fonts = 1

" airline # extensions # airline
let g:airline#extensions#tabline#enabled = 1

" airline # extensions # ctrlspace
let g:airline#extensions#ctrlspace#enabled = 1
" }}}

" ======== CtrlSpace ======== {{{
let g:CtrlSpaceSetDefaultMapping = 0
" }}}
```