### PR TITLE
[add] short_path formatter in section_c

### DIFF
--- a/autoload/airline/formatter/short_path.vim
+++ b/autoload/airline/formatter/short_path.vim
@@ -1,0 +1,8 @@
+scriptencoding utf-8
+
+function! airline#formatter#short_path#format(val) abort
+  if get(g:, 'airline_stl_path_style', 'default') ==# 'short'
+    return '%{pathshorten(expand("'.a:val.'"))}%'
+  endif
+  return a:val
+endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -146,7 +146,7 @@ function! airline#init#bootstrap()
         \ 'function': 'airline#parts#readonly',
         \ 'accent': 'red',
         \ })
-  call airline#parts#define_raw('file', '%f%m')
+  call airline#parts#define_raw('file', airline#formatter#short_path#format('%f%m'))
   call airline#parts#define_raw('path', '%F%m')
   call airline#parts#define('linenr', {
         \ 'raw': '%{g:airline_symbols.linenr}%l',

--- a/t/init.vim
+++ b/t/init.vim
@@ -33,6 +33,11 @@ describe 'init sections'
     Expect g:airline_section_c == '%<%f%m %#__accent_red#%{airline#util#wrap(airline#parts#readonly(),0)}%#__restore__#%#__accent_bold#%#__restore__#'
   end
 
+  it 'section c should be file and coc_status short style'
+    let g:airline_stl_path_style = 'short'
+    Expect g:airline_section_c == '%<%{airline#formatter#short_path#format("%f%m")}% %#__accent_red#%{airline#util#wrap(airline#parts#readonly(),0)}%#__restore__#%#__accent_bold#%#__restore__#'
+  end
+
   it 'section x should be filetype'
     Expect g:airline_section_x == '%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
   end

--- a/t/init.vim
+++ b/t/init.vim
@@ -33,11 +33,6 @@ describe 'init sections'
     Expect g:airline_section_c == '%<%f%m %#__accent_red#%{airline#util#wrap(airline#parts#readonly(),0)}%#__restore__#%#__accent_bold#%#__restore__#'
   end
 
-  it 'section c should be file and coc_status short style'
-    let g:airline_stl_path_style = 'short'
-    Expect g:airline_section_c == '%<%{airline#formatter#short_path#format("%f%m")}% %#__accent_red#%{airline#util#wrap(airline#parts#readonly(),0)}%#__restore__#%#__accent_bold#%#__restore__#'
-  end
-
   it 'section x should be filetype'
     Expect g:airline_section_x == '%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
   end


### PR DESCRIPTION
@chrisbra 

Hello.
I've implemented an option to shorten the path displayed in airlines section_c.
How about this PR?
I'd love to hear your opinion.

## config

```vim
let g:airline_stl_path_style = 'short'
```
(default value : 'default')

Related issue #2060

### screenshot

#### default

<img width="600" alt="スクリーンショット 2020-07-23 16 00 00" src="https://user-images.githubusercontent.com/36619465/88259745-e2146100-ccfd-11ea-8af7-11d815540422.png">

#### short

<img width="445" alt="スクリーンショット 2020-07-23 15 59 43" src="https://user-images.githubusercontent.com/36619465/88259749-e3de2480-ccfd-11ea-8c58-84010ba29337.png">



