### PR TITLE
[WIP] Rewrite wordcount plugin

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -189,6 +189,7 @@ function! airline#check_mode(winnr)
   if get(w:, 'airline_lastmode', '') != mode_string
     call airline#highlighter#highlight_modified_inactive(context.bufnr)
     call airline#highlighter#highlight(l:mode, context.bufnr)
+    silent doautocmd User AirlineModeChanged
     let w:airline_lastmode = mode_string
   endif
 

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -1,12 +1,59 @@
 " MIT License. Copyright (c) 2013-2018 Bailey Ling et al.
-" vim: et ts=2 sts=2 sw=2
+" vim: et ts=2 sts=2 sw=2 fdm=marker
 
 scriptencoding utf-8
 
-let s:formatter = get(g:, 'airline#extensions#wordcount#formatter', 'default')
-let g:airline#extensions#wordcount#filetypes = get(g:, 'airline#extensions#wordcount#filetypes',
-      \ '\vhelp|markdown|rst|org|text|asciidoc|tex|mail')
+" get wordcount {{{1
+if exists('*wordcount')
+  function! s:get_wordcount(type)
+    return string(wordcount()[a:type])
+  endfunction
+else
+  function! s:get_wordcount(type)
+    " index to retrieve from whitespace-separated output of g_CTRL-G
+    " 11 - words, 5 - visual words (in visual mode)
+    let idx = (a:type == 'words') ? 11 : 5
 
+    let save_status = v:statusmsg
+    execute "silent normal! g\<cn-g>"
+    let stat = v:statusmsg
+    let v:statusmsg = save_status
+
+    let parts = split(stat)
+    if len(parts) > idx
+      return parts[idx]
+    endif
+  endfunction
+endif
+
+" format {{{1
+let s:formatter = get(g:, 'airline#extensions#wordcount#formatter', 'default')
+
+" wrapper function for compatibility; redefined below for old-style formatters
+function! s:format_wordcount(type)
+  return airline#extensions#wordcount#formatters#{s:formatter}#transform(
+        \ s:get_wordcount(a:type))
+endfunction
+
+" check user-defined formatter exists and has appropriate functions, otherwise
+" fall back to default
+if s:formatter !=# 'default'
+  execute 'runtime! autoload/airline/extensions/wordcount/formatters/'.s:formatter
+  if !exists('*airline#extensions#wordcount#formatters#{s:formatter}#transform')
+    if !exists('*airline#extensions#wordcount#formatters#{s:formatter}#format')
+      let s:formatter = 'default'
+    else
+      " redefine for backwords compatibility
+      function! s:format_wordcount(type)
+        if a:type !=# 'visual_words'
+          return airline#extensions#wordcount#formatters#{s:formatter}#format()
+        endif
+      endfunction
+    endif
+  endif
+endif
+
+" update {{{1
 function! s:wordcount_update()
   if empty(bufname(''))
     return
@@ -14,7 +61,7 @@ function! s:wordcount_update()
   if match(&ft, get(g:, 'airline#extensions#wordcount#filetypes')) > -1
     let l:mode = mode()
     if l:mode ==# 'v' || l:mode ==# 'V' || l:mode ==# 's' || l:mode ==# 'S'
-      let b:airline_wordcount = airline#extensions#wordcount#formatters#{s:formatter}#format()
+      let b:airline_wordcount = s:format_wordcount('visual_words')
       let b:airline_change_tick = b:changedtick
     else
       if get(b:, 'airline_wordcount_cache', '') is# '' ||
@@ -22,7 +69,7 @@ function! s:wordcount_update()
             \ get(b:, 'airline_change_tick', 0) != b:changedtick || 
             \ get(b:, 'airline_winwidth', 0) != winwidth(0)
         " cache data
-        let b:airline_wordcount = airline#extensions#wordcount#formatters#{s:formatter}#format()
+        let b:airline_wordcount = s:format_wordcount('words')
         let b:airline_wordcount_cache = b:airline_wordcount
         let b:airline_change_tick = b:changedtick
         let b:airline_winwidth = winwidth(0)
