### PR TITLE
[fix] typo in doc

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -355,7 +355,7 @@ its contents. >
   let g:airline_symbols.readonly = ''
   let g:airline_symbols.linenr = '☰'
   let g:airline_symbols.maxlinenr = ''
-  let g:airline_symbols.dirty=⚡
+  let g:airline_symbols.dirty='⚡'
 
   " old vim-powerline symbols
   let g:airline_left_sep = '⮀'


### PR DESCRIPTION
I fixed typo in `doc`.

## reference 

#2052 