### PR TITLE
add in coc_status to coc.nvim integration

### DIFF
--- a/autoload/airline/extensions/coc.vim
+++ b/autoload/airline/extensions/coc.vim
@@ -16,7 +16,7 @@ function! airline#extensions#coc#get_error()
 endfunction
 
 function! airline#extensions#coc#get(type)
-  if !exists(":CocCommand")
+  if !exists(':CocCommand')
     return ''
   endif
   let _backup = get(g:, 'coc_stl_format', '')
@@ -42,7 +42,12 @@ function! airline#extensions#coc#get(type)
   endif
 endfunction
 
+function! airline#extensions#coc#get_status()
+  return get(g:, 'coc_status', '')
+endfunction
+
 function! airline#extensions#coc#init(ext)
   call airline#parts#define_function('coc_error_count', 'airline#extensions#coc#get_error')
   call airline#parts#define_function('coc_warning_count', 'airline#extensions#coc#get_warning')
+  call airline#parts#define_function('coc_status', 'airline#extensions#coc#get_status')
 endfunction

--- a/autoload/airline/extensions/coc.vim
+++ b/autoload/airline/extensions/coc.vim
@@ -7,15 +7,15 @@ scriptencoding utf-8
 let s:error_symbol = get(g:, 'airline#extensions#coc#error_symbol', 'E:')
 let s:warning_symbol = get(g:, 'airline#extensions#coc#warning_symbol', 'W:')
 
-function! airline#extensions#coc#get_warning()
+function! airline#extensions#coc#get_warning() abort
   return airline#extensions#coc#get('warning')
 endfunction
 
-function! airline#extensions#coc#get_error()
+function! airline#extensions#coc#get_error() abort
   return airline#extensions#coc#get('error')
 endfunction
 
-function! airline#extensions#coc#get(type)
+function! airline#extensions#coc#get(type) abort
   if !exists(':CocCommand')
     return ''
   endif
@@ -42,11 +42,11 @@ function! airline#extensions#coc#get(type)
   endif
 endfunction
 
-function! airline#extensions#coc#get_status()
+function! airline#extensions#coc#get_status() abort
   return get(g:, 'coc_status', '')
 endfunction
 
-function! airline#extensions#coc#init(ext)
+function! airline#extensions#coc#init(ext) abort
   call airline#parts#define_function('coc_error_count', 'airline#extensions#coc#get_error')
   call airline#parts#define_function('coc_warning_count', 'airline#extensions#coc#get_warning')
   call airline#parts#define_function('coc_status', 'airline#extensions#coc#get_status')

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -161,6 +161,10 @@ function! airline#init#bootstrap()
   call airline#parts#define('branch', {
         \ 'raw': '',
         \ 'minwidth': 80})
+  call airline#parts#define('coc_status', {
+        \ 'raw': '',
+        \ 'accent': 'airline_term'
+        \ })
   call airline#parts#define_empty(['obsession', 'tagbar', 'syntastic-warn',
         \ 'syntastic-err', 'eclim', 'whitespace','windowswap',
         \ 'ycm_error_count', 'ycm_warning_count', 'neomake_error_count',
@@ -193,7 +197,7 @@ function! airline#init#sections()
     if exists("+autochdir") && &autochdir == 1
       let g:airline_section_c = airline#section#create(['%<', 'path', spc, 'readonly'])
     else
-      let g:airline_section_c = airline#section#create(['%<', 'file', spc, 'readonly'])
+      let g:airline_section_c = airline#section#create(['%<', 'file', spc, 'readonly', 'coc_status'])
     endif
   endif
   if !exists('g:airline_section_gutter')

--- a/t/init.vim
+++ b/t/init.vim
@@ -29,8 +29,8 @@ describe 'init sections'
     Expect g:airline_section_b == ''
   end
 
-  it 'section c should be file'
-    Expect g:airline_section_c == '%<%f%m %#__accent_red#%{airline#util#wrap(airline#parts#readonly(),0)}%#__restore__#'
+  it 'section c should be file and coc_status'
+    Expect g:airline_section_c == '%<%f%m %#__accent_red#%{airline#util#wrap(airline#parts#readonly(),0)}%#__restore__#%#__accent_airline_term#%#__restore__#'
   end
 
   it 'section x should be filetype'
@@ -76,6 +76,7 @@ describe 'init sections'
     Expect airline#parts#get('ycm_warning_count').raw == ''
     Expect airline#parts#get('languageclient_error_count').raw == ''
     Expect airline#parts#get('languageclient_warning_count').raw == ''
+    Expect airline#parts#get('coc_status').raw == ''
   end
 end
 


### PR DESCRIPTION
This pr addresses #2076 by grabbing the `coc_status` and displaying in in `c`. I wasn't 100% sure where else it would actually be a good fit since normally the message are a least a few words long. I also took a look for example at some of the other statusbar integrations, and they all look to sort of put it in the middle. I'm open to something else if you think it would make more sense?

Also, I wasn't exactly sure what to do with the color. The way it is now, it's the same as the file path.

<img width="638" alt="Screenshot 2020-02-28 at 00 09 59" src="https://user-images.githubusercontent.com/13974112/75495435-d034c900-59be-11ea-8ded-34686466ceb4.png">

I know for my own one I'd much rather highlight group like `LineNr` and use that so it looks more like this.

<img width="638" alt="Screenshot 2020-02-28 at 00 10 32" src="https://user-images.githubusercontent.com/13974112/75495496-f5293c00-59be-11ea-89e2-5d704705b3db.png">

What would you recommend to do for the color?