### PR TITLE
[add] support for battery.vim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This is the Changelog for the vim-airline project.
     - [searchcount](https://vim-jp.org/vimdoc-en/eval.html#searchcount())  support
     - [fern.vim](https://github.com/lambdalisue/fern.vim) support
     - [Vim-CMake](https://github.com/cdelledonne/vim-cmake) support
+    - [battery.vim](https://github.com/lambdalisue/battery.vim) support
+    - [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) support
 - Improvements
   - git branch can also be displayed using [gina.vim](https://github.com/lambdalisue/gina.vim)
   - coc extensions can also show additional status messages

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -450,6 +450,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'searchcount')
   endif
 
+  if get(g:, 'loaded_battery', 0) && get(g:, 'airline#extensions#battery#enabled', 0)
+    call airline#extensions#battery#init(s:ext)
+    call add(s:loaded_ext, 'battery')
+  endif
+
   if !get(g:, 'airline#extensions#disable_rtp_load', 0)
     " load all other extensions, which are not part of the default distribution.
     " (autoload/airline/extensions/*.vim outside of our s:script_path).

--- a/autoload/airline/extensions/battery.vim
+++ b/autoload/airline/extensions/battery.vim
@@ -1,0 +1,20 @@
+" MIT License. Copyright (c) 2014-2020 Mathias Andersson et al.
+" Plugin: https://github.com/lambdalisue/battery.vim
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+if !exists('g:loaded_battery')
+  finish
+endif
+
+function! airline#extensions#battery#status(...) abort
+  if !exists('g:battery#update_statusline') 
+    let g:battery#update_statusline = 1
+  endif
+  let w:airline_section_z = '%{battery#component()}'
+endfunction
+
+function! airline#extensions#battery#init(ext) abort
+  call a:ext.add_statusline_func('airline#extensions#battery#status')
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -480,6 +480,13 @@ ale <https://github.com/dense-analysis/ale>
 * ale close_lnum_symbol >
   let airline#extensions#ale#close_lnum_symbol = ')'
 
+-------------------------------------                      *airline-battery*
+vim-battery <https://github.com/lambdalisue/battery.vim>
+
+* enable/disable battery integration >
+  let g:airline#extensions#battery#enabled = 1
+<  default: 0
+
 -------------------------------------                      *airline-bookmark*
 vim-bookmark <https://github.com/MattesGroeger/vim-bookmarks>
 


### PR DESCRIPTION
I write a extension about `battery.vim`.
If you use this extension, section_z is overwritten and the value returned by the battery.vim api is rendered into section_z.

## screen shot

<img width="564" alt="スクリーンショット 2020-09-08 1 11 02" src="https://user-images.githubusercontent.com/36619465/92405394-6d439c00-f170-11ea-986d-6054be8bf8c5.png">

## related issue 

#2220