### PR TITLE
add plaintex filetype

### DIFF
--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -87,7 +87,7 @@ endfunction
 " default filetypes:
 function! airline#extensions#wordcount#apply(...)
   let filetypes = get(g:, 'airline#extensions#wordcount#filetypes', 
-    \ ['asciidoc', 'help', 'mail', 'markdown', 'org', 'rst', 'tex', 'text'])
+    \ ['asciidoc', 'help', 'mail', 'markdown', 'org', 'rst', 'plaintex', 'tex', 'text'])
   " export current filetypes settings to global namespace
   let g:airline#extensions#wordcount#filetypes = filetypes
 

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1387,7 +1387,7 @@ vim-windowswap <https://github.com/wesQ3/vim-windowswap>
   " The default value matches filetypes typically used for documentation
   " such as markdown and help files. Default is:
   let g:airline#extensions#wordcount#filetypes =
-    \ ['asciidoc', 'help', 'mail', 'markdown', 'org', 'rst', 'tex', 'text'])
+    \ ['asciidoc', 'help', 'mail', 'markdown', 'org', 'plaintex', 'rst', 'tex', 'text'])
   " Use ['all'] to enable for all filetypes.
 
 * defines the name of a formatter for word count will be displayed: >


### PR DESCRIPTION
Hello, Christian.
I added `plaintex`'s filetype in wordcount extension.
In Vim's document, if we open tex file, tex files are opened as plaintex by default.
Therefore, I added this file type.

## document
> https://vim-jp.org/vimdoc-en/filetype.html#g:tex_flavor
