### PR TITLE
[add] check vista's toggle

### DIFF
--- a/autoload/airline/extensions/vista.vim
+++ b/autoload/airline/extensions/vista.vim
@@ -3,6 +3,9 @@
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8
+if !get(g:, 'loaded_vista', 0)
+  finish
+endif
 
 function! airline#extensions#vista#currenttag()
   if get(w:, 'airline_active', 0)


### PR DESCRIPTION
I have added confirmation of the existence of the vista.vim's global variable.
This will help prevent unexpected script loading.

## Reference

This patch added global variables in vista.vim.

> https://github.com/liuchengxu/vista.vim/pull/258