### PR TITLE
Add more customization for 'localsearch' extension

### DIFF
--- a/autoload/airline/extensions/localsearch.vim
+++ b/autoload/airline/extensions/localsearch.vim
@@ -12,6 +12,8 @@ let g:airline#extensions#localsearch#loaded = 001
 
 let s:spc = g:airline_symbols.space
 
+let g:airline#extensions#localsearch#inverted = get(g:, 'airline#extensions#localsearch#inverted', 0)
+
 function! airline#extensions#localsearch#load_theme(palette)
   call airline#highlighter#exec('localsearch_dark', [ '#ffffff' , '#000000' , 15  , 1 , ''])
 endfunction
@@ -28,8 +30,11 @@ function! airline#extensions#localsearch#apply(...)
   let builder = a:1
 
   """"" WARNING: the API for the builder is not finalized and may change
-  if exists('#localsearch#WinEnter') " If localsearch mode is enabled
+  if exists('#localsearch#WinEnter') && !g:airline#extensions#localsearch#inverted " If localsearch mode is enabled and 'invert' option is false
     call builder.add_section('localsearch_dark', s:spc.airline#section#create('LS').s:spc)
+  endif
+  if !exists('#localsearch#WinEnter') && g:airline#extensions#localsearch#inverted " If localsearch mode is disabled and 'invert' option is true
+    call builder.add_section('localsearch_dark', s:spc.airline#section#create('GS').s:spc)
   endif
   return 0
 endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -847,6 +847,10 @@ localsearch <https://github.com/mox-mox/vim-localsearch>
 * enable/disable localsearch indicator integration >
   let g:airline#extensions#localsearch#enabled = 1
 
+* show only when localsearch is off (shows 'GS' denoting GlobalSearch)
+  (this option is set to 0 by default) >
+  let g:airline#extensions#localsearch#enabled = 1
+
 -------------------------------------                    *airline-lsp*
 lsp <https://github.com/prabirshrestha/vim-lsp>
 


### PR DESCRIPTION
Now it can be configured to show only when localsearch is disabled. It
is useful if you mostly keep localsearch enabled and don't want to keep
seeing the extra 'LS' section, but still want to have some kind of a
visual indication about when localsearch is disabled.