### PR TITLE
[RFC] Add support for searchcount extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -428,6 +428,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'cursormode')
   endif
 
+  if get(g:, 'airline#extensions#searchcount#enabled', 1) && exists('*searchcount')
+    call airline#extensions#searchcount#init(s:ext)
+    call add(s:loaded_ext, 'searchcount')
+  endif
+
   if !get(g:, 'airline#extensions#disable_rtp_load', 0)
     " load all other extensions, which are not part of the default distribution.
     " (autoload/airline/extensions/*.vim outside of our s:script_path).

--- a/autoload/airline/extensions/searchcount.vim
+++ b/autoload/airline/extensions/searchcount.vim
@@ -43,6 +43,5 @@ function! s:update_searchcount(timer) abort
   if a:timer ==# s:searchcount_timer
     call searchcount(#{
           \ recompute: 1, maxcount: 0, timeout: 100})
-    redrawstatus
   endif
 endfunction

--- a/autoload/airline/extensions/searchcount.vim
+++ b/autoload/airline/extensions/searchcount.vim
@@ -1,0 +1,48 @@
+" MIT License. Copyright (c) 2013-2020 Bailey Ling et al.
+" This extension is inspired by vim-anzu <https://github.com/osyo-manga/vim-anzu>.
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+
+function! airline#extensions#searchcount#init(ext) abort
+  call a:ext.add_statusline_func('airline#extensions#searchcount#apply')
+endfunction
+
+function! airline#extensions#searchcount#apply(...) abort
+  call airline#extensions#append_to_section('y', 
+        \ '%{v:hlsearch ? airline#extensions#searchcount#status() : ""}')
+endfunction
+
+function! airline#extensions#searchcount#status() abort
+  let result = searchcount(#{recompute: 1})
+  if empty(result) || result.total ==# 0
+    return ''
+  endif
+  if result.incomplete ==# 1     " timed out
+    return printf(' /%s [?/??]', @/)
+  elseif result.incomplete ==# 2 " max count exceeded
+    if result.total > result.maxcount &&
+          \  result.current > result.maxcount
+      return printf('%s[>%d/>%d]', @/,
+            \		    result.current, result.total)
+    elseif result.total > result.maxcount
+      return printf('%s[%d/>%d]', @/,
+            \		    result.current, result.total)
+    endif
+  endif
+  return printf('%s[%d/%d]', @/,
+        \		result.current, result.total)
+endfunction
+
+autocmd CursorMoved *
+      \ let s:searchcount_timer = timer_start(
+      \   10, function('s:update_searchcount'))
+
+function! s:update_searchcount(timer) abort
+  if a:timer ==# s:searchcount_timer
+    call searchcount(#{
+          \ recompute: 1, maxcount: 0, timeout: 100})
+    redrawstatus
+  endif
+endfunction


### PR DESCRIPTION
Using searchcount(), I added an extension like [vim-anzu](https://github.com/osyo-manga/vim-anzu).
What do you think this extension? @chrisbra 
I'd love to hear your opinion.

## Demo

![extension](https://user-images.githubusercontent.com/36619465/85932228-2716c480-b905-11ea-95c0-15c8ba5a1a8c.gif)

ps : It is shown in section_y.

## related issue

#2154