### PR TITLE
can choice to use gina's extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -34,7 +34,7 @@ let s:filetype_overrides = {
       \ 'vimshell': ['vimshell','%{vimshell#get_status_string()}'],
       \ }
 
-if exists(':Gina') && (v:version > 704 || (v:version == 704 && has("patch1898")))
+if airline#util#has_gina() && get(g:, 'airline#extensions#gina_status', 1)
   " Gina needs the Vim 7.4.1898, which introduce the <mods> flag for custom commands
   let s:filetype_overrides['gina-status'] = ['gina', '%{gina#component#repo#preset()}' ]
   let s:filetype_overrides['diff'] = ['gina', '%{gina#component#repo#preset()}' ]

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -137,7 +137,7 @@ endfunction
 
 function! airline#util#has_gina()
   if !exists("s:has_gina")
-    let s:has_gina = exists(':Gina')
+    let s:has_gina = (exists(':Gina') && v:version >= 800)
   endif
   return s:has_gina
 endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -709,6 +709,10 @@ gina.vim <https://github.com/lambdalisue/gina.vim>
 Airline displays the gina.vim specific statusline.
 (for details, see the help of gina.vim)
 
+* enable/disable bufferline integration >
+  let g:airline#extensions#gina_status = 1
+<  default: 1
+
 -------------------------------------                     *airline-grepper*
 vim-grepper <https://github.com/mhinz/vim-grepper>
 


### PR DESCRIPTION
Hello, Crhistian.
I wrote a patch.
This patch can choice `gina.vim`'s statusline like below.
Please check this Pull Request.

## let g:airline#extensions#gina_status = 1

<img width="568" alt="スクリーンショット 2019-12-17 19 28 25" src="https://user-images.githubusercontent.com/36619465/70987738-db889000-2103-11ea-98bd-db90b3680b11.png">

## let g:airline#extensions#gina_status = 0

<img width="568" alt="スクリーンショット 2019-12-17 19 27 59" src="https://user-images.githubusercontent.com/36619465/70987718-d1669180-2103-11ea-8e46-a9eab2dc181e.png">

> default 1
