### PR TITLE
[add] branch symbol's Explanation

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -487,6 +487,12 @@ If a file is edited, that is not yet in the repository, the
 notexists symbol will be displayed after the branch name. If the repository
 is not clean, the dirty symbol will be displayed after the branch name.
 
+* notexists symbol means you are editing a file, that has not been commited yet
+  default: '?'
+
+* the dirty symbol basically means your working directory is dirty
+  default: '!'
+
 Note: the branch extension will be disabled for windows smaller than 80
 characters.
 


### PR DESCRIPTION
I add airline branch symbol's Explanation in doc.
What do you think? @chrisbra 

## Related PR

> https://github.com/vim-airline/vim-airline-themes/issues/215