### PR TITLE
Fixed t:undotree undefined error

### DIFF
--- a/autoload/airline/extensions/undotree.vim
+++ b/autoload/airline/extensions/undotree.vim
@@ -11,14 +11,14 @@ function! airline#extensions#undotree#apply(...)
   if exists('t:undotree')
     if &ft == 'undotree'
       if exists('*t:undotree.GetStatusLine')
-        call airline#extensions#apply_left_override('undo', '%{t:undotree.GetStatusLine()}')
+        call airline#extensions#apply_left_override('undo', '%{exists("t:undotree") ? t:undotree.GetStatusLine() : ""}')
       else
         call airline#extensions#apply_left_override('undotree', '%f')
       endif
     endif
 
     if &ft == 'diff' && exists('*t:diffpanel.GetStatusLine')
-      call airline#extensions#apply_left_override('diff', '%{t:diffpanel.GetStatusLine()}')
+      call airline#extensions#apply_left_override('diff', '%{exists("t:diffpanel") ? t:diffpanel.GetStatusLine() : ""}')
     endif
   endif
 endfunction


### PR DESCRIPTION
the ```t:undotree.GetStatusLine()``` is appended to the status line when ```t:undotree``` exists, but it seems like the ```statusline``` will be executed when ```t:undtree``` is no longer available during window destruction.