### PR TITLE
abopt get() function

### DIFF
--- a/autoload/airline/extensions/ycm.vim
+++ b/autoload/airline/extensions/ycm.vim
@@ -4,7 +4,7 @@
 
 scriptencoding utf-8
 
-if !exists('g:loaded_youcompleteme')
+if !get(g:, 'loaded_youcompleteme', 0)
   finish
 endif
 


### PR DESCRIPTION
Many extensions used the get function, but I used the exists function. 
I wrote this patch because it wasn't uniform.

## example

https://github.com/vim-airline/vim-airline/blob/master/autoload/airline/extensions/unite.vim#L7-L9