### PR TITLE
Refactor the focusgain enable/disable logic

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -85,7 +85,9 @@ let s:names = {'0': 'index', '1': 'orig', '2':'fetch', '3':'merge'}
 let s:sha1size = get(g:, 'airline#extensions#branch#sha1_len', 7)
 
 function! s:update_git_branch()
-  call airline#util#ignore_next_focusgain()
+  " suspend FocusGained autocommand, might cause loops because system()
+  " causes a refresh, which causes a system() command again #2029
+  call airline#util#suspend_focusgain(1)
   if !airline#util#has_fugitive() && !airline#util#has_gina()
     let s:vcs_config['git'].branch = ''
     return
@@ -110,12 +112,13 @@ function! s:update_git_branch()
       let s:vcs_config['git'].branch='mas'
     endif
   endif
+  call airline#util#suspend_focusgain(0)
 endfunction
 
 function! s:display_git_branch()
-  " disable FocusGained autocommand, might cause loops because system() causes
-  " a refresh, which causes a system() command again #2029
-  call airline#util#ignore_next_focusgain()
+  " suspend FocusGained autocommand, might cause loops because system()
+  " causes a refresh, which causes a system() command again #2029
+  call airline#util#suspend_focusgain(1)
   let name = b:buffer_vcs_config['git'].branch
   try
     let commit = matchstr(FugitiveParse()[0], '^\x\+')
@@ -132,6 +135,7 @@ function! s:display_git_branch()
     endif
   catch
   endtry
+  call airline#util#suspend_focusgain(0)
   return name
 endfunction
 

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -11,7 +11,7 @@ let s:spc = g:airline_symbols.space
 let s:nomodeline = (v:version > 703 || (v:version == 703 && has("patch438"))) ? '<nomodeline>' : ''
 let s:has_strchars = exists('*strchars')
 let s:has_strcharpart = exists('*strcharpart')
-let s:focusgained_ignored = 0
+let s:focusgain_suspended = 0
 
 " TODO: Try to cache winwidth(0) function
 " e.g. store winwidth per window and access that, only update it, if the size
@@ -135,7 +135,7 @@ endfunction
 
 function! airline#util#ignore_buf(name)
   let pat = '\c\v'. get(g:, 'airline#ignore_bufadd_pat', '').
-        \ get(g:, 'airline#extensions#tabline#ignore_bufadd_pat', 
+        \ get(g:, 'airline#extensions#tabline#ignore_bufadd_pat',
         \ '!|defx|gundo|nerd_tree|startify|tagbar|term://|undotree|vimfiler')
   return match(a:name, pat) > -1
 endfunction
@@ -192,15 +192,10 @@ function! airline#util#stl_disabled(winnr)
    \ airline#util#getbufvar(winbufnr(a:winnr), 'airline_disable_statusline', 0)
 endfunction
 
-function! airline#util#ignore_next_focusgain()
-  let s:focusgained_ignored += 1
+function! airline#util#suspend_focusgain(suspend)
+  let s:focusgain_suspended = a:suspend
 endfunction
 
 function! airline#util#try_focusgained()
-  let s:focusgained_ignored -= 1
-  if s:focusgained_ignored < 0
-    let s:focusgained_ignored = 0
-  endif
-  return s:focusgained_ignored <= 0
+  return s:focusgain_suspended < 1
 endfunction
-


### PR DESCRIPTION
If I use this solution (pretty much the same as @chrisbra, but now suspending on both update_git_branch and display_git_branch) I cannot reproduce the issue.

I did a profile to show what it looks like on my machine ([full profile](https://gist.github.com/svanharmelen/ec4d1651c84cd1919300e0222d32afed)), but in short doing the same actions @idbrii did gave me totally different numbers.

To get profile:

```
> nvim ~/.config/nvim/plugged/vim-airline/autoload/airline/extensions/branch.vim
:profile start ~/airline.vprof | profile func * | Gedit HEAD 
" count five seconds after buffer shows commit info
:quit
```

```
count  total (s)   self (s)
...
FUNCTION  airline#extensions#branch#head()
    Defined: ~/.config/nvim/plugged/vim-airline/autoload/airline/extensions/branch.vim line 241
Called 8 times
...
FUNCTION  <SNR>109_display_git_branch()
    Defined: ~/.config/nvim/plugged/vim-airline/autoload/airline/extensions/branch.vim line 116
Called 1 time
```