### PR TITLE
Update to new Fugitive real path API

### DIFF
--- a/autoload/airline/extensions/fugitiveline.vim
+++ b/autoload/airline/extensions/fugitiveline.vim
@@ -18,8 +18,8 @@ function! airline#extensions#fugitiveline#bufname()
   if !exists('b:fugitive_name')
     let b:fugitive_name = ''
     try
-      if bufname('%') =~? '^fugitive:' && exists('*FugitivePath')
-        let b:fugitive_name = FugitivePath()
+      if bufname('%') =~? '^fugitive:' && exists('*FugitiveReal')
+        let b:fugitive_name = FugitiveReal(bufname('%'))
       elseif exists('b:git_dir')
         let buffer = fugitive#buffer()
         if buffer.type('blob')


### PR DESCRIPTION
Apologies for the churn. I've decided the word "path" is just too confusing.

By the way, while the old `buffer.repo().translate(buffer.path())` was potentially slow because it called `git rev-parse`, both halves of the new `if` conditional should be fast and IO free, in case anyone wants to eliminate the caching.