### PR TITLE
[fix] nerdtree's url in doc and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ If you are interested in becoming a maintainer (we always welcome more maintaine
 [15]: https://github.com/techlivezheng/vim-plugin-minibufexpl
 [16]: https://github.com/sjl/gundo.vim
 [17]: https://github.com/mbbill/undotree
-[18]: https://github.com/scrooloose/nerdtree
+[18]: https://github.com/preservim/nerdtree
 [19]: https://github.com/majutsushi/tagbar
 [20]: https://powerline.readthedocs.org/en/master/installation.html#patched-fonts
 [21]: https://bitbucket.org/ludovicchabant/vim-lawrencium

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -798,7 +798,7 @@ neomake <https://github.com/neomake/neomake>
   let airline#extensions#neomake#warning_symbol = 'W:'
 <
 -------------------------------------                   *airline-nerdtree*
-NerdTree <https://github.com/scrooloose/nerdtree.git>
+NerdTree <https://github.com/preservim/nerdtree.git>
 
 Airline displays the Nerdtree specific statusline (which can be configured
 using the |'NerdTreeStatusline'| variable (for details, see the help of


### PR DESCRIPTION
I update `nerdtree`'s url in doc and `README.md`.
Could you check this Pull Request?
## reference

> https://github.com/preservim/nerdtree