### PR TITLE
Add poetv extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -282,6 +282,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'virtualenv')
   endif
 
+  if (get(g:, 'airline#extensions#poetv#enabled', 1) && (exists(':PoetvActivate') || isdirectory($VIRTUAL_ENV)))
+    call airline#extensions#poetv#init(s:ext)
+    call add(s:loaded_ext, 'poetv')
+  endif
+
   if (get(g:, 'airline#extensions#eclim#enabled', 1) && exists(':ProjectCreate'))
     call airline#extensions#eclim#init(s:ext)
     call add(s:loaded_ext, 'eclim')

--- a/autoload/airline/extensions/poetv.vim
+++ b/autoload/airline/extensions/poetv.vim
@@ -1,0 +1,32 @@
+" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" Plugin: https://github.com/petobens/poet_v
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+let s:spc = g:airline_symbols.space
+
+function! airline#extensions#poetv#init(ext)
+  call a:ext.add_statusline_func('airline#extensions#poetv#apply')
+endfunction
+
+function! airline#extensions#poetv#apply(...)
+  if &filetype =~# 'python'
+    if get(g:, 'poetv_loaded', 0)
+      let statusline = poetv#statusline()
+    else
+      let statusline = fnamemodify($VIRTUAL_ENV, ':t')
+    endif
+    if !empty(statusline)
+      call airline#extensions#append_to_section('x',
+            \ s:spc.g:airline_right_alt_sep.s:spc.statusline)
+    endif
+  endif
+endfunction
+
+function! airline#extensions#poetv#update()
+  if &filetype =~# 'python'
+    call airline#extensions#poetv#apply()
+    call airline#update_statusline()
+  endif
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -838,6 +838,12 @@ files with the 'filetype' "po".
 * truncate width names to a fixed length >
   let g:airline#extensions#po#displayed_limit = 0
 
+-------------------------------------                   *airline-poetv*
+poetv <https://github.com/petobens/poet-v>
+
+* enable/disable poetv integration >
+  let g:airline#extensions#poetv#enabled = 1
+<
 -------------------------------------                   *airline-promptline*
 promptline <https://github.com/edkolev/promptline.vim>
 


### PR DESCRIPTION
This is essentially the same as vim-virtualenv but it also adds support for venvs created by poetry and pipenv .