### PR TITLE
update term status

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -214,7 +214,7 @@ function! airline#check_mode(winnr)
       let l:mode = ['replace']
     elseif l:m[0] =~# '\v(v|V||s|S|)'
       let l:mode = ['visual']
-    elseif l:m ==# "t"
+    elseif l:m ==# "t" && has("termninal")
       let l:mode = ['terminal']
     elseif l:m[0] ==# "c"
       let l:mode = ['commandline']

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -156,10 +156,10 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'netrw')
   endif
 
-  if has("terminal") || has('nvim')
-    call airline#extensions#term#init(s:ext)
-    call add(s:loaded_ext, 'term')
-  endif
+  " if has("terminal") || has('nvim')
+    " call airline#extensions#term#init(s:ext)
+    " call add(s:loaded_ext, 'term')
+  " endif
 
   if get(g:, 'airline#extensions#ycm#enabled', 0)
     call airline#extensions#ycm#init(s:ext)

--- a/autoload/airline/extensions/term.vim
+++ b/autoload/airline/extensions/term.vim
@@ -1,51 +1,51 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
-" vim: et ts=2 sts=2 sw=2
-
-scriptencoding utf-8
-
-function! airline#extensions#term#apply(...)
-  if &buftype == 'terminal' || bufname('%')[0] == '!'
-    let spc = g:airline_symbols.space
-
-    let name=get(g:airline_mode_map, 't', 't')
-    call a:1.add_section('airline_a', spc.name.spc)
-    call a:1.add_section('airline_b', '')
-    call a:1.add_section('airline_term', spc.s:termname())
-    call a:1.split()
-    call a:1.add_section('airline_y', '')
-    call a:1.add_section('airline_z', spc.airline#section#create_right(['linenr', 'maxlinenr']))
-    return 1
-  endif
-endfunction
-
-function! airline#extensions#term#inactive_apply(...)
-  if getbufvar(a:2.bufnr, '&buftype') == 'terminal'
-    let spc = g:airline_symbols.space
-    call a:1.add_section('airline_a', spc.'TERMINAL'.spc)
-    call a:1.add_section('airline_b', spc.'%f')
-    let neoterm_id = getbufvar(a:2.bufnr, 'neoterm_id')
-    if neoterm_id != ''
-      call a:1.add_section('airline_c', spc.'neoterm_'.neoterm_id.spc)
-    endif
-    return 1
-  endif
-endfunction
-
-function! s:termname()
-  let bufname = bufname('%')
-  if has('nvim')
-    return matchstr(bufname, 'term.*:\zs.*')
-  else
-    " get rid of leading '!'
-    if bufname[0] is# '!'
-      return bufname[1:]
-    else
-      return bufname
-    endif
-  endif
-endfunction
-
-function! airline#extensions#term#init(ext)
-  call a:ext.add_statusline_func('airline#extensions#term#apply')
-  call a:ext.add_inactive_statusline_func('airline#extensions#term#inactive_apply')
-endfunction
+" " MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" " vim: et ts=2 sts=2 sw=2
+" 
+" scriptencoding utf-8
+" 
+" function! airline#extensions#term#apply(...)
+"   if &buftype == 'terminal' || bufname('%')[0] == '!'
+"     let spc = g:airline_symbols.space
+" 
+"     let name=get(g:airline_mode_map, 't', 't')
+"     call a:1.add_section('airline_a', spc.name.spc)
+"     call a:1.add_section('airline_b', '')
+"     call a:1.add_section('airline_term', spc.s:termname())
+"     call a:1.split()
+"     call a:1.add_section('airline_y', '')
+"     call a:1.add_section('airline_z', spc.airline#section#create_right(['linenr', 'maxlinenr']))
+"     return 1
+"   endif
+" endfunction
+" 
+" function! airline#extensions#term#inactive_apply(...)
+"   if getbufvar(a:2.bufnr, '&buftype') == 'terminal'
+"     let spc = g:airline_symbols.space
+"     call a:1.add_section('airline_a', spc.'TERMINAL'.spc)
+"     call a:1.add_section('airline_b', spc.'%f')
+"     let neoterm_id = getbufvar(a:2.bufnr, 'neoterm_id')
+"     if neoterm_id != ''
+"       call a:1.add_section('airline_c', spc.'neoterm_'.neoterm_id.spc)
+"     endif
+"     return 1
+"   endif
+" endfunction
+" 
+" function! s:termname()
+"   let bufname = bufname('%')
+"   if has('nvim')
+"     return matchstr(bufname, 'term.*:\zs.*')
+"   else
+"     " get rid of leading '!'
+"     if bufname[0] is# '!'
+"       return bufname[1:]
+"     else
+"       return bufname
+"     endif
+"   endif
+" endfunction
+" 
+" function! airline#extensions#term#init(ext)
+"   call a:ext.add_statusline_func('airline#extensions#term#apply')
+"   call a:ext.add_inactive_statusline_func('airline#extensions#term#inactive_apply')
+" endfunction


### PR DESCRIPTION
This patch is for #1957 issue.

## It move's like this.

![Untitled](https://user-images.githubusercontent.com/36619465/62846675-f2aa1200-bd0c-11e9-877f-2671da349180.gif)

## before moving

![Untitled](https://user-images.githubusercontent.com/36619465/62846771-95629080-bd0d-11e9-910b-f25810edb054.gif)

I think term.vim is not need so I comment out all line in this file.

Please review this code.
