### PR TITLE
vim-bookmark extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -213,6 +213,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'tagbar')
   endif
 
+  if get(g:, 'airline#extensions#bookmark#enabled', 1)
+    call airline#extensions#bookmark#init(s:ext)
+    call add(s:loaded_ext, 'bookmark')
+  endif
+
   if get(g:, 'airline#extensions#csv#enabled', 1)
         \ && (get(g:, 'loaded_csv', 0) || exists(':Table'))
     call airline#extensions#csv#init(s:ext)

--- a/autoload/airline/extensions/bookmark.vim
+++ b/autoload/airline/extensions/bookmark.vim
@@ -1,0 +1,23 @@
+"
+" MIT License. Copyright (c) 2019 Bjoern Petri <bjoern.petri@sundevil.de>
+"
+function! airline#extensions#bookmark#currentbookmark()
+  if get(w:, 'airline_active', 0)
+	let file = expand("%:p")
+	if file ==# ""
+		return
+	endif
+
+	let current_line = line('.')
+	let has_bm = bm#has_bookmark_at_line(file, current_line)
+	let bm = has_bm ? bm#get_bookmark_by_line(file, current_line) : 0
+	let annotation = has_bm ? bm['annotation'] : ""
+
+	return annotation
+	endif
+  return ''
+endfunction
+
+function! airline#extensions#bookmark#init(ext)
+  call airline#parts#define_function('bookmark', 'airline#extensions#bookmark#currentbookmark')
+endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -165,6 +165,7 @@ function! airline#init#bootstrap()
         \ 'ycm_error_count', 'ycm_warning_count', 'neomake_error_count',
         \ 'neomake_warning_count', 'ale_error_count', 'ale_warning_count',
         \ 'languageclient_error_count', 'languageclient_warning_count'])
+  call airline#parts#define_text('bookmark', '')
   call airline#parts#define_text('capslock', '')
   call airline#parts#define_text('gutentags', '')
   call airline#parts#define_text('grepper', '')
@@ -197,7 +198,7 @@ function! airline#init#sections()
     let g:airline_section_gutter = airline#section#create(['%='])
   endif
   if !exists('g:airline_section_x')
-    let g:airline_section_x = airline#section#create_right(['tagbar', 'gutentags', 'grepper', 'filetype'])
+    let g:airline_section_x = airline#section#create_right(['bookmark', 'tagbar', 'gutentags', 'grepper', 'filetype'])
   endif
   if !exists('g:airline_section_y')
     let g:airline_section_y = airline#section#create_right(['ffenc'])

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -446,7 +446,13 @@ ale <https://github.com/w0rp/ale>
 <
 * ale close_lnum_symbol >
   let airline#extensions#ale#close_lnum_symbol = ')'
-<
+
+-------------------------------------                       *airline-bookmark*
+vim-bookmark <https://github.com/MattesGroeger/vim-bookmarks>
+
+* enable/disable bookmark integration >
+  let g:airline#extensions#bookmark#enabled = 1
+
 -------------------------------------                       *airline-branch*
 vim-airline will display the branch-indicator together with the branch name in
 the statusline, if one of the following plugins is installed:

--- a/t/init.vim
+++ b/t/init.vim
@@ -34,7 +34,7 @@ describe 'init sections'
   end
 
   it 'section x should be filetype'
-    Expect g:airline_section_x == '%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
+    Expect g:airline_section_x == '%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
   end
 
   it 'section y should be fenc and ff'


### PR DESCRIPTION
This extension integrates bookmark annotations, created with MattesGroeger/vim-bookmarks.

It can be enabled by using:
let g:airline#extensions#bookmark#enabled = 1

