### PR TITLE
[fix] searchcount's extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -439,7 +439,7 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'cursormode')
   endif
 
-  if get(g:, 'airline#extensions#searchcount#enabled', 1)
+  if get(g:, 'airline#extensions#searchcount#enabled', 1) && exists('*searchcount')
     call airline#extensions#searchcount#init(s:ext)
     call add(s:loaded_ext, 'searchcount')
   endif

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -439,7 +439,7 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'cursormode')
   endif
 
-  if get(g:, 'airline#extensions#searchcount#enabled', 1) && exists('*searchcount')
+  if get(g:, 'airline#extensions#searchcount#enabled', 1)
     call airline#extensions#searchcount#init(s:ext)
     call add(s:loaded_ext, 'searchcount')
   endif

--- a/autoload/airline/extensions/searchcount.vim
+++ b/autoload/airline/extensions/searchcount.vim
@@ -4,6 +4,9 @@
 
 scriptencoding utf-8
 
+if !exists('*searchcount')
+  finish
+endif
 
 function! airline#extensions#searchcount#init(ext) abort
   call a:ext.add_statusline_func('airline#extensions#searchcount#apply')

--- a/autoload/airline/extensions/searchcount.vim
+++ b/autoload/airline/extensions/searchcount.vim
@@ -13,7 +13,7 @@ function! airline#extensions#searchcount#init(ext) abort
 endfunction
 
 function! airline#extensions#searchcount#apply(...) abort
-  call airline#extensions#append_to_section('y', 
+  call airline#extensions#append_to_section('y',
         \ '%{v:hlsearch ? airline#extensions#searchcount#status() : ""}')
 endfunction
 


### PR DESCRIPTION
There was a slight problem with the searchcount extension, so I fixed that.

## minimum vimrc

```vim
call plug#begin('~/.vim/plugged')
Plug 'vim-airline/vim-airline'
call plug#end()

let g:airline_extensions = ['searchcount']
```

## Error

<img width="559" alt="スクリーンショット 2020-07-21 14 13 32" src="https://user-images.githubusercontent.com/36619465/88015536-629b5c00-cb5c-11ea-8839-5cacc2917a3d.png">

## Revised

<img width="421" alt="スクリーンショット 2020-07-21 14 15 22" src="https://user-images.githubusercontent.com/36619465/88015639-a55d3400-cb5c-11ea-9490-72f086771b1e.png">

