### PR TITLE
add check v:version for coc.nvim

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -293,7 +293,7 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'ale')
   endif
 
-  if (get(g:, 'airline#extensions#coc#enabled', 1) && exists(':CocCommand'))
+  if (get(g:, 'airline#extensions#coc#enabled', 1) && exists(':CocCommand')) && v:version >= 800
     call airline#extensions#coc#init(s:ext)
     call add(s:loaded_ext, 'coc')
   endif


### PR DESCRIPTION
Hello, Christian.

`coc.nvim` is supported for `Vim >= 8.0` or `Neovim >= 0.3.0`

> https://github.com/neoclide/coc.nvim/blob/0177653aa5a136274c8c40f06671ccbc26515f13/doc/coc.txt#L63-L65

I add this checking for coc.nvim's extension.
Therefore, Vim7 user can't load this extension.

Please check this Pull Request.