### PR TITLE
Fix echo extension load

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -151,7 +151,9 @@ function! airline#extensions#load()
         call airline#extensions#{ext}#init(s:ext)
       catch /^Vim\%((\a\+)\)\=:E117/	" E117, function does not exist
         call airline#util#warning("Extension '".ext."' not installed, ignoring!")
+        continue
       endtry
+      call add(s:loaded_ext, ext)
     endfor
     return
   endif


### PR DESCRIPTION
Hello, Christian.
I fixed a small bug.
Please look this example.

### minimum vimrc

```let g:airline_extensions = ['branch', 'tabline']```

I wrote this config in my vimrc and these extensions is loaded, but I run `:AirlineExtensions` command, displays that all extensions is not loaded.

This patch will fix this issue.
Could you check this Pull Request?

# screenshot

## Before

 <img width="1436" alt="スクリーンショット 2020-01-27 7 05 41" src="https://user-images.githubusercontent.com/36619465/73142560-8745d800-40d3-11ea-9f56-d2d2540e2d6a.png">

## After

<img width="1430" alt="スクリーンショット 2020-01-27 7 05 09" src="https://user-images.githubusercontent.com/36619465/73142553-76956200-40d3-11ea-9c06-cbc7ee1648ba.png">

