### PR TITLE
Add dictionary key check for d.severity

### DIFF
--- a/autoload/airline/extensions/languageclient.vim
+++ b/autoload/airline/extensions/languageclient.vim
@@ -67,7 +67,7 @@ function! airline#extensions#languageclient#get(type)
 
   let cnt = 0
   for d in s:diagnostics_for_buffer()
-    if d.severity == a:type
+    if has_key(d, 'severity') && d.severity == a:type
       let cnt += 1
     endif
   endfor


### PR DESCRIPTION
We need the same has key check that was added in aec0a1a15a4d24b7b5f1c619bbfd123331ad64f4.