### PR TITLE
update license's year in vim-airline

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (C) 2013-2019 Bailey Ling, Christian Brabandt, et al.
+Copyright (C) 2013-2020 Bailey Ling, Christian Brabandt, et al.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ information. By default (without configuration) this line will look like this:
 |~                                                                            |
 |~                     VIM - Vi IMproved                                      |
 |~                                                                            |
-|~                       version 8.0                                          |
+|~                       version 8.2                                          |
 |~                    by Bram Moolenaar et al.                                |
 |~           Vim is open source and freely distributable                      |
 |~                                                                            |
@@ -292,7 +292,7 @@ If you are interested in becoming a maintainer (we always welcome more maintaine
 
 # License
 
-[MIT License][58]. Copyright (c) 2013-2019 Bailey Ling & Contributors.
+[MIT License][58]. Copyright (c) 2013-2020 Bailey Ling & Contributors.
 
 [1]: https://github.com/Lokaltog/vim-powerline
 [2]: https://github.com/Lokaltog/powerline

--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/async.vim
+++ b/autoload/airline/async.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Christian Brabandt et al.
+" MIT License. Copyright (c) 2013-2020 Christian Brabandt et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/debug.vim
+++ b/autoload/airline/debug.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -1,5 +1,5 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
-" Plugin: fugitive, lawrencium and vcscommand
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
+" Plugin: fugitive, gina, lawrencium and vcscommand
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/extensions/default.vim
+++ b/autoload/airline/extensions/default.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/extensions/example.vim
+++ b/autoload/airline/extensions/example.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/extensions/term.vim
+++ b/autoload/airline/extensions/term.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2 fdm=marker
 
 scriptencoding utf-8

--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling Christian Brabandt et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling Christian Brabandt et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/msdos.vim
+++ b/autoload/airline/msdos.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling Christian Brabandt et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling Christian Brabandt et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/section.vim
+++ b/autoload/airline/section.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/themes.vim
+++ b/autoload/airline/themes.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/autoload/airline/themes/dark.vim
+++ b/autoload/airline/themes/dark.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
 " vim: et ts=2 sts=2 sw=2 tw=80
 
 scriptencoding utf-8

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling Christian Brabandt et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling Christian Brabandt et al.
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -1,4 +1,4 @@
-" MIT License. Copyright (c) 2013-2019 Bailey Ling, Christian Brabandt et al.
+" MIT License. Copyright (c) 2013-2020 Bailey Ling, Christian Brabandt et al.
 " vim: et ts=2 sts=2 sw=2
 
 let s:save_cpo = &cpo


### PR DESCRIPTION
Hello, Christian.
Happy New Year!
As the year went up, I updated the vim-airline's license year.
Could you check this Pull Request?

PS: Some files in the extension directory depend on external plugins and some have not been updated yet, but I will do them if necessary.