### PR TITLE
vim-magit: Can't use an empty dictionary key

### DIFF
--- a/autoload/airline/extensions/vimagit.vim
+++ b/autoload/airline/extensions/vimagit.vim
@@ -9,7 +9,7 @@ if !get(g:, 'loaded_magit', 0)
   finish
 endif
 
-let s:commit_mode = {'': 'STAGING', 'CC': 'COMMIT', 'CA': 'AMEND'}
+let s:commit_mode = {'ST': 'STAGING', 'CC': 'COMMIT', 'CA': 'AMEND'}
 
 function! airline#extensions#vimagit#init(ext) abort
   call a:ext.add_statusline_func('airline#extensions#vimagit#apply')


### PR DESCRIPTION
I updated vim-airline, and I now get an error on line 12 of vimagit.vim:

"E713: Cannot use empty key for Dictionary"

I don't know if this is a "proper" fix but it makes the error go away and I haven't noticed a problem. :-)