### PR TITLE
add gina support for vim-airline's branch

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -255,6 +255,7 @@ function! airline#extensions#load()
 
   if get(g:, 'airline#extensions#branch#enabled', 1) && (
           \ airline#util#has_fugitive() ||
+          \ airline#util#has_gina() ||
           \ airline#util#has_lawrencium() ||
           \ airline#util#has_vcscommand() ||
           \ airline#util#has_custom_scm())

--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -85,17 +85,26 @@ let s:names = {'0': 'index', '1': 'orig', '2':'fetch', '3':'merge'}
 let s:sha1size = get(g:, 'airline#extensions#branch#sha1_len', 7)
 
 function! s:update_git_branch()
-  if !airline#util#has_fugitive()
+  if !airline#util#has_fugitive() && !airline#util#has_gina()
     let s:vcs_config['git'].branch = ''
     return
   endif
-
-  let s:vcs_config['git'].branch = exists("*FugitiveHead") ?
-        \ FugitiveHead(s:sha1size) : fugitive#head(s:sha1size)
-  if s:vcs_config['git'].branch is# 'master' &&
-        \ airline#util#winwidth() < 81
-    " Shorten default a bit
-    let s:vcs_config['git'].branch='mas'
+  if airline#util#has_fugitive()
+    let s:vcs_config['git'].branch = exists("*FugitiveHead") ?
+          \ FugitiveHead(s:sha1size) : fugitive#head(s:sha1size)
+    if s:vcs_config['git'].branch is# 'master' &&
+          \ airline#util#winwidth() < 81
+      " Shorten default a bit
+      let s:vcs_config['git'].branch='mas'
+    endif
+  else
+    let g:gina#component#repo#commit_length = s:sha1size
+    let s:vcs_config['git'].branch = gina#component#repo#branch()
+    if s:vcs_config['git'].branch is# 'master' &&
+          \ airline#util#winwidth() < 81
+      " Shorten default a bit
+      let s:vcs_config['git'].branch='mas'
+    endif
   endif
 endfunction
 
@@ -200,7 +209,7 @@ function! s:update_untracked()
   for vcs in keys(s:vcs_config)
     " only check, for git, if fugitive is installed
     " and for 'hg' if lawrencium is installed, else skip
-    if vcs is# 'git' && !airline#util#has_fugitive()
+    if vcs is# 'git' && (!airline#util#has_fugitive())
       continue
     elseif vcs is# 'mercurial' && !airline#util#has_lawrencium()
       continue

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -135,6 +135,14 @@ function! airline#util#has_fugitive()
   return s:has_fugitive
 endfunction
 
+function! airline#util#has_gina()
+  if !exists("s:has_gina")
+    let s:has_gina = exists(':Gina')
+  endif
+  return s:has_gina
+endfunction
+
+
 function! airline#util#has_lawrencium()
   if !exists("s:has_lawrencium")
     let s:has_lawrencium  = exists('*lawrencium#statusline')

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -474,6 +474,7 @@ vim-airline will display the branch-indicator together with the branch name
 in the statusline, if one of the following plugins is installed:
 
 fugitive.vim <https://github.com/tpope/vim-fugitive>
+gina.vim     <https://github.com/lambdalisue/gina.vim>
 lawrencium   <https://bitbucket.org/ludovicchabant/vim-lawrencium>
 vcscommand   <http://www.vim.org/scripts/script.php?script_id=90>
 


### PR DESCRIPTION
Hello, Christian.
This patch was written to show git branch even in plugins other than vim-fugitive.
 If you install gina.vim, you will be able to display the branch without installing vim-fugitive.

## reference

> https://github.com/lambdalisue/gina.vim

Please check this Pull Request.

### minimam vimrc

```vim
set encoding=utf-8
scriptencoding utf-8

call plug#begin('~/.vim/plugged')
Plug 'kazukazuinaina/vim-airline'
Plug 'lambdalisue/gina.vim'
call plug#end()

"---------setting vim-airline-----------
let g:airline#extensions#branch#enabled = 1
let g:airline#extensions#branch#displayed_head_limit = 10
```

## screenshot

<img width="568" alt="スクリーンショット 2019-12-14 3 36 16" src="https://user-images.githubusercontent.com/36619465/70823347-ff598680-1e22-11ea-8e85-7ad7cc4cc6be.png">
