### PR TITLE
Load vimtex only when the extension is enabled

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -334,10 +334,12 @@ function! airline#extensions#load()
     call add(loaded_ext, 'obsession')
   endif
 
-  runtime autoload/vimtex.vim
-  if (get(g:, 'airline#extensions#vimtex#enabled', 1)) && exists('*vimtex#init')
-   call airline#extensions#vimtex#init(s:ext)
-   call add(loaded_ext, 'vimtex')
+  if get(g:, 'airline#extensions#vimtex#enabled', 1)
+    runtime autoload/vimtex.vim
+    if exists('*vimtex#init')
+      call airline#extensions#vimtex#init(s:ext)
+      call add(loaded_ext, 'vimtex')
+    endif
   endif
 
   if (get(g:, 'airline#extensions#cursormode#enabled', 0))


### PR DESCRIPTION
Do not force loading the full vimtex autoload script for all users. First check if the extension is enabled.

I still think it is wrong to load vimtex just to check if the extension can be activated, because it bypasses the whole purpose of vimtex being an autoload script that loads only for LaTex files, but it doesn't seem to be another way to check if vimtex is available.

I have the extension disabled anyway, but vimtex was still loaded, thus this PR.