### PR TITLE
Improve the term extension and make it consistent

### DIFF
--- a/autoload/airline/extensions/term.vim
+++ b/autoload/airline/extensions/term.vim
@@ -5,51 +5,60 @@ scriptencoding utf-8
 
 call airline#parts#define_function('tmode', 'airline#extensions#term#termmode')
 call airline#parts#define('terminal', {'text': get(g:airline_mode_map, 't', 't'), 'accent': 'bold'})
+
+let s:spc = g:airline_symbols.space
+
 let s:section_a = airline#section#create_left(['terminal', 'tmode'])
+let s:section_z = airline#section#create(['linenr', 'maxlinenr'])
 
-function! airline#extensions#term#apply(...)
-  if &buftype == 'terminal' || bufname('%')[0] == '!'
-    let spc = g:airline_symbols.space
-
-    call a:1.add_section('airline_a', spc.s:section_a.spc)
-    call a:1.add_section('airline_b', '')
-    call a:1.add_section('airline_term', spc.s:termname())
+function! airline#extensions#term#apply(...) abort
+  if &buftype ==? 'terminal' || bufname(a:2.bufnr)[0] ==? '!'
+    call a:1.add_section_spaced('airline_a', s:section_a)
+    call a:1.add_section_spaced('airline_b', s:neoterm_id(a:2.bufnr))
+    call a:1.add_section('airline_term', s:spc.s:termname(a:2.bufnr))
     call a:1.split()
     call a:1.add_section('airline_y', '')
-    call a:1.add_section('airline_z', spc.airline#section#create_right(['linenr', 'maxlinenr']))
+    call a:1.add_section_spaced('airline_z', s:section_z)
     return 1
   endif
 endfunction
 
-function! airline#extensions#term#inactive_apply(...)
-  if getbufvar(a:2.bufnr, '&buftype') == 'terminal'
-    let spc = g:airline_symbols.space
-    call a:1.add_section('airline_a', spc.'TERMINAL'.spc)
-    call a:1.add_section('airline_b', spc.'%f')
-    let neoterm_id = getbufvar(a:2.bufnr, 'neoterm_id')
-    if neoterm_id != ''
-      call a:1.add_section('airline_c', spc.'neoterm_'.neoterm_id.spc)
-    endif
+function! airline#extensions#term#inactive_apply(...) abort
+  if getbufvar(a:2.bufnr, '&buftype') ==? 'terminal'
+    call a:1.add_section_spaced('airline_a', s:section_a)
+    call a:1.add_section_spaced('airline_b', s:neoterm_id(a:2.bufnr))
+    call a:1.add_section('airline_term', s:spc.s:termname(a:2.bufnr))
+    call a:1.split()
+    call a:1.add_section('airline_y', '')
+    call a:1.add_section_spaced('airline_z', s:section_z)
     return 1
   endif
 endfunction
 
-function! airline#extensions#term#termmode()
+function! airline#extensions#term#termmode() abort
   let mode = airline#parts#mode()[0]
-  if mode ==? 'T'
-    " don't need to output T, statusline already says "TERMINAL"
-    let mode=''
+  if mode ==? 'T' || mode ==? '-'
+    " We don't need to output T, the statusline already says "TERMINAL".
+    " Also we don't want to output "-" on an inactive statusline.
+    let mode = ''
   endif
   return mode
 endfunction
 
-function! s:termname()
-  let bufname = bufname('%')
+function! s:termname(bufnr) abort
+  let bufname = bufname(a:bufnr)
   if has('nvim')
-    return matchstr(bufname, 'term.*:\zs.*')
+    " Get rid of the leading "term", working dir and process ID.
+    " Afterwards, remove the possibly added neoterm ID.
+    return substitute(matchstr(bufname, 'term.*:\zs.*'),
+                    \ ';#neoterm-\d\+', '', '')
   else
-    " get rid of leading '!'
-    if bufname[0] is# '!'
+    if bufname =~? 'neoterm-\d\+'
+      " Do not return a redundant buffer name, when this is a neoterm terminal.
+      return ''
+    endif
+    " Get rid of the leading "!".
+    if bufname[0] ==? '!'
       return bufname[1:]
     else
       return bufname
@@ -57,7 +66,15 @@ function! s:termname()
   endif
 endfunction
 
-function! airline#extensions#term#init(ext)
+function! s:neoterm_id(bufnr) abort
+  let id = getbufvar(a:bufnr, 'neoterm_id')
+  if id !=? ''
+    let id = 'neoterm-'.id
+  endif
+  return id
+endfunction
+
+function! airline#extensions#term#init(ext) abort
   call a:ext.add_statusline_func('airline#extensions#term#apply')
   call a:ext.add_inactive_statusline_func('airline#extensions#term#inactive_apply')
 endfunction


### PR DESCRIPTION
This improves the term extension in a few ways.

First it fixes some vint warnings about case sensitive comparisons.

Next it makes the active and inactive variants consistent, as well as
making the line number display consistent to other buffer types. This
was one of the main reasons to do this, because the inclusion of the
Neoterm ID in a previous pull request made inactive terminal status
lines look really inconsistent compared to the active ones.

Further this now shows the Neoterm ID in both active and inactive
buffers in Airline section B. It also removes the now redundant
Neoterm IDs from the buffer name in both Neovim and Vim.

Finally the cosmetic buffer name is now used for both active and
inactive variants.