### PR TITLE
[battery.vim] Change indicator to not overwrite position section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The statusline is the colored line at the bottom, which contains the sections
 section|meaning (example)
 -------|------------------
   A    | displays the mode + additional flags like crypt/spell/paste (INSERT)
-  B    | VCS information - branch, hunk summary (master)
+  B    | Environment status (VCS information - branch, hunk summary (master), [battery][61] level)
   C    | filename + read-only flag (~/.vim/vimrc RO)
   X    | filetype  (vim)
   Y    | file encoding[fileformat] (utf-8[unix])
@@ -66,7 +66,8 @@ For a better look, those sections can be colored differently, depending on vario
    [undotree][17], [nerdtree][18], [tagbar][19], [vim-gitgutter][29],
    [vim-signify][30], [quickfixsigns][39], [syntastic][5], [eclim][34],
    [lawrencium][21], [virtualenv][31], [tmuxline][35], [taboo.vim][37],
-   [ctrlspace][38], [vim-bufmru][47], [vimagit][50], [denite][51] and more.
+   [ctrlspace][38], [vim-bufmru][47], [vimagit][50], [denite][51],
+   [vim.battery][61] and more.
 *  Looks good with regular fonts and provides configuration points so you can use unicode or powerline symbols.
 *  Optimized for speed - loads in under a millisecond.
 *  Extensive suite of themes for popular color schemes including [solarized][23] (dark and light), [tomorrow][24] (all variants), [base16][32] (all variants), [molokai][25], [jellybeans][26] and others.
@@ -190,6 +191,9 @@ vim-airline integrates with a variety of plugins out of the box.  These extensio
 
 #### [Vim-CMake][60]
 ![image](https://user-images.githubusercontent.com/24732205/87788512-c876a380-c83d-11ea-9ee3-5f639f986a8f.png)
+
+#### [vim.battery][61]
+![image](https://user-images.githubusercontent.com/1969470/94561399-368b0e00-0264-11eb-94a0-f6b67c73d422.png)
 
 ## Extras
 
@@ -357,3 +361,4 @@ If you are interested in becoming a maintainer (we always welcome more maintaine
 [58]: https://github.com/vim-airline/vim-airline/blob/master/LICENSE
 [59]: https://github.com/neoclide/coc-git
 [60]: https://github.com/cdelledonne/vim-cmake
+[61]: http://github.com/lambdalisue/battery.vim/

--- a/autoload/airline/extensions/battery.vim
+++ b/autoload/airline/extensions/battery.vim
@@ -9,12 +9,15 @@ if !exists('g:loaded_battery')
 endif
 
 function! airline#extensions#battery#status(...) abort
-  if !exists('g:battery#update_statusline') 
+  if !exists('g:battery#update_statusline')
     let g:battery#update_statusline = 1
+    call battery#update()
   endif
-  let w:airline_section_z = '%{battery#component()}'
+
+  let bat = battery#component()
+  return bat
 endfunction
 
 function! airline#extensions#battery#init(ext) abort
-  call a:ext.add_statusline_func('airline#extensions#battery#status')
+  call airline#parts#define_function('battery', 'airline#extensions#battery#status')
 endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -172,7 +172,7 @@ function! airline#init#bootstrap()
         \ 'lsp_error_count', 'lsp_warning_count',
         \ 'nvimlsp_error_count', 'nvimlsp_warning_count',
         \ 'languageclient_error_count', 'languageclient_warning_count',
-        \ 'coc_warning_count', 'coc_error_count', 'vista'])
+        \ 'coc_warning_count', 'coc_error_count', 'vista', 'battery'])
   call airline#parts#define_text('bookmark', '')
   call airline#parts#define_text('capslock', '')
   call airline#parts#define_text('gutentags', '')
@@ -194,7 +194,11 @@ function! airline#init#sections()
     let g:airline_section_a = airline#section#create_left(['mode', 'crypt', 'paste', 'keymap', 'spell', 'capslock', 'xkblayout', 'iminsert'])
   endif
   if !exists('g:airline_section_b')
-    let g:airline_section_b = airline#section#create(['hunks', 'branch'])
+    if airline#util#winwidth() > 99
+      let g:airline_section_b = airline#section#create(['hunks', 'branch', 'battery'])
+    else
+      let g:airline_section_b = airline#section#create(['hunks', 'branch'])
+    endif
   endif
   if !exists('g:airline_section_c')
     if exists("+autochdir") && &autochdir == 1

--- a/t/init.vim
+++ b/t/init.vim
@@ -84,6 +84,7 @@ describe 'init sections'
     Expect airline#parts#get('vista').raw == ''
     Expect airline#parts#get('coc_warning_count').raw == ''
     Expect airline#parts#get('coc_error_count').raw == ''
+    Expect airline#parts#get('battery').raw == ''
   end
 end
 


### PR DESCRIPTION
Follow-up for #2227, adds the indicator to a location where it is not overwriting other indicators/widgets.

![Screenshot_20200929_145656](https://user-images.githubusercontent.com/1969470/94561314-1f4c2080-0264-11eb-8463-64fe1e15d76a.png)
![Screenshot_20200929_145815](https://user-images.githubusercontent.com/1969470/94561399-368b0e00-0264-11eb-94a0-f6b67c73d422.png)
