### PR TITLE
Externalize quickfix function returning text

### DIFF
--- a/autoload/airline/extensions/quickfix.vim
+++ b/autoload/airline/extensions/quickfix.vim
@@ -13,7 +13,7 @@ endif
 
 function! airline#extensions#quickfix#apply(...)
   if &buftype == 'quickfix'
-    let w:airline_section_a = s:get_text()
+    let w:airline_section_a = airline#extensions#quickfix#get_type()
     let w:airline_section_b = '%{get(w:, "quickfix_title", "")}'
     let w:airline_section_c = ''
     let w:airline_section_x = ''
@@ -31,7 +31,7 @@ function! airline#extensions#quickfix#inactive_qf_window(...)
   endif
 endfunction
 
-function! s:get_text()
+function! airline#extensions#quickfix#get_type()
   if exists("*win_getid") && exists("*getwininfo")
     let dict = getwininfo(win_getid())
     if len(dict) > 0 && get(dict[0], 'quickfix', 0) && !get(dict[0], 'loclist', 0)


### PR DESCRIPTION
Useful when one wants to use this function for something else and to know if a QuickFix window is actually a Location list with qf as `&filetype`.

References:

- https://stackoverflow.com/questions/18522086/what-is-the-best-way-to-distinguish-the-current-buffer-is-location-list-or-quick
- http://vim.1045645.n5.nabble.com/detect-QuickFix-window-list-or-LocationList-td4952180.html