### PR TITLE
Add formatter for short paths

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/short_path.vim
+++ b/autoload/airline/extensions/tabline/formatters/short_path.vim
@@ -1,0 +1,19 @@
+" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+let s:fnamecollapse = get(g:, 'airline#extensions#tabline#fnamecollapse', 1)
+
+function! airline#extensions#tabline#formatters#short_path#format(bufnr, buffers)
+  let _ = ''
+
+  let name = bufname(a:bufnr)
+  if empty(name)
+    let _ .= '[No Name]'
+  else
+    let _ .= fnamemodify(name, ':p:h:t') . '/' . fnamemodify(name, ':t')
+  endif
+
+  return airline#extensions#tabline#formatters#default#wrap_name(a:bufnr, _)
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -976,7 +976,15 @@ with the middle mouse button to delete that buffer.
   " The `unique_tail_improved` - another algorithm, that will smartly uniquify
   " buffers names with similar filename, suppressing common parts of paths.
   let g:airline#extensions#tabline#formatter = 'unique_tail_improved'
-<
+
+  " The `short_path` - is a simple formatter, that will show the
+  filename, with its extension, and the first parent directory only.
+
+  e.g.
+     /home/user/project/subdir/file.ext -> subdir/file.ext
+
+  let g:airline#extensions#tabline#formatter = 'short_path'
+
 * configure the minimum number of buffers needed to show the tabline. >
   let g:airline#extensions#tabline#buffer_min_count = 0
 <


### PR DESCRIPTION
Add new formatter that shows the file path up to the first parent directory

This formatter comes almost directly from #1323, thanks to @sgon00 for the initial code