### PR TITLE
update nerdtree's statusline

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -28,7 +28,6 @@ let s:filetype_overrides = {
       \ 'gundo': [ 'Gundo', '' ],
       \ 'help':  [ 'Help', '%f' ],
       \ 'minibufexpl': [ 'MiniBufExplorer', '' ],
-      \ 'nerdtree': [ get(g:, 'NERDTreeStatusline', 'NERD'), '' ],
       \ 'startify': [ 'startify', '' ],
       \ 'vim-plug': [ 'Plugins', '' ],
       \ 'vimfiler': [ 'vimfiler', '%{vimfiler#get_status_string()}' ],
@@ -41,6 +40,12 @@ if exists(':Gina') && (v:version > 704 || (v:version == 704 && has("patch1898"))
   let s:filetype_overrides['diff'] = ['gina', '%{gina#component#repo#preset()}' ]
   let s:filetype_overrides['gina-log'] = ['gina', '%{gina#component#repo#preset()}' ]
   let s:filetype_overrides['gina-tag'] = ['gina', '%{gina#component#repo#preset()}' ]
+endif
+
+if get(g:, 'airline#extensions#nerdtree_statusline', 1)
+  let s:filetype_overrides['nerdtree'] = [ get(g:, 'NERDTreeStatusline', 'NERD'), '' ]
+else
+  let s:filetype_overrides['nerdtree'] = ['NERDtree', '']
 endif
 
 let s:filetype_regex_overrides = {}

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -785,6 +785,10 @@ Airline displays the Nerdtree specific statusline (which can be configured
 using the |'NerdTreeStatusline'| variable (for details, see the help of
 NerdTree)
 
+* enable/disable nerdtree's statusline integration >
+  let g:airline#extensions#nerdtree_status = 1
+<  default: 1
+
 -------------------------------------                      *airline-nrrwrgn*
 NrrwRgn <https://github.com/chrisbra/NrrwRgn>
 


### PR DESCRIPTION
Hello!
I wrote a patch.
This patch can choice `NERDTree`'s statusline like below.
Please check this Pull Request.

### let g:airline#extensions#nerdtree_statusline = 1

<img width="226" alt="スクリーンショット 2019-11-11 19 22 01" src="https://user-images.githubusercontent.com/36619465/68579923-9ba50c00-04b8-11ea-9911-17f0fcf5bcc0.png">

### let g:airline#extensions#nerdtree_statusline = 0
<img width="221" alt="スクリーンショット 2019-11-11 19 22 25" src="https://user-images.githubusercontent.com/36619465/68579927-9d6ecf80-04b8-11ea-9d23-b72b5dc120da.png">

default 1