### PR TITLE
allow disabling airline per-buffer

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -125,7 +125,7 @@ endfunction
 
 " Update the statusline
 function! airline#update_statusline()
-  if airline#util#stl_disabled()
+  if airline#util#stl_disabled(winnr())
     return
   endif
   let range = filter(range(1, winnr('$')), 'v:val != winnr()')
@@ -154,11 +154,11 @@ endfunction
 
 " Function to draw inactive statuslines for inactive windows
 function! airline#update_statusline_inactive(range)
-  if airline#util#stl_disabled()
+  if airline#util#stl_disabled(winnr())
     return
   endif
   for nr in a:range
-    if airline#util#getwinvar(nr, 'airline_disabled', 0)
+    if airline#util#stl_disabled(nr)
       continue
     endif
     call setwinvar(nr, 'airline_active', 0)

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -170,11 +170,11 @@ function! airline#util#themes(match)
   return sort(map(files, 'fnamemodify(v:val, ":t:r")') + ['random'])
 endfunction
 
-function! airline#util#stl_disabled()
+function! airline#util#stl_disabled(winnr)
   " setting the statusline is disabled,
   " either globally or per window
   " w:airline_disabled is deprecated!
   return get(g:, 'airline_disable_statusline', 0) ||
-   \ airline#util#getwinvar(winnr(), 'airline_disable_statusline', 0) ||
-   \ airline#util#getwinvar(winnr(), 'airline_disabled', 0)
+   \ airline#util#getwinvar(a:winnr, 'airline_disable_statusline', 0) ||
+   \ airline#util#getwinvar(a:winnr, 'airline_disabled', 0)
 endfunction

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -67,6 +67,17 @@ function! airline#util#prepend(text, minwidth)
 endfunction
 
 if v:version >= 704
+  function! airline#util#getbufvar(bufnr, key, def)
+    return getbufvar(a:bufnr, a:key, a:def)
+  endfunction
+else
+  function! airline#util#getbufvar(bufnr, key, def)
+    let bufvals = getbufvar(a:bufnr, '')
+    return get(bufvals, a:key, a:def)
+  endfunction
+endif
+
+if v:version >= 704
   function! airline#util#getwinvar(winnr, key, def)
     return getwinvar(a:winnr, a:key, a:def)
   endfunction
@@ -172,9 +183,10 @@ endfunction
 
 function! airline#util#stl_disabled(winnr)
   " setting the statusline is disabled,
-  " either globally or per window
+  " either globally, per window, or per buffer
   " w:airline_disabled is deprecated!
   return get(g:, 'airline_disable_statusline', 0) ||
    \ airline#util#getwinvar(a:winnr, 'airline_disable_statusline', 0) ||
-   \ airline#util#getwinvar(a:winnr, 'airline_disabled', 0)
+   \ airline#util#getwinvar(a:winnr, 'airline_disabled', 0) ||
+   \ airline#util#getbufvar(winbufnr(a:winnr), 'airline_disable_statusline', 0)
 endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -234,9 +234,14 @@ values):
 <
   Old deprecated name: `w:airline_disabled`
 
-  See also the following option, for disabling setting the statusline globally
+  See also the following options, for disabling setting the statusline
+  globally or per-buffer
 * Disable setting the statusline option: >
+  " disable globally
   let g:airline_disable_statusline = 1
+
+  " disable per-buffer
+  let b:airline_disable_statusline = 1
 
 < This setting disables setting the 'statusline' option. This allows to use
  e.g. the tabline extension (|airline-tabline|) but keep the 'statusline'

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -181,7 +181,7 @@ function! s:airline_toggle()
       endif
     augroup END
 
-    if !airline#util#stl_disabled()
+    if !airline#util#stl_disabled(winnr())
       if &laststatus < 2
         set laststatus=2
       endif


### PR DESCRIPTION
Useful for disabling airline on plugin-created buffers.

Depends on #2026 