### PR TITLE
make VimLeave autocmd nested

### DIFF
--- a/autoload/airline/extensions/cursormode.vim
+++ b/autoload/airline/extensions/cursormode.vim
@@ -111,7 +111,7 @@ endfunction
 
 augroup airline#extensions#cursormode
   autocmd!
-  autocmd VimLeave * call s:set_cursor_color_for(g:cursormode_exit_mode)
+  autocmd VimLeave * nested call s:set_cursor_color_for(g:cursormode_exit_mode)
   " autocmd VimEnter * call airline#extensions#cursormode#activate()
   autocmd Colorscheme * call airline#extensions#cursormode#activate()
 augroup END


### PR DESCRIPTION
add "nested" to autocmd to make it play well w/ YouCompleteMe

see https://github.com/valloric/youcompleteme/blob/109a0192795a9b7ea87e382cdbeeabcff091473c/README.md#ycm-does-not-shut-down-when-i-quit-vim