### PR TITLE
add try catch in gina.vim's extension in branch.vim

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -98,8 +98,11 @@ function! s:update_git_branch()
       let s:vcs_config['git'].branch='mas'
     endif
   else
-    let g:gina#component#repo#commit_length = s:sha1size
-    let s:vcs_config['git'].branch = gina#component#repo#branch()
+    try
+      let g:gina#component#repo#commit_length = s:sha1size
+      let s:vcs_config['git'].branch = gina#component#repo#branch()
+    catch
+    endtry
     if s:vcs_config['git'].branch is# 'master' &&
           \ airline#util#winwidth() < 81
       " Shorten default a bit


### PR DESCRIPTION
Hello, Christian.
The api of gina.vim does not behave exactly like vim-fugitive so this may cause some exceptions and errors. 
Since this is a specification of gina.vim, exceptions were supplemented using `try catch`.
This patch is a patch that fixes those errors.
Please check this Pull Request.
## example of error

<img width="564" alt="スクリーンショット 2019-12-15 23 10 33" src="https://user-images.githubusercontent.com/36619465/70863916-8b3cf100-1f90-11ea-9786-ba0630a0cd4a.png">
