### PR TITLE
[RDY] defx integration

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -217,6 +217,10 @@ function! airline#extensions#load()
     let s:filetype_regex_overrides['^int-'] = ['vimshell','%{substitute(&ft, "int-", "", "")}']
   endif
 
+  if exists(':Defx')
+    let s:filetype_overrides['defx'] = ['defx', '%{b:defx.paths[0]}']
+  endif
+
   if get(g:, 'airline#extensions#branch#enabled', 1) && (
           \ airline#util#has_fugitive() ||
           \ airline#util#has_lawrencium() ||


### PR DESCRIPTION
This adds support for [defx](https://github.com/Shougo/defx.nvim). I'm tagging this as WIP since I cannot get the `%{printf('%s', b:defx.paths[0][-15:])}` part to show up in section_b. Running `echo printf('%s', b:defx.paths[0][-15:])` in a defx buffer correctly shows the (truncated) path though. Help is appreciated.