### PR TITLE
add :Gina branch command support

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -40,6 +40,7 @@ if exists(':Gina') && (v:version > 704 || (v:version == 704 && has("patch1898"))
   let s:filetype_overrides['diff'] = ['gina', '%{gina#component#repo#preset()}' ]
   let s:filetype_overrides['gina-log'] = ['gina', '%{gina#component#repo#preset()}' ]
   let s:filetype_overrides['gina-tag'] = ['gina', '%{gina#component#repo#preset()}' ]
+  let s:filetype_overrides['gina-branch'] = ['gina', '%{gina#component#repo#branch()}' ]
 endif
 
 if get(g:, 'airline#extensions#nerdtree_statusline', 1)


### PR DESCRIPTION
Hi!

`:Gina branch` is a command like a`git branch` support by `gina.vim`.

This patch is to add supporting this feature.

Prease review this Pull Request!

## screenshot

### before
<img width="568" alt="スクリーンショット 2019-12-02 12 01 53" src="https://user-images.githubusercontent.com/36619465/69927599-db7d7300-14fb-11ea-9f64-da92ff2cfd59.png">

### after
<img width="570" alt="スクリーンショット 2019-12-02 11 59 46" src="https://user-images.githubusercontent.com/36619465/69927603-e0dabd80-14fb-11ea-9e26-7bf1db2c7ffe.png">


