### PR TITLE
add 'g:airline#extensions#tabline#tabtitle_formatter' option for user to specify a customized format() function to display tab title in tabmode

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -186,6 +186,11 @@ function! airline#extensions#tabline#title(n)
     let title = gettabvar(a:n, 'title')
   endif
 
+  let formatter = get(g:, 'airline#extensions#tabline#title_formatter')
+  if empty(title) && formatter !=# '' && exists("*".formatter)
+    let title = call(formatter, [a:n])
+  endif
+
   if empty(title)
     let buflist = tabpagebuflist(a:n)
     let winnr = tabpagewinnr(a:n)


### PR DESCRIPTION
**e.g.**
In tabmode, use "CTRL-W w" switch window, tabpage will update the title with the bufname of the current window.
changes in **vimrc**:
```
let g:airline#extensions#tabline#tabtitle_formatter = 'AirLineTabTitleFormatter'
func! AirLineTabTitleFormatter(n)
    let buflist = tabpagebuflist(a:n)
    let winnr = tabpagewinnr(a:n)
    let bufnr = buflist[winnr - 1]
    let name = bufname(bufnr)

    if empty(name)
        if getqflist({'qfbufnr' : 0}).qfbufnr == bufnr
            let title = airline#extensions#tabline#formatters#default#wrap_name(bufnr, '[Quickfix List]')
        elseif win_getid(tabpagewinnr(a:n), a:n) && getloclist(win_getid(tabpagewinnr(a:n), a:n), {'qfbufnr' : 0}).qfbufnr == bufnr
            let title = airline#extensions#tabline#formatters#default#wrap_name(bufnr, '[Location List]')
        else
            let title = airline#extensions#tabline#formatters#default#wrap_name(bufnr, '[No Name]')
        endif
    else
        if name =~ 'term://'
            " Neovim terminal
            let tail = substitute(name, '\(term:\)//.*:\(.*\)', '\1 \2', '')
        else
            let tail = fnamemodify(name, ':s?/\+$??:t')
        endif
        let title = airline#extensions#tabline#formatters#default#wrap_name(bufnr, tail)
    endif

    return title != '' ? title : airline#extensions#tabline#formatters#default#format(bufnr, buflist)
endfunc
```