### PR TITLE
[add] some coc's test

### DIFF
--- a/t/init.vim
+++ b/t/init.vim
@@ -80,6 +80,8 @@ describe 'init sections'
     Expect airline#parts#get('languageclient_warning_count').raw == ''
     Expect airline#parts#get('coc_status').raw == ''
     Expect airline#parts#get('vista').raw == ''
+    Expect airline#parts#get('coc_warning_count').raw == ''
+    Expect airline#parts#get('coc_error_count').raw == ''
   end
 end
 


### PR DESCRIPTION
I add some coc's status test in `t/init.vim`.
This should improve the quality of unit test.

## related PR

#2106 