### PR TITLE
Rename to g:loaded_fern from g:fern_loaded

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -165,7 +165,7 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'gina')
   endif
 
-  if get(g:, 'fern_loaded', 0) && get(g:, 'airline#extensions#fern#enabled', 1)
+  if (get(g:, 'fern_loaded', 0) || get(g:, 'loaded_fern', 0)) && get(g:, 'airline#extensions#fern#enabled', 1)
     call airline#extensions#fern#init(s:ext)
     call add(s:loaded_ext, 'fern')
   endif

--- a/autoload/airline/extensions/fern.vim
+++ b/autoload/airline/extensions/fern.vim
@@ -3,7 +3,7 @@
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8
-if !get(g:, 'fern_loaded', 0)
+if !(get(g:, 'fern_loaded', 0) || get(g:, 'loaded_fern', 0))
   finish
 endif
 


### PR DESCRIPTION
This is mini update PR.

In fern.vim, g:fern_loaded was renamed to g:loaded_fern in fern.vim ... https://github.com/lambdalisue/fern.vim/commit/aad432d2c3247fd4ffc0481a7b45eb5d8483e171.
This PR is following the commit.