### PR TITLE
add 'g:airline#extensions#tabline#tabtitle_formatter' option

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -186,6 +186,11 @@ function! airline#extensions#tabline#title(n)
     let title = gettabvar(a:n, 'title')
   endif
 
+  let formatter = get(g:, 'airline#extensions#tabline#tabtitle_formatter')
+  if empty(title) && formatter !=# '' && exists("*".formatter)
+    let title = call(formatter, [a:n])
+  endif
+
   if empty(title)
     let buflist = tabpagebuflist(a:n)
     let winnr = tabpagewinnr(a:n)

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1216,6 +1216,30 @@ Note: Not displayed if the number of tabs is less than 1
 
   let g:airline#extensions#tabline#formatter = 'short_path'
 
+* defines the customized format() function to display tab title in tab mode. >
+  let g:airline#extensions#tabline#tabtitle_formatter = 'MyTabTitleFormatter'
+<
+  Then define the MyTabTitleFormatter() function in your vimrc. >
+    function MyTabTitleFormatter(n)
+      let buflist = tabpagebuflist(a:n)
+      let winnr = tabpagewinnr(a:n)
+      let bufnr = buflist[winnr - 1]
+      let winid = win_getid(winnr, a:n)
+      let title = bufname(bufnr)
+
+      if empty(title)
+        if getqflist({'qfbufnr' : 0}).qfbufnr == bufnr
+          let title = '[Quickfix List]'
+        elseif winid && getloclist(winid, {'qfbufnr' : 0}) . qfbufnr == bufnr
+          let title = '[Location List]'
+        else
+          let title = '[No Name]'
+        endif
+      endif
+
+      return title
+    endfunction
+
 * configure the minimum number of buffers needed to show the tabline. >
   let g:airline#extensions#tabline#buffer_min_count = 0
 <

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1230,7 +1230,7 @@ Note: Not displayed if the number of tabs is less than 1
       if empty(title)
         if getqflist({'qfbufnr' : 0}).qfbufnr == bufnr
           let title = '[Quickfix List]'
-        elseif winid && getloclist(winid, {'qfbufnr' : 0}) . qfbufnr == bufnr
+        elseif winid && getloclist(winid, {'qfbufnr' : 0}).qfbufnr == bufnr
           let title = '[Location List]'
         else
           let title = '[No Name]'


### PR DESCRIPTION
The option can be used to specify a customized format() function to display tab title in tab mode