### PR TITLE
Add vim-dirvish support

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -444,6 +444,12 @@ function! airline#extensions#load()
       endif
     endfor
   endif
+
+  if exists(':Dirvish')
+    call airline#extensions#dirvish#init(s:ext)
+    call add(s:loaded_ext, 'dirvish')
+  endif
+
 endfunction
 
 function! airline#extensions#get_loaded_extensions()

--- a/autoload/airline/extensions/dirvish.vim
+++ b/autoload/airline/extensions/dirvish.vim
@@ -1,0 +1,39 @@
+" MIT Licsense
+" Plugin: https://github.com/justinmk/vim-dirvish
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+if !exists(':Dirvish')
+  finish
+endif
+
+let s:spc = g:airline_symbols.space
+
+function! airline#extensions#dirvish#init(ext) abort
+  call a:ext.add_statusline_func('airline#extensions#dirvish#apply')
+endfunction
+
+function! airline#extensions#dirvish#apply(...) abort
+  if &filetype ==# 'dirvish'
+    let w:airline_section_a = 'Dirvish'
+
+    let w:airline_section_b = exists('*airline#extensions#branch#get_head')
+      \ ? '%{airline#extensions#branch#get_head()}'
+      \ : ''
+
+    let w:airline_section_c =
+      \   '%{join(split((execute("lcd"))))}'
+      \ . s:spc
+      \ . get(w:, 'airline_section_c', g:airline_section_c)
+
+    let w:airline_section_x = ''
+    let w:airline_section_y = ''
+
+    let current_column_regex = ':%\dv'
+    let w:airline_section_z = join(filter(
+      \   split(get(w:, 'airline_section_z', g:airline_section_z)),
+      \   'v:val !~ current_column_regex'
+      \ ))
+  endif
+endfunction


### PR DESCRIPTION
Matched VCS format of Netrw to only show branch name.
Filetype hidden as it is a duplicate on the left side.
File encoding hidden as it does not matter in dirvish buffer.
Removed unnecessary current column information.

I based this off of the `autoload/airline/extensions/example.vim` file. I do not necessarily know if what I did is the best way to approach this, but I am open to other options. I just cannot guarantee that I would immediately know how to do them. 