### PR TITLE
The rest of the wordcount fixes, and some improvements

### DIFF
--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -12,7 +12,7 @@ if exists('*wordcount')
 else  " Pull wordcount from the g_ctrl-g stats
   function! s:get_wordcount(visual_mode_active)
     let pattern = a:visual_mode_active
-          \ ? '\d\+\ze Words;'
+          \ ? 'Lines; \zs\d\+\ze of \d\+ Words;'
           \ : 'Word \d\+ of \zs\d\+'
 
     let save_status = v:statusmsg

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -7,27 +7,26 @@ scriptencoding utf-8
 if exists('*wordcount')
   function! s:get_wordcount(visual_mode_active)
     let query = a:visual_mode_active ? 'visual_words' : 'words'
-    let result = wordcount()
-    if has_key(result, query)
-      return string(result[query])
-    endif
-    return ''
+    return get(wordcount(), query, 0)
   endfunction
-else
+else  " Pull wordcount from the g_ctrl-g stats
   function! s:get_wordcount(visual_mode_active)
-    " index to retrieve from whitespace-separated output of g_CTRL-G
-    " 11 : words, 5 : visual words (in visual mode)
-    let idx = a:visual_mode_active ? 5 : 11
+    let pattern = a:visual_mode_active
+          \ ? '\d\+\ze Words;'
+          \ : 'Word \d\+ of \zs\d\+'
 
     let save_status = v:statusmsg
-    execute "silent normal! g\<c-g>"
-    let stat = v:statusmsg
+    if !a:visual_mode_active && col('.') == col('$')
+      let save_pos = getpos('.')
+      execute "silent normal! g\<c-g>"
+      call setpos('.', save_pos)
+    else
+      execute "silent normal! g\<c-g>"
+    endif
+    let stats = v:statusmsg
     let v:statusmsg = save_status
 
-    let parts = split(substitute(stat, ';', '', 'g'))
-    if len(parts) > idx
-      return parts[idx]
-    endif
+    return str2nr(matchstr(stats, pattern))
   endfunction
 endif
 

--- a/autoload/airline/extensions/wordcount/formatters/default.vim
+++ b/autoload/airline/extensions/wordcount/formatters/default.vim
@@ -3,16 +3,16 @@
 
 scriptencoding utf-8
 
-function! s:update_fmt(...)
+function! airline#extensions#wordcount#formatters#default#update_fmt(...)
   let s:fmt = get(g:, 'airline#extensions#wordcount#formatter#default#fmt', '%s words')
   let s:fmt_short = get(g:, 'airline#extensions#wordcount#formatter#default#fmt_short', s:fmt == '%s words' ? '%sW' : s:fmt)
 endfunction
 
 " Reload format when statusline is rebuilt
-call s:update_fmt()
-if index(g:airline_statusline_funcrefs, function('s:update_fmt')) == -1
+call airline#extensions#wordcount#formatters#default#update_fmt()
+if index(g:airline_statusline_funcrefs, function('airline#extensions#wordcount#formatters#default#update_fmt')) == -1
   " only add it, if not already done
-  call airline#add_statusline_funcref(function('s:update_fmt'))
+  call airline#add_statusline_funcref(function('airline#extensions#wordcount#formatters#default#update_fmt'))
 endif
 
 if match(get(v:, 'lang', ''), '\v\cC|en') > -1
@@ -24,10 +24,6 @@ else
 endif
 
 function! airline#extensions#wordcount#formatters#default#to_string(wordcount)
-  if empty(a:wordcount)
-    return
-  endif
-
   if winwidth(0) >= 80
     if a:wordcount > 999
       " Format number according to locale, e.g. German: 1.245 or English: 1,245
@@ -41,4 +37,3 @@ function! airline#extensions#wordcount#formatters#default#to_string(wordcount)
   endif
   return str . g:airline_symbols.space . g:airline_right_alt_sep . g:airline_symbols.space
 endfunction
-

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -592,16 +592,15 @@ eclim <https://eclim.org>
   let g:airline#extensions#eclim#enabled = 1
 
 -------------------------------------                    *airline-wordcount*
-display the word count of the document or visual selection
-
-* enable/disable word counting. >
+* enable/disable word counting of the document/visual selection >
   let g:airline#extensions#wordcount#enabled = 1
 <
 * set list of filetypes for which word counting is enabled: >
-  " the default value matches filetypes typically used for documentation
+  " The default value matches filetypes typically used for documentation
   " such as markdown and help files.
   let g:airline#extensions#wordcount#filetypes =
     \ ['help', 'markdown', 'rst', 'org', 'text', 'asciidoc', 'tex', 'mail']
+  " Use ['all'] to enable for all filetypes.
 
 * defines the name of a formatter for word count will be displayed: >
   " The default will try to guess LC_NUMERIC and format number accordingly


### PR DESCRIPTION
I compiled vim 7.2, so I think I've found the remaining problems now.

As mentioned in the commit details:
- Old vim doesn't like funcrefs of script local function, so the format update function is now an autoload
- Apparently 'normal!' can sometimes move the cursor if you were in insert mode so I compensated for that. It feels like it should be a vim bug, even if that won't help with supporting old versions of vim.
- Stopped to_string() from refusing to format 0. It tries to format everything now, not sure what the expected behavior should be if you pass it a string (right now it optimistically tries to format everything)

- Now the old get_wordcount() pulls the right values with a direct match. Seems simpler and more elegant than using magic indices.
- I also changed one of the safety checks I missed to a simpler get() call. Hope you don't mind.
- Added a bit of documentation that I forgot last time.