@@ -30,6 +77,11 @@ function! s:wordcount_update()
     endif
   endif
 endfunction
+
+" autocmds & airline functions {{{1
+" default filetypes
+let g:airline#extensions#wordcount#filetypes = get(g:, 'airline#extensions#wordcount#filetypes',
+      \ '\vhelp|markdown|rst|org|text|asciidoc|tex|mail')
 
 function! airline#extensions#wordcount#apply(...)
   if match(&ft, get(g:, 'airline#extensions#wordcount#filetypes')) > -1

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -11,7 +11,7 @@ if exists('*wordcount')
 else
   function! s:get_wordcount(type)
     " index to retrieve from whitespace-separated output of g_CTRL-G
-    " 11 - words, 5 - visual words (in visual mode)
+    " 11 : words, 5 : visual words (in visual mode)
     let idx = (a:type == 'words') ? 11 : 5
 
     let save_status = v:statusmsg
@@ -31,7 +31,7 @@ let s:formatter = get(g:, 'airline#extensions#wordcount#formatter', 'default')
 
 " wrapper function for compatibility; redefined below for old-style formatters
 function! s:format_wordcount(type)
-  return airline#extensions#wordcount#formatters#{s:formatter}#transform(
+  return airline#extensions#wordcount#formatters#{s:formatter}#to_string(
         \ s:get_wordcount(a:type))
 endfunction
 
@@ -39,7 +39,7 @@ endfunction
 " fall back to default
 if s:formatter !=# 'default'
   execute 'runtime! autoload/airline/extensions/wordcount/formatters/'.s:formatter
-  if !exists('*airline#extensions#wordcount#formatters#{s:formatter}#transform')
+  if !exists('*airline#extensions#wordcount#formatters#{s:formatter}#to_string')
     if !exists('*airline#extensions#wordcount#formatters#{s:formatter}#format')
       let s:formatter = 'default'
     else

--- a/autoload/airline/extensions/wordcount/formatters/default.vim
+++ b/autoload/airline/extensions/wordcount/formatters/default.vim
@@ -3,57 +3,28 @@
 
 scriptencoding utf-8
 
-function! airline#extensions#wordcount#formatters#default#format()
-  let fmt = get(g:, 'airline#extensions#wordcount#formatter#default#fmt', '%s words')
-  let fmt_short = get(g:, 'airline#extensions#wordcount#formatter#default#fmt_short', fmt == '%s words' ? '%sW' : fmt)
-  let words = string(s:wordcount())
-  if empty(words)
+let s:fmt = get(g:, 'airline#extensions#wordcount#formatter#default#fmt', '%s words')
+let s:fmt_short = get(g:, 'airline#extensions#wordcount#formatter#default#fmt_short', s:fmt == '%s words' ? '%sW' : s:fmt)
+
+function! airline#extensions#wordcount#formatters#default#transform(text)
+  if empty(a:text)
     return
   endif
+
   let result = g:airline_symbols.space . g:airline_right_alt_sep . g:airline_symbols.space
   if winwidth(0) >= 80
     let separator = s:get_decimal_group()
-    if words > 999 && !empty(separator)
+    if a:text > 999 && !empty(separator)
       " Format number according to locale, e.g. German: 1.245 or English: 1,245
-      let words = substitute(words, '\d\@<=\(\(\d\{3\}\)\+\)$', separator.'&', 'g')
+      let text = substitute(a:text, '\d\@<=\(\(\d\{3\}\)\+\)$', separator.'&', 'g')
+    else
+      let text = a:text
     endif
-    let result = printf(fmt, words). result
+    let result = printf(s:fmt, a:text). result
   else
-    let result = printf(fmt_short, words). result
+    let result = printf(s:fmt_short, a:text). result
   endif
   return result
