### PR TITLE
update license year in doc/airline.txt

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1783,7 +1783,7 @@ Contributions and pull requests are welcome.
 =============================================================================
 LICENSE                                                    *airline-license*
 
-MIT License. Copyright © 2013-2019 Bailey Ling, Christian Brabandt, Mike
+MIT License. Copyright © 2013-2020 Bailey Ling, Christian Brabandt, Mike
 Hartington et al.
 
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Hi, Christian.
I notice to forget updating license date in `doc/airline.txt` so I updated it.
Could you check this Pull Request?

## Related PR

#2040 