### PR TITLE
Improve update logic after ale finished

### DIFF
--- a/autoload/airline/extensions/ale.vim
+++ b/autoload/airline/extensions/ale.vim
@@ -74,6 +74,7 @@ function! airline#extensions#ale#init(ext)
   augroup airline_ale
     autocmd!
     autocmd CursorHold,BufWritePost * call <sid>ale_refresh()
+    autocmd User ALEJobStarted,ALELintPost call <sid>ale_refresh()
   augroup END
 endfunction
 


### PR DESCRIPTION
Previously the ale refresh was triggered after user interactions only.
When linting takes some time and the user is not actively working the
ale information was not updated while the things ale directly controls
were updated. This change makes showing linting results a loot smoother.