### PR TITLE
branch: ignore upcoming FocusGained when updating

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -85,6 +85,7 @@ let s:names = {'0': 'index', '1': 'orig', '2':'fetch', '3':'merge'}
 let s:sha1size = get(g:, 'airline#extensions#branch#sha1_len', 7)
 
 function! s:update_git_branch()
+  call airline#util#ignore_next_focusgain()
   if !airline#util#has_fugitive() && !airline#util#has_gina()
     let s:vcs_config['git'].branch = ''
     return
@@ -114,7 +115,7 @@ endfunction
 function! s:display_git_branch()
   " disable FocusGained autocommand, might cause loops because system() causes
   " a refresh, which causes a system() command again #2029
-  call airline#util#focusgain(0)
+  call airline#util#ignore_next_focusgain()
   let name = b:buffer_vcs_config['git'].branch
   try
     let commit = matchstr(FugitiveParse()[0], '^\x\+')
@@ -131,7 +132,6 @@ function! s:display_git_branch()
     endif
   catch
   endtry
-  call airline#util#focusgain(1)
   return name
 endfunction
 

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -11,7 +11,7 @@ let s:spc = g:airline_symbols.space
 let s:nomodeline = (v:version > 703 || (v:version == 703 && has("patch438"))) ? '<nomodeline>' : ''
 let s:has_strchars = exists('*strchars')
 let s:has_strcharpart = exists('*strcharpart')
-let s:focusgained_enabled = 0
+let s:focusgained_ignored = 0
 
 " TODO: Try to cache winwidth(0) function
 " e.g. store winwidth per window and access that, only update it, if the size
@@ -192,10 +192,15 @@ function! airline#util#stl_disabled(winnr)
    \ airline#util#getbufvar(winbufnr(a:winnr), 'airline_disable_statusline', 0)
 endfunction
 
-function! airline#util#focusgain(allow)
-  let s:focusgained_enabled = a:allow
+function! airline#util#ignore_next_focusgain()
+  let s:focusgained_ignored += 1
 endfunction
 
-function! airline#util#focusgained_disabled()
-  return s:focusgained_enabled < 1
+function! airline#util#try_focusgained()
+  let s:focusgained_ignored -= 1
+  if s:focusgained_ignored < 0
+    let s:focusgained_ignored = 0
+  endif
+  return s:focusgained_ignored <= 0
 endfunction
+

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -83,10 +83,9 @@ function! s:on_window_changed(event)
 endfunction
 
 function! s:on_focus_gained()
-  if airline#util#focusgained_disabled()
-    return
+  if airline#util#try_focusgained()
+    unlet! w:airline_lastmode | :call <sid>airline_refresh(1)
   endif
-  unlet! w:airline_lastmode | :call <sid>airline_refresh(1)
 endfunction
 
 function! s:on_cursor_moved()


### PR DESCRIPTION
closes #2029

airline#util#focusgain(1) was called too soon -- it's called before vim
loses focus and not after it gains focus. Instead, we ignore the next
FocusGained event.

Verified it fixes the issue for me (Win10, Vim8.2)