### PR TITLE
Fix the formatting of syntastic error messages

### DIFF
--- a/autoload/airline/extensions/syntastic.vim
+++ b/autoload/airline/extensions/syntastic.vim
@@ -22,9 +22,9 @@ function! airline#extensions#syntastic#get(type)
   let _backup = get(g:, 'syntastic_stl_format', '')
   let is_err = (a:type  is# 'error')
   if is_err
-    let g:syntastic_stl_format = get(g:, 'airline#extensions#syntastic#stl_format_err', '%E{[%e(#%fe)]}')
+    let g:syntastic_stl_format = get(g:, 'airline#extensions#syntastic#stl_format_err', '%E{[%fe(#%e)]}')
   else
-    let g:syntastic_stl_format = get(g:, 'airline#extensions#syntastic#stl_format_warn', '%W{[%w(#%fw)]}')
+    let g:syntastic_stl_format = get(g:, 'airline#extensions#syntastic#stl_format_warn', '%W{[%fw(#%w)]}')
   endif
   let cnt = SyntasticStatuslineFlag()
   if !empty(_backup)

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -770,13 +770,13 @@ syntastic <https://github.com/vim-syntastic/syntastic>
   let airline#extensions#syntastic#error_symbol = 'E:'
 <
 * syntastic statusline error format (see |syntastic_stl_format|) >
-  let airline#extensions#syntastic#stl_format_err = '%E{[%e(#%fe)]}'
+  let airline#extensions#syntastic#stl_format_err = '%E{[%fe(#%e)]}'
 
 * syntastic warning >
   let airline#extensions#syntastic#warning_symbol = 'W:'
 <
 * syntastic statusline warning format (see |syntastic_stl_format|) >
-  let airline#extensions#syntastic#stl_format_warn = '%W{[%w(#%fw)]}'
+  let airline#extensions#syntastic#stl_format_warn = '%W{[%fw(#%w)]}'
 <
 -------------------------------------                      *airline-tabline*
 Note: If you're using the ctrlspace tabline only the option marked with (c)


### PR DESCRIPTION
The magic flags were in the wrong order, `%e` is the number of errors, it
should go in the parentheses after the `#` symbol. `%fe` is the line number
of the first error. Same for the warnings.