### PR TITLE
[add] new option / always show tab count feature

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -251,7 +251,10 @@ function! airline#extensions#tabline#add_label(dict, type, right)
 endfunction
 
 function! airline#extensions#tabline#add_tab_label(dict)
-  if get(g:, 'airline#extensions#tabline#show_tab_count', 1) && tabpagenr('$') > 1
+  let show_tab_count = get(g:, 'airline#extensions#tabline#show_tab_conut', 1)
+  if show_tab_count == 2
+    call a:dict.add_section_spaced('airline_tabmod', printf('%s %d/%d', "tab", tabpagenr(), tabpagenr('$')))
+  elseif show_tab_count == 1 && tabpagenr('$') > 1
     call a:dict.add_section_spaced('airline_tabmod', printf('%s %d/%d', "tab", tabpagenr(), tabpagenr('$')))
   endif
 endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -956,6 +956,11 @@ with the middle mouse button to delete that buffer.
 
 * enable/disable displaying number of tabs in the right side (c) >
   let g:airline#extensions#tabline#show_tab_count = 1
+
+Note: Not displayed if the number of tabs is less than 1
+
+* always displaying number of tabs in the right side (c) >
+  let g:airline#extensions#tabline#show_tab_count = 2
 <
 * configure filename match rules to exclude from the tabline. >
   let g:airline#extensions#tabline#excludes = []


### PR DESCRIPTION
This pull request is cleated to resolve issue #2091

```viml
" always show tab count, even if there's only one tab!
let g:airline#extensions#tabline#show_tab_count = 2
```

## config list

- value : 0 (always don't show tab count)
- value : 1 (default value) (show tab count more than exists two tabs)
- value : 2 (always show tab count)