### PR TITLE
Fix handling of virtualenv and poetv plugins

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -293,13 +293,13 @@ function! airline#extensions#load()
   " extension won't be initialized. Since both extensions currently just
   " add a virtualenv identifier section to the airline, this seems
   " acceptable.
-  if (get(g:, 'airline#extensions#poetv#enabled', 1) && (exists(':PoetvActivate')))
+  if (get(g:, 'airline#extensions#poetv#enabled', 0) && (exists(':PoetvActivate')))
     call airline#extensions#poetv#init(s:ext)
     call add(s:loaded_ext, 'poetv')
-  elseif (get(g:, 'airline#extensions#virtualenv#enabled', 1) && (exists(':VirtualEnvList')))
+  elseif (get(g:, 'airline#extensions#virtualenv#enabled', 0) && (exists(':VirtualEnvList')))
     call airline#extensions#virtualenv#init(s:ext)
     call add(s:loaded_ext, 'virtualenv')
-  elseif (get(g:, 'airline#extensions#poetv#enabled', 1) && (isdirectory($VIRTUAL_ENV)))
+  elseif (get(g:, 'airline#extensions#poetv#enabled', 0) && (isdirectory($VIRTUAL_ENV)))
     call airline#extensions#poetv#init(s:ext)
     call add(s:loaded_ext, 'poetv')
   endif


### PR DESCRIPTION
Fix #2148 

If `airline#extensions#poetv#enabled` is not set, `get(g:, 'airline#extensions#poetv#enabled', 1` will return `1` (same for `airline#extensions#virtualenv#enabled`).  Thus, if both extensions are not set *and* `$VIRTUAL_ENV` exists, the last `elseif` evaluates as True and the virtualenv will be automatically appended using `fnamemodify($VIRTUAL_ENV, ':t')`.  With this PR the virtualenv will be automatically appended only if either extension is enabled.

It may be good idea to include in the docs an example of how one could set a section or part explicitly to `fnamemodify($VIRTUAL_ENV, ':t')` if they do not have/want either extension.
