### PR TITLE
Remove incorrect copyright attribution

### DIFF
--- a/autoload/airline/extensions/languageclient.vim
+++ b/autoload/airline/extensions/languageclient.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2018 Bjorn Neergaard, w0rp, hallettj et al.
+" MIT License. Copyright (c) 2013-2018 Bjorn Neergaard, hallettj et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8


### PR DESCRIPTION
I have never touched anything in this file, nor in the LanguageClient plugin, so the copyright attribution is incorrect. @neersighted may also wish to be removed from the list here.