### PR TITLE
fix untrack branch check about gina

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -212,7 +212,7 @@ function! s:update_untracked()
   for vcs in keys(s:vcs_config)
     " only check, for git, if fugitive is installed
     " and for 'hg' if lawrencium is installed, else skip
-    if vcs is# 'git' && (!airline#util#has_fugitive())
+    if vcs is# 'git' && (!airline#util#has_fugitive() && !airline#util#has_gina())
       continue
     elseif vcs is# 'mercurial' && !airline#util#has_lawrencium()
       continue


### PR DESCRIPTION
Hi, Crhistian.
I fixed `branch.vim` a bit.
I corrected the problem that the icon is not displayed for untrack file when branch is displayed using gina.vim with this patch.
Please check this Pull Request.
