### PR TITLE
add neoterm support

### DIFF
--- a/autoload/airline/extensions/term.vim
+++ b/autoload/airline/extensions/term.vim
@@ -23,6 +23,10 @@ function! airline#extensions#term#inactive_apply(...)
     let spc = g:airline_symbols.space
     call a:1.add_section('airline_a', spc.'TERMINAL'.spc)
     call a:1.add_section('airline_b', spc.'%f')
+    let neoterm_id = getbufvar(a:2.bufnr, 'neoterm_id')
+    if neoterm_id != ''
+      call a:1.add_section('airline_c', spc.'neoterm_'.neoterm_id.spc)
+    endif
     return 1
   endif
 endfunction


### PR DESCRIPTION
it shows neoterm_id on a inactive neoterm window

Neoterm save id in b:neoterm_id, and it supports dynamic command like :[N]T for sending string to neoterm window N.

This PR add section C on all inactive neoterm split windows to show their ID. 