### PR TITLE
[update] .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ doc/tags
 *.lock
 .vim-flavor
 *.swp
+.bundle
+vendor
+


### PR DESCRIPTION
`bundle install --path vendor/bundle` to ignore files created when installing vim-flavor and vim-vspce