### PR TITLE
check to gina.vim can use or not use on vim7 and under version

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -34,7 +34,7 @@ let s:filetype_overrides = {
       \ 'vimshell': ['vimshell','%{vimshell#get_status_string()}'],
       \ }
 
-if exists(':Gina')
+if exists(':Gina') && has('patch-7.4.1898')
   let s:filetype_overrides['gina-status'] = ['gina', '%{gina#component#repo#preset()}' ]
   let s:filetype_overrides['diff'] = ['gina', '%{gina#component#repo#preset()}' ]
   let s:filetype_overrides['gina-log'] = ['gina', '%{gina#component#repo#preset()}' ]


### PR DESCRIPTION
Hello.

`gina.vim` can only use `Vim 8.0.0107 or above or Neovim 0.2.0`

gina.vim uses `mods` feature in `plugins` dir so vim7 does not have so I added check to `exists('mods')`

As a result, even if the `:Gina` command can be executed, it can be processed without overriding if don't  exist `mods` feature.

