### PR TITLE
Fix missing TerminalOpen event

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -128,7 +128,9 @@ function! s:airline_toggle()
         autocmd FocusGained * unlet! w:airline_lastmode | :call <sid>airline_refresh()
       endif
 
-      autocmd TerminalOpen * :call airline#load_theme() " reload current theme for Terminal, forces the terminal extension to be loaded
+      if exists("##TerminalOpen") 
+        autocmd TerminalOpen * :call airline#load_theme() " reload current theme for Terminal, forces the terminal extension to be loaded
+      endif
       autocmd TabEnter * :unlet! w:airline_lastmode | let w:airline_active=1
       autocmd BufWritePost */autoload/airline/themes/*.vim
             \ exec 'source '.split(globpath(&rtp, 'autoload/airline/themes/'.g:airline_theme.'.vim', 1), "\n")[0]


### PR DESCRIPTION
E216: No such group or event: TerminalOpen * :call airline#load_theme()

See https://travis-ci.org/vim-airline/vim-airline/builds/457461499#L545