-endfunction
-
-function! s:wordcount()
-  if exists("*wordcount")
-    let l:mode = mode()
-    if l:mode ==# 'v' || l:mode ==# 'V' || l:mode ==# 's' || l:mode ==# 'S'
-      let l:visual_words = wordcount()['visual_words']
-      if l:visual_words != ''
-        return l:visual_words
-      else
-        return 0
-      endif
-    else
-      return wordcount()['words']
-    endif
-  elseif mode() =~? 's'
-    return
-  else
-    let old_status = v:statusmsg
-    let position = getpos(".")
-    exe "silent normal! g\<c-g>"
-    let stat = v:statusmsg
-    call setpos('.', position)
-    let v:statusmsg = old_status
-
-    let parts = split(stat)
-    if len(parts) > 11
-      return str2nr(parts[11])
-    else
-      return
-    endif
-  endif
 endfunction
 
 function! s:get_decimal_group()
@@ -64,3 +35,4 @@ function! s:get_decimal_group()
   endif
   return ''
 endfunction
+

--- a/autoload/airline/extensions/wordcount/formatters/default.vim
+++ b/autoload/airline/extensions/wordcount/formatters/default.vim
@@ -6,33 +6,30 @@ scriptencoding utf-8
 let s:fmt = get(g:, 'airline#extensions#wordcount#formatter#default#fmt', '%s words')
 let s:fmt_short = get(g:, 'airline#extensions#wordcount#formatter#default#fmt_short', s:fmt == '%s words' ? '%sW' : s:fmt)
 
-function! airline#extensions#wordcount#formatters#default#transform(text)
-  if empty(a:text)
+if match(get(v:, 'lang', ''), '\v\cC|en') > -1
+  let s:decimal_group = ','
+elseif match(get(v:, 'lang', ''), '\v\cde|dk|fr|pt') > -1
+  let s:decimal_group = '.'
+else
+  let s:decimal_group = ''
+endif
+
+function! airline#extensions#wordcount#formatters#default#to_string(wordcount)
+  if empty(a:wordcount)
     return
   endif
 
-  let result = g:airline_symbols.space . g:airline_right_alt_sep . g:airline_symbols.space
   if winwidth(0) >= 80
-    let separator = s:get_decimal_group()
-    if a:text > 999 && !empty(separator)
+    if a:wordcount > 999
       " Format number according to locale, e.g. German: 1.245 or English: 1,245
-      let text = substitute(a:text, '\d\@<=\(\(\d\{3\}\)\+\)$', separator.'&', 'g')
+      let wordcount = substitute(a:wordcount, '\d\@<=\(\(\d\{3\}\)\+\)$', s:decimal_group.'&', 'g')
     else
-      let text = a:text
+      let wordcount = a:wordcount
     endif
-    let result = printf(s:fmt, a:text). result
+    let str = printf(s:fmt, wordcount)
   else
-    let result = printf(s:fmt_short, a:text). result
+    let str = printf(s:fmt_short, a:wordcount)
   endif
-  return result
-endfunction
-
-function! s:get_decimal_group()
-  if match(get(v:, 'lang', ''), '\v\cC|en') > -1
-    return ','
-  elseif match(get(v:, 'lang', ''), '\v\cde|dk|fr|pt') > -1
-    return '.'
-  endif
-  return ''
+  return str . g:airline_symbols.space . g:airline_right_alt_sep . g:airline_symbols.space
 endfunction
 

--- a/autoload/airline/extensions/wordcount/formatters/default.vim
+++ b/autoload/airline/extensions/wordcount/formatters/default.vim
@@ -3,8 +3,14 @@
 
 scriptencoding utf-8
 
-let s:fmt = get(g:, 'airline#extensions#wordcount#formatter#default#fmt', '%s words')
-let s:fmt_short = get(g:, 'airline#extensions#wordcount#formatter#default#fmt_short', s:fmt == '%s words' ? '%sW' : s:fmt)
+function s:update_fmt(...)
+  let s:fmt = get(g:, 'airline#extensions#wordcount#formatter#default#fmt', '%s words')
+  let s:fmt_short = get(g:, 'airline#extensions#wordcount#formatter#default#fmt_short', s:fmt == '%s words' ? '%sW' : s:fmt)
+endfunction
+
+" Reload format when statusline is rebuilt
+call s:update_fmt()
+call airline#add_statusline_funcref(function('s:update_fmt'))
 
 if match(get(v:, 'lang', ''), '\v\cC|en') > -1
   let s:decimal_group = ','


