### PR TITLE
[fixup] Release the search restriction and remove unnecessary functions

### DIFF
--- a/autoload/airline/extensions/searchcount.vim
+++ b/autoload/airline/extensions/searchcount.vim
@@ -18,7 +18,7 @@ function! airline#extensions#searchcount#apply(...) abort
 endfunction
 
 function! airline#extensions#searchcount#status() abort
-  let result = searchcount(#{recompute: 1})
+  let result = searchcount(#{recompute: 1, maxcount: -1})
   if empty(result) || result.total ==# 0
     return ''
   endif
@@ -36,15 +36,4 @@ function! airline#extensions#searchcount#status() abort
   endif
   return printf('%s[%d/%d]', @/,
         \		result.current, result.total)
-endfunction
-
-autocmd CursorMoved *
-      \ let s:searchcount_timer = timer_start(
-      \   10, function('s:update_searchcount'))
-
-function! s:update_searchcount(timer) abort
-  if a:timer ==# s:searchcount_timer
-    call searchcount(#{
-          \ recompute: 1, maxcount: 0, timeout: 100})
-  endif
 endfunction


### PR DESCRIPTION
I remove unnecessary function and release the search restriction.
Currently, we were unable to successfully count more than 100 search results, so we lifted the limit.

## before

<img width="486" alt="スクリーンショット 2020-07-28 16 35 20" src="https://user-images.githubusercontent.com/36619465/88633716-58470800-d0f0-11ea-804d-e6ab4eda9011.png">

## after

<img width="478" alt="スクリーンショット 2020-07-28 16 34 59" src="https://user-images.githubusercontent.com/36619465/88633744-609f4300-d0f0-11ea-831d-ede98aa8d17f.png">


