### PR TITLE
Respect minwidth for hunks and branch parts

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -266,8 +266,9 @@ function! airline#extensions#branch#head()
     endif
   endif
 
+  let winwidth = get(airline#parts#get('branch'), 'minwidth', 120)
   let minwidth = empty(get(b:, 'airline_hunks', '')) ? 14 : 7
-  let b:airline_head = airline#util#shorten(b:airline_head, 120, minwidth)
+  let b:airline_head = airline#util#shorten(b:airline_head, winwidth, minwidth)
   return b:airline_head
 endfunction
 

--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -266,14 +266,14 @@ function! airline#extensions#branch#head()
     endif
   endif
 
-  let winwidth = get(airline#parts#get('branch'), 'minwidth', 120)
-  let minwidth = empty(get(b:, 'airline_hunks', '')) ? 14 : 7
-  let b:airline_head = airline#util#shorten(b:airline_head, winwidth, minwidth)
   return b:airline_head
 endfunction
 
 function! airline#extensions#branch#get_head()
   let head = airline#extensions#branch#head()
+  let winwidth = get(airline#parts#get('branch'), 'minwidth', 120)
+  let minwidth = empty(get(b:, 'airline_hunks', '')) ? 14 : 7
+  let head = airline#util#shorten(head, winwidth, minwidth)
   let empty_message = get(g:, 'airline#extensions#branch#empty_message', '')
   let symbol = get(g:, 'airline#extensions#branch#symbol', g:airline_symbols.branch)
   return empty(head)

--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -75,9 +75,10 @@ function! airline#extensions#hunks#get_hunks()
   endif
   let hunks = s:get_hunks()
   let string = ''
+  let winwidth = get(airline#parts#get('hunks'), 'minwidth', 100)
   if !empty(hunks)
     for i in [0, 1, 2]
-      if (s:non_zero_only == 0 && airline#util#winwidth() > 100) || hunks[i] > 0
+      if (s:non_zero_only == 0 && airline#util#winwidth() > winwidth) || hunks[i] > 0
         let string .= printf('%s%s ', s:hunk_symbols[i], hunks[i])
       endif
     endfor

--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -42,7 +42,7 @@ function! s:get_hunks_empty()
   return ''
 endfunction
 
-function! s:get_hunks()
+function! airline#extensions#hunks#get_raw_hunks()
   if !exists('b:source_func') || get(b:, 'source_func', '') is# 's:get_hunks_empty'
     if get(g:, 'loaded_signify') && sy#buffer_is_active()
       let b:source_func = 's:get_hunks_signify'
@@ -73,7 +73,7 @@ function! airline#extensions#hunks#get_hunks()
     \ get(b:, 'source_func', '') isnot# 's:get_hunks_changes'
     return b:airline_hunks
   endif
-  let hunks = s:get_hunks()
+  let hunks = airline#extensions#hunks#get_raw_hunks()
   let string = ''
   let winwidth = get(airline#parts#get('hunks'), 'minwidth', 100)
   if !empty(hunks)

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -151,8 +151,14 @@ function! airline#init#bootstrap()
         \ 'raw': '/%L%{g:airline_symbols.maxlinenr}',
         \ 'accent': 'bold'})
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
-  call airline#parts#define_empty(['hunks', 'branch', 'obsession', 'tagbar',
-        \ 'syntastic-warn', 'syntastic-err', 'eclim', 'whitespace','windowswap',
+  call airline#parts#define('hunks', {
+        \ 'raw': '',
+        \ 'minwidth': 100})
+  call airline#parts#define('branch', {
+        \ 'raw': '',
+        \ 'minwidth': 120})
+  call airline#parts#define_empty(['obsession', 'tagbar', 'syntastic-warn',
+        \ 'syntastic-err', 'eclim', 'whitespace','windowswap',
         \ 'ycm_error_count', 'ycm_warning_count', 'neomake_error_count',
         \ 'neomake_warning_count', 'ale_error_count', 'ale_warning_count',
         \ 'languageclient_error_count', 'languageclient_warning_count'])

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -143,7 +143,7 @@ values):
   let g:airline_inactive_collapse=1
 <
 * Use alternative seperators for the statusline of inactive windows >
-  let g:airline_inactive_alt_sep=1 
+  let g:airline_inactive_alt_sep=1
 <
 * themes are automatically selected based on the matching colorscheme. this
   can be overridden by defining a value. >
@@ -233,7 +233,7 @@ values):
 <
 * Display the statusline in the tabline (first top line): >
   let g:airline_statusline_ontop = 1
-< 
+<
   Setting this option, allows to use the statusline option to be used by
   a custom function or another plugin, since airline won't change it.
 
@@ -828,7 +828,7 @@ with the middle mouse button to delete that buffer.
 
   Note: last option can be used to specify a different formatter for
   displaying the numbers. By default tabline/formatter/tabnr.vim is used
-  The argument of that setting should either be a filename that exists 
+  The argument of that setting should either be a filename that exists
   autoload/airline/extensions/tabline/formatter/ (without .vim extension)
   and needs to provide a format() function. Alternatively you can use a
   custom function name, that is defined e.g. in your .vimrc file. In any
@@ -1161,7 +1161,7 @@ virtualenv <https://github.com/jmcantrell/vim-virtualenv>
   " (see above at g:airline#extensions#whitespace#checks)
   " To disable mixed-indent-file for go files use:
   let g:airline#extensions#whitespace#skip_indent_check_ft = {'go': ['mixed-indent-file']}
-<  
+<
 -------------------------------------                   *airline-windowswap*
 vim-windowswap <https://github.com/wesQ3/vim-windowswap>
 

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -632,6 +632,10 @@ vim-signify <https://github.com/mhinz/vim-signify>
 changesPlugin <https://github.com/chrisbra/changesPlugin>
 quickfixsigns <https://github.com/tomtom/quickfixsigns_vim>
 
+You can use `airline#extensions#hunks#get_raw_hunks()` to get the full hunks,
+without shortening. This allows for advanced customization, or a quick way of
+querying how many changes you got. It will return something like '+4 ~2 -1'.
+
 * enable/disable showing a summary of changed hunks under source control. >
   let g:airline#extensions#hunks#enabled = 1
 <


### PR DESCRIPTION
Hi, first let me thank you for an awesome vim plugin ❤️ 

This contains three related changes. First a fix to make `hunks` and `branch` respect `minwidth` instead of hard coding 100 and 120 respectively. I've done this very carefully to not break anything. Secondly a small tweak to allow advanced customization of the `hunks`. This just exposes the previously `s:` function `get_hunks` as `get_raw_hunks`.

Finally, and this is the one I'm a bit unsure of, I move the branch name shortening from `head` to `get_head`, which means `b:airline_head` isn't shortened anymore. All code inside this plugin are fine with this, as they only check if it's empty or not. But it's technically a breaking change, I think.

If you don't like a commit, it can be easily rebased away. I'm looking forward to your feedback.