### PR TITLE
Support fzf and fzf.vim

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -170,6 +170,12 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'netrw')
   endif
 
+  " fzf buffers are also terminal buffers, so this must be above term.
+  if exists(':FZF') && get(g:, 'airline#extensions#fzf#enabled', 1)
+    call airline#extensions#fzf#init(s:ext)
+    call add(s:loaded_ext, 'fzf')
+  endif
+
   if (has("terminal") || has('nvim')) &&
         \ get(g:, 'airline#extensions#term#enabled', 1)
     call airline#extensions#term#init(s:ext)

--- a/autoload/airline/extensions/fzf.vim
+++ b/autoload/airline/extensions/fzf.vim
@@ -1,0 +1,48 @@
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
+" Plugin: https://github.com/junegunn/fzf, https://github.com/junegunn/fzf.vim
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+if !get(g:, 'loaded_fzf', 0)
+  finish
+endif
+
+function! airline#extensions#fzf#init(ext) abort
+  " Remove the custom statusline that fzf.vim sets by removing its `FileType
+  " fzf` autocmd. Ideally we'd use `let g:fzf_statusline = 0`, but this
+  " variable is checked *before* airline#extensions#init() is called.
+  augroup _fzf_statusline
+    autocmd!
+  augroup END
+
+  call a:ext.add_statusline_func('airline#extensions#fzf#apply')
+  call a:ext.add_inactive_statusline_func('airline#extensions#fzf#inactive_apply')
+endfunction
+
+function! airline#extensions#fzf#statusline(...) abort
+  let spc = g:airline_symbols.space
+
+  let builder = airline#builder#new({ 'active': 1 })
+  call builder.add_section('airline_a', spc.'FZF'.spc)
+  call builder.add_section('airline_c', '')
+  return builder.build()
+endfunction
+
+function! airline#extensions#fzf#apply(...) abort
+  if &filetype ==# 'fzf'
+    let spc = g:airline_symbols.space
+    call a:1.add_section('airline_a', spc.'FZF'.spc)
+    call a:1.add_section('airline_c', '')
+    return 1
+  endif
+endfunction
+
+function! airline#extensions#fzf#inactive_apply(...) abort
+  if getbufvar(a:2.bufnr, '&filetype') ==# 'fzf'
+    let spc = g:airline_symbols.space
+    call a:1.add_section('airline_a', spc.'FZF'.spc)
+    call a:1.add_section('airline_c', '')
+    return 1
+  endif
+endfunction


### PR DESCRIPTION
Adds a more "airliney" statusbar for the terminal buffers created by the [fzf](https://github.com/junegunn/fzf) and [fzf.vim](https://github.com/junegunn/fzf.vim) plugins.

| Command | Before | After |
| - | - | - |
| `:Files` | <img width="858" alt="Screen Shot 2020-06-05 at 17 00 46" src="https://user-images.githubusercontent.com/612155/83846690-585d0400-a74e-11ea-9e26-124469627472.png"> | <img width="858" alt="Screen Shot 2020-06-05 at 16 59 49" src="https://user-images.githubusercontent.com/612155/83846703-5d21b800-a74e-11ea-91e2-00ce44346508.png"> |
| `:Tags` | <img width="858" alt="Screen Shot 2020-06-05 at 17 00 52" src="https://user-images.githubusercontent.com/612155/83846731-690d7a00-a74e-11ea-9dee-7bf80667fb58.png"> | <img width="858" alt="Screen Shot 2020-06-05 at 16 59 58" src="https://user-images.githubusercontent.com/612155/83846756-7296e200-a74e-11ea-8284-e0d718dd1e61.png"> |