### PR TITLE
Modified dark.vim commandline foreground color

### DIFF
--- a/autoload/airline/themes/dark.vim
+++ b/autoload/airline/themes/dark.vim
@@ -131,8 +131,8 @@ let g:airline#themes#dark#palette.inactive_modified = {
       \ }
 
 " For commandline mode, we use the colors from normal mode, except the mode
-" indicator should be colored differently, e.g. blue on light green
-let s:airline_a_commandline = [ '#0000ff' , '#0cff00' , 63  , 40 ]
+" indicator should be colored differently, e.g. light green
+let s:airline_a_commandline = [ '#0000ff' , '#0cff00' , 17  , 40 ]
 let s:airline_b_commandline = [ '#ffffff' , '#444444' , 255 , 238 ]
 let s:airline_c_commandline = [ '#9cffd3' , '#202020' , 85  , 234 ]
 let g:airline#themes#dark#palette.commandline = airline#themes#generate_color_map(s:airline_a_commandline, s:airline_b_commandline, s:airline_c_commandline)


### PR DESCRIPTION

![diff](https://user-images.githubusercontent.com/7781739/64728243-958ab300-d4a8-11e9-8581-c00e5e21dfcd.png)
(top is original, bottom is modification)

The foreground color for `commandline` mode is the same as `normal` mode, which is easier to read against the green background