### PR TITLE
Only attempt to use dirvish if b:dirvish exists

### DIFF
--- a/autoload/airline/extensions/dirvish.vim
+++ b/autoload/airline/extensions/dirvish.vim
@@ -15,7 +15,7 @@ function! airline#extensions#dirvish#init(ext) abort
 endfunction
 
 function! airline#extensions#dirvish#apply(...) abort
-  if &filetype ==# 'dirvish'
+  if &filetype ==# 'dirvish' && exists("b:dirvish")
     let w:airline_section_a = 'Dirvish'
 
     let w:airline_section_b = exists('*airline#extensions#branch#get_head')


### PR DESCRIPTION
This was causing persistent errors when you run, for example,

```
ls | nvim -c 'setf dirvish'
```

as dirvish will not yet have set that local variable yet airline will
attempt to use it.