### PR TITLE
Use disabled style for inactive tabs

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -102,7 +102,7 @@ function! airline#extensions#tabline#load_theme(palette)
   let colors    = get(a:palette, 'tabline', {})
   let tablabel  = get(colors, 'airline_tablabel', a:palette.normal.airline_b)
   " Theme for tabs on the left
-  let tab     = get(colors, 'airline_tab', a:palette.normal.airline_b)
+  let tab     = get(colors, 'airline_tab', a:palette.inactive.airline_c)
   let tabsel  = get(colors, 'airline_tabsel', a:palette.normal.airline_a)
   let tabtype = get(colors, 'airline_tabtype', a:palette.visual.airline_a)
   let tabfill = get(colors, 'airline_tabfill', a:palette.normal.airline_c)


### PR DESCRIPTION
I apologize if I'm misunderstanding the intent of how this was setup or if I've missed some documentation that would've explained it.

It seemed undesirable that inactive tabs on the left would use the style from section B, while the inactive tabs on the right would use the inactive style from section C. Aside from this detail, it looked like the tabs on the left and the right were attempting to source all of the same styles. This change is to bring the left and right tabline styles into alignment with each other.

If there's a better way to do this than changing the core extension, I'm happy to close this and do that instead. Just submitting this because the current setup didn't seem conceptually consistent.