### PR TITLE
add fugitive statusline

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -24,6 +24,7 @@ let s:script_path = tolower(resolve(expand('<sfile>:p:h')))
 
 let s:filetype_overrides = {
       \ 'defx':  ['defx', '%{b:defx.paths[0]}'],
+      \ 'fugitive': ['fugitive', '%{airline#util#wrap(airline#extensions#branch#get_head(),80)}'],
       \ 'gundo': [ 'Gundo', '' ],
       \ 'help':  [ 'Help', '%f' ],
       \ 'minibufexpl': [ 'MiniBufExplorer', '' ],


### PR DESCRIPTION
I wrote a patch that displays 'fugitive' in the statusline when using vim-fugitive's `:Gstatus` command. This will improve the user interface.

Please check this Pull Request.

## Before
<img width="567" alt="スクリーンショット 2019-11-10 9 49 58" src="https://user-images.githubusercontent.com/36619465/68536977-9d2ee100-039f-11ea-8d1b-b8bb60e35e8b.png">

## After
<img width="563" alt="スクリーンショット 2019-11-10 9 49 34" src="https://user-images.githubusercontent.com/36619465/68536976-9bfdb400-039f-11ea-9e7e-f8a610316dd8.png">

