### PR TITLE
[fix] operator and [add] abort in autoload function

### DIFF
--- a/autoload/airline/extensions/denite.vim
+++ b/autoload/airline/extensions/denite.vim
@@ -12,8 +12,8 @@ let s:denite_ver = (exists('*denite#get_status_mode') ? 2 : 3)
 " Denite does not use vim's built-in modal editing but has a custom prompt
 " that implements its own insert/normal mode so we have to handle changing the
 " highlight
-function! airline#extensions#denite#check_denite_mode(bufnr)
-  if &filetype !=# 'denite' || &filetype !=# 'denite-filter'
+function! airline#extensions#denite#check_denite_mode(bufnr) abort
+  if &filetype !=# 'denite' && &filetype !=# 'denite-filter'
     return ''
   endif
 
@@ -30,7 +30,7 @@ function! airline#extensions#denite#check_denite_mode(bufnr)
   return ''
 endfunction
 
-function! airline#extensions#denite#apply(...)
+function! airline#extensions#denite#apply(...) abort
   if &filetype ==# 'denite' || &filetype ==# 'denite-filter'
     let w:airline_skip_empty_sections = 0
     call a:1.add_section('airline_a', ' Denite %{airline#extensions#denite#check_denite_mode('.a:2['bufnr'].')}')
@@ -49,7 +49,7 @@ function! airline#extensions#denite#apply(...)
   endif
 endfunction
 
-function! airline#extensions#denite#init(ext)
+function! airline#extensions#denite#init(ext) abort
   call denite#custom#option('_', 'statusline', 0)
   call a:ext.add_statusline_func('airline#extensions#denite#apply')
 endfunction


### PR DESCRIPTION
I fixed an operator mistake in the denite extension.
As a result, the `airline#extensions#denite#check_denite_mode` function will be executed at the appropriate timing.
