### PR TITLE
Improve multibyte character handling in branch ext

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -279,8 +279,10 @@ function! airline#extensions#branch#head()
 
   if exists("g:airline#extensions#branch#displayed_head_limit")
     let w:displayed_head_limit = g:airline#extensions#branch#displayed_head_limit
-    if len(b:airline_head) > w:displayed_head_limit - 1
-      let b:airline_head = b:airline_head[0:(w:displayed_head_limit - 1)].(&encoding ==? 'utf-8' ?  '…' : '.')
+    if strwidth(b:airline_head) > w:displayed_head_limit - 1
+      let b:airline_head =
+            \ strcharpart(b:airline_head, 0, w:displayed_head_limit - 1)
+            \ ..(&encoding ==? 'utf-8' ?  '…' : '.')
     endif
   endif
 


### PR DESCRIPTION
This fixes a bug that causes a mangled statusline. The bug occurs, when
the `displayed_head_limit` variable is set and causes the substring
expression to take a substring, which ends in the middle of a multi-byte
character.

This patch replaces the byte-based methods for measuring the
length of the branch name and creating a substring with methods that are
character-based and multi-byte aware.

It also has the nice side effect of making the length measuring more
accurate, by taking the actual display width of multi-byte characters
and the ambiwidth setting into account.