### PR TITLE
[add] vaffle's path section

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -32,7 +32,7 @@ let s:filetype_overrides = {
       \ 'vim-plug': [ 'Plugins', '' ],
       \ 'vimfiler': [ 'vimfiler', '%{vimfiler#get_status_string()}' ],
       \ 'vimshell': ['vimshell','%{vimshell#get_status_string()}'],
-      \ 'vaffle' : [ 'Vaffle', '' ],
+      \ 'vaffle' : [ 'Vaffle', '%{b:vaffle.dir}' ],
       \ }
 
 if get(g:, 'airline#extensions#nerdtree_statusline', 1)


### PR DESCRIPTION
I supported vaffle's extension like defx.nvim
This patch add dir's section.

## reference

**vaffle.vim**

> https://github.com/cocopon/vaffle.vim/

## screen shot

### before

<img width="561" alt="スクリーンショット 2020-04-29 21 40 46" src="https://user-images.githubusercontent.com/36619465/80596968-24613580-8a62-11ea-93af-804655fb89d1.png">

### after

<img width="563" alt="スクリーンショット 2020-04-29 21 40 26" src="https://user-images.githubusercontent.com/36619465/80596999-2f1bca80-8a62-11ea-8515-c051f0ca1ce5.png">


