### PR TITLE
update airline.txt about airline-term

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1104,6 +1104,7 @@ Vim-Airline comes with a small extension for the styling the builtin
 
 * enable/disable terminal integration >
   let g:airline#extensions#term#enabled = 1
+  default: 1
 
 -------------------------------------                        *airline-tabws*
 vim-tabws <https://github.com/s1341/vim-tabws>


### PR DESCRIPTION
Hello😀. 
I added the default value for `let g: airline#extensions#term#enabled` because it was not explicitly stated in the documentation.
Please check this changing.