### PR DESCRIPTION
This is a major rewrite but the principles are mostly the same. The old code had a weird structure, unnecessary autocommands, and support for visual word counting hacked into it (and that's undocumented). The new implementation is significantly faster, and the code structure makes more sense (at least in my subjective opinion). Everything is complete except the documentation, which is why I tagged this [WIP]. If everything else is ok I'll update that.

The most major change is using a new function to interface with the formatter. Originally the formatter was itself responsible for actually getting the wordcount, which doesn't make sense, and also makes a lot more work for anyone wanting to write a formatter. Now the wordcount plugin itself handles the logic of getting the wordcount; a new function - `to_string()`, is called, which takes the wordcount number and formats it. Any formatter will support visual mode this way, since the visual wordcount is just passed to `to_string()`. The old `format()` function is still supported though, so nothing should break.

Because the wordcount plugin gets the wordcount itself, it can be cached so that the formatter only gets called when the wordcount has changed. That massively reduces calls to the formatter and I think it's the most significant optimisation to the logic.

I changed `g:airline#extensions#wordcount#filetypes` to support a list of filetypes, more intuitive than a pattern match (and `['all']` enables word-counting for all filetypes). The old pattern match is still tried if it isn't a list.

No CursorMoved autocommands are needed anymore, the logic is triggered directly from the statusline through `airline#extensions#wordcount#get()`. The old code registered CursorMoved autocommands and calculated the wordcount for all buffers, even ones that never had to display a wordcount - it was just never used in the statusline. So that's a massive optimisation for all buffers where the user doesn't want word-counting.

The code is also split up into more functions, with different functions being defined for compatiblity with old Vim/old-style formatters, a bit of a crude dynamic dispatch approach. I also set the locale specific seperator once only at plugin load (under the assumption that people don't change their locale in the middle of an editing session).

Some numbers (Vim 8.1, patches 1-374):
I typed in the same couple paragraphs of text with and without the rewrite. The major improvement is the reduction in calls the formatter. From:

```
FUNCTION  airline#extensions#wordcount#formatters#default#format()
    Defined: ~/.vim/devel/vim-airline/autoload/airline/extensions/wordcount/formatters/default.vim line 6
Called 709 times
Total time:   0.192237
 Self time:   0.118619
```
to:
```
FUNCTION  airline#extensions#wordcount#formatters#default#to_string()
    Defined: ~/.vim/devel/vim-airline/autoload/airline/extensions/wordcount/formatters/default.vim line 23
Called 143 times
Total time:   0.010432
 Self time:   0.010432
```

To measure the total improvement, compare the "main" function, which sets off the call chain to update `b:airline_wordcount` if necessary. In the old version that is `s:wordcount_update()` (called by autocommand):
```
FUNCTION  <SNR>94_wordcount_update()
    Defined: ~/.vim/devel/vim-airline/autoload/airline/extensions/wordcount.vim line 10
Called 711 times
Total time:   0.349182
 Self time:   0.156945
```
After the rewrite, it's `airline#extensions#wordcount#get()`, called from the statusline:
```
FUNCTION  airline#extensions#wordcount#get()
    Defined: ~/.vim/devel/vim-airline/autoload/airline/extensions/wordcount.vim line 69
Called 735 times
Total time:   0.124206
 Self time:   0.046229
```

So that's almost 3 times faster. For buffers where wordcounting is not enabled `s:wordcount_update()` would still run, and incur a performance cost. Now there is no performance penalty for filetypes where word counting is not used.

I documented the exact changes in each commit message. The plugin should still work reverting any number of commits I added.