### PR TITLE
Add OmniSharp extension to display server status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the Changelog for the vim-airline project.
     - [Vaffle](https://github.com/cocopon/vaffle.vim) support
     - [vim-dirvish](https://github.com/justinmk/vim-dirvish) support
     - [fzf.vim](https://github.com/junegunn/fzf.vim) support
+    - [OmniSharp](https://github.com/OmniSharp/omnisharp-vim) support
 - Improvements
   - git branch can also be displayed using [gina.vim](https://github.com/lambdalisue/gina.vim)
   - coc extensions can also show additional status messages

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -461,6 +461,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'dirvish')
   endif
 
+  if (get(g:, 'airline#extensions#omnisharp#enabled', 1) && get(g:, 'OmniSharp_loaded', 0))
+    call airline#extensions#omnisharp#init(s:ext)
+    call add(s:loaded_ext, 'omnisharp')
+  endif
+
 endfunction
 
 function! airline#extensions#get_loaded_extensions()

--- a/autoload/airline/extensions/omnisharp.vim
+++ b/autoload/airline/extensions/omnisharp.vim
@@ -1,0 +1,45 @@
+" MIT License
+" Plugin: https://github.com/OmniSharp/omnisharp-vim
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+if !get(g:, 'OmniSharp_loaded', 0)
+  finish
+endif
+
+function! airline#extensions#omnisharp#server_status(...) abort
+  if !exists(':OmniSharpGotoDefinition') || !get(g:, 'OmniSharp_server_stdio', 0)
+    return ''
+  endif
+
+  let host = OmniSharp#GetHost(bufnr('%'))
+  if type(host.job) != v:t_dict || get(host.job, 'stopped')
+    return ''
+  endif
+
+  let sln = fnamemodify(host.sln_or_dir, ':t')
+
+  if get(host.job, 'loaded', 0)
+    return sln
+  endif
+
+  try
+    let projectsloaded = OmniSharp#project#CountLoaded()
+    let projectstotal = OmniSharp#project#CountTotal()
+  catch
+    " The CountLoaded and CountTotal functions are very new - catch the error
+    " when they don't exist
+    let projectsloaded = 0
+    let projectstotal = 0
+  endtry
+  return printf('%s(%d/%d)', sln, projectsloaded, projectstotal)
+endfunction
+
+function! airline#extensions#omnisharp#init(ext) abort
+  call airline#parts#define_function('omnisharp', 'airline#extensions#omnisharp#server_status')
+  augroup airline_omnisharp
+    autocmd!
+    autocmd User OmniSharpStarted,OmniSharpReady,OmniSharpStopped AirlineRefresh!
+  augroup END
+endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -178,6 +178,7 @@ function! airline#init#bootstrap()
   call airline#parts#define_text('grepper', '')
   call airline#parts#define_text('xkblayout', '')
   call airline#parts#define_text('keymap', '')
+  call airline#parts#define_text('omnisharp', '')
 
   unlet g:airline#init#bootstrapping
 endfunction
@@ -205,7 +206,7 @@ function! airline#init#sections()
     let g:airline_section_gutter = airline#section#create(['%='])
   endif
   if !exists('g:airline_section_x')
-    let g:airline_section_x = airline#section#create_right(['bookmark', 'tagbar', 'vista', 'gutentags', 'grepper', 'filetype'])
+    let g:airline_section_x = airline#section#create_right(['bookmark', 'tagbar', 'vista', 'gutentags', 'omnisharp', 'grepper', 'filetype'])
   endif
   if !exists('g:airline_section_y')
     let g:airline_section_y = airline#section#create_right(['ffenc'])

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -882,6 +882,12 @@ vim-obsession <https://github.com/tpope/vim-obsession>
 * set marked window indicator string >
   let g:airline#extensions#obsession#indicator_text = '$'
 <
+-------------------------------------                    *airline-omnisharp*
+OmniSharp <https://github.com/OmniSharp/omnisharp-vim>
+
+* enable/disable OmniSharp integration >
+  let g:airline#extensions#omnisharp#enabled = 1
+
 -------------------------------------                          *airline-po*
 This extension will display the currently translated, untranslated and fuzzy
 messages when editing translations (po files). Related plugin (not necessary

--- a/t/init.vim
+++ b/t/init.vim
@@ -34,7 +34,7 @@ describe 'init sections'
   end
 
   it 'section x should be filetype'
-    Expect g:airline_section_x == '%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
+    Expect g:airline_section_x == '%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
   end
 
   it 'section y should be fenc and ff'


### PR DESCRIPTION
This PR adds the OmniSharp server status for C#

While the server is loading (4 of 23 projects loaded, for solution "OmniSharp.sln"):

![image](https://user-images.githubusercontent.com/5274565/86853702-22bf8800-c10b-11ea-9d8a-f798ee92c320.png)

Once the server is loaded:

![image](https://user-images.githubusercontent.com/5274565/86853774-484c9180-c10b-11ea-9cdb-7a5296f462ae.png)
