### PR TITLE
Fix Vista init

### DIFF
--- a/autoload/airline/extensions/vista.vim
+++ b/autoload/airline/extensions/vista.vim
@@ -12,4 +12,5 @@ endfunction
 
 function! airline#extensions#vista#init(ext)
   call airline#parts#define_function('vista', 'airline#extensions#vista#currenttag')
+  autocmd VimEnter * call vista#RunForNearestMethodOrFunction()
 endfunction


### PR DESCRIPTION
`b:vista_nearest_method_or_function` is not set until `vista#RunForNearestMethodOrFunction()` is called.