### PR TITLE
Add Arduino to list of C-like languages

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -31,7 +31,7 @@ endfunction
 
 function! s:check_mixed_indent_file()
   let c_like_langs = get(g:, 'airline#extensions#c_like_langs',
-        \ [ 'c', 'cpp', 'cuda', 'go', 'javascript', 'ld', 'php' ])
+        \ [ 'arduino', 'c', 'cpp', 'cuda', 'go', 'javascript', 'ld', 'php' ])
   if index(c_like_langs, &ft) > -1
     " for C-like languages: allow /** */ comment style with one space before the '*'
     let head_spc = '\v(^ +\*@!)'

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -666,7 +666,7 @@ eclim <https://eclim.org>
 
 * configure, which filetypes have special treatment of /* */ comments,
   matters for mix-indent-file algorithm: >
-  let airline#extensions#c_like_langs = ['c', 'cpp', 'cuda', 'go', 'javascript', 'ld', 'php']
+  let airline#extensions#c_like_langs = ['arduino', 'c', 'cpp', 'cuda', 'go', 'javascript', 'ld', 'php']
 <
 * disable whitespace checking for an individual buffer >
   " Checking is enabled by default because b:airline_whitespace_disabled


### PR DESCRIPTION
Add 'arduino' filetype to list of C-like languages. This is needed in
order to avoid mix-indent-file warnings when using hard tabs for
indentation in Arduino source files \(\*\.ino, \*\.pde\) containing top level
block comments with leading space before a '\*'.

Similar to: 460ed028645bdb52ebb4f83a84e64dbf30861ff1
Original fix: 8fde76dd63675b54c918d686036e8de9e057ae8d