### PR TITLE
Add fern.vim support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the Changelog for the vim-airline project.
     - [fzf.vim](https://github.com/junegunn/fzf.vim) support
     - [OmniSharp](https://github.com/OmniSharp/omnisharp-vim) support
     - [searchcount](https://vim-jp.org/vimdoc-en/eval.html#searchcount())  support
+    - [fern.vim](https://github.com/lambdalisue/fern.vim) support
 - Improvements
   - git branch can also be displayed using [gina.vim](https://github.com/lambdalisue/gina.vim)
   - coc extensions can also show additional status messages

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -165,6 +165,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'gina')
   endif
 
+  if get(g:, 'fern_loaded', 0) && get(g:, 'airline#extensions#fern#enabled', 1)
+    call airline#extensions#fern#init(s:ext)
+    call add(s:loaded_ext, 'fern')
+  endif
+
   if exists(':NetrwSettings')
     call airline#extensions#netrw#init(s:ext)
     call add(s:loaded_ext, 'netrw')

--- a/autoload/airline/extensions/fern.vim
+++ b/autoload/airline/extensions/fern.vim
@@ -1,0 +1,36 @@
+" MIT License. Copyright (c) 2013-2020
+" Plugin: https://github.com/lambdalisue/fern.vim
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+if !get(g:, 'fern_loaded', 0)
+  finish
+endif
+
+function! airline#extensions#fern#apply(...) abort
+  if (&ft =~# 'fern')
+    let spc = g:airline_symbols.space
+    let fri = fern#fri#parse(expand('%f'))
+
+    call a:1.add_section('airline_a', spc.'fern'.spc)
+    if exists('*airline#extensions#branch#get_head')
+      call a:1.add_section('airline_b', spc.'%{airline#extensions#branch#get_head()}'.spc)
+    else
+      call a:1.add_section('airline_b', '')
+    endif
+    if !(fri.authority =~# '^drawer')
+      let abspath = substitute(fri.path, 'file://', '', '')
+      call a:1.add_section('airline_c', spc.fnamemodify(abspath, ':~'))
+      call a:1.split()
+      if len(get(g:, 'fern#comparators', {}))
+        call a:1.add_section('airline_y', spc.'%{fern#comparator}'.spc)
+      endif
+    endif
+    return 1
+  endif
+endfunction
+
+function! airline#extensions#fern#init(ext) abort
+  let g:fern_force_overwrite_statusline = 0
+  call a:ext.add_statusline_func('airline#extensions#fern#apply')
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -722,6 +722,16 @@ eclim <https://eclim.org>
   |airline-syntastic| extension. >
   let g:airline#extensions#eclim#enabled = 1
 
+-------------------------------------                 	      *airline-fern*
+fern.vim <https://github.com/lambdalisue/fern.vim>
+
+Airline displays the fern.vim specific statusline.
+(for details, see the help of fern.vim)
+
+* enable/disable bufferline integration >
+  let g:airline#extensions#fern#enabled = 1
+<  default: 1
+
 -------------------------------------                  *airline-fugitiveline*
 This extension hides the fugitive://**// part of the buffer names, to only
 show the file name as if it were in the current working tree.


### PR DESCRIPTION
The PR added to support for [fern.vim](https://github.com/lambdalisue/fern.vim).
fern.vim is a plugin of asynchronous tree viewer.

## ScreenShot
![image](https://user-images.githubusercontent.com/22848261/87221565-e9577880-c3a7-11ea-8666-fea245b018cb.png)

| A | B | C | ... | X | Y | Z |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| fern | \<branch\> | \<working directory\> | | | \<comparator\> (used `sort`) | |

drawer mode
![image](https://user-images.githubusercontent.com/22848261/87221743-57506f80-c3a9-11ea-8fc5-596ecbd067f0.png)

| A | B | C | ... | X | Y | Z |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| fern | \<branch\> |  | | | | |