### PR TITLE
Get rid of g:airline_gui_mode

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -133,11 +133,8 @@ function! airline#builder#should_change_group(group1, group2)
   endif
   let color1 = airline#highlighter#get_highlight(a:group1)
   let color2 = airline#highlighter#get_highlight(a:group2)
-  if g:airline_gui_mode ==# 'gui'
-    return color1[1] != color2[1] || color1[0] != color2[0]
-  else
-    return color1[3] != color2[3] || color1[2] != color2[2]
-  endif
+  return color1[1] != color2[1] || color1[0] != color2[0]
+      \ ||  color1[2] != color2[2] || color1[3] != color2[3]
 endfunction
 
 function! s:get_transitioned_seperator(self, prev_group, group, side)

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -31,7 +31,6 @@ function! airline#init#bootstrap()
   call s:check_defined('g:airline_exclude_filenames', ['DebuggerWatch','DebuggerStack','DebuggerStatus'])
   call s:check_defined('g:airline_exclude_filetypes', [])
   call s:check_defined('g:airline_exclude_preview', 0)
-  call s:check_defined('g:airline_gui_mode', airline#init#gui_mode())
 
   call s:check_defined('g:airline_mode_map', {})
   call extend(g:airline_mode_map, {
@@ -183,10 +182,6 @@ function! airline#init#bootstrap()
   call airline#parts#define_text('omnisharp', '')
 
   unlet g:airline#init#bootstrapping
-endfunction
-
-function! airline#init#gui_mode()
-  return has('gui_running') || (has("termguicolors") && &termguicolors == 1) ?  'gui' : 'cterm'
 endfunction
 
 function! airline#init#sections()

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -99,7 +99,6 @@ function! s:on_colorscheme_changed()
   call s:init()
   unlet! g:airline#highlighter#normal_fg_hi
   call airline#highlighter#reset_hlcache()
-  let g:airline_gui_mode = airline#init#gui_mode()
   if !s:theme_in_vimrc
     call airline#switch_matching_theme()
   endif
@@ -139,11 +138,7 @@ function! s:airline_toggle()
             \ | call <sid>on_window_changed('CmdwinEnter')
       autocmd CmdwinLeave * call airline#remove_statusline_func('airline#cmdwinenter')
 
-      autocmd GUIEnter,ColorScheme * call <sid>on_colorscheme_changed()
-      if exists("##OptionSet")
-        " Make sure that g_airline_gui_mode is refreshed
-        autocmd OptionSet termguicolors call <sid>on_colorscheme_changed()
-      endif
+      autocmd ColorScheme * call <sid>on_colorscheme_changed()
       " Set all statuslines to inactive
       autocmd FocusLost * call airline#update_statusline_focuslost()
       " Refresh airline for :syntax off

--- a/t/highlighter.vim
+++ b/t/highlighter.vim
@@ -6,8 +6,19 @@ describe 'highlighter'
     hi Foo2 ctermfg=3 ctermbg=4
     call airline#highlighter#add_separator('Foo1', 'Foo2', 0)
     let hl = airline#highlighter#get_highlight('Foo1_to_Foo2')
-    Expect hl == [ '', '', '4', '2', '' ]
+    Expect hl == [ 'NONE', 'NONE', '4', '2', '' ]
   end
+
+  if exists("+termguicolors")
+    it 'should create separator highlight groups with termguicolors'
+      set termguicolors
+      hi Foo1 guifg=#cd0000 guibg=#00cd00 ctermfg=1 ctermbg=2
+      hi Foo2 guifg=#cdcd00 guibg=#0000ee ctermfg=3 ctermbg=4
+      call airline#highlighter#add_separator('Foo1', 'Foo2', 0)
+      let hl = airline#highlighter#get_highlight('Foo1_to_Foo2')
+      Expect hl == [ '#0000ee', '#00cd00', '4', '2', '' ]
+    end
+  endif
 
   it 'should populate accent colors'
     Expect exists('g:airline#themes#dark#palette.normal.airline_c_red') to_be_false

--- a/t/themes.vim
+++ b/t/themes.vim
@@ -8,23 +8,42 @@ describe 'themes'
     call airline#highlighter#reset_hlcache()
     highlight Foo ctermfg=1 ctermbg=2
     let colors = airline#themes#get_highlight('Foo')
+    Expect colors[0] == 'NONE'
+    Expect colors[1] == 'NONE'
     Expect colors[2] == '1'
     Expect colors[3] == '2'
   end
+
+  if exists("+termguicolors")
+    it 'should extract correct colors with termguicolors'
+      call airline#highlighter#reset_hlcache()
+      set termguicolors
+      highlight Foo guifg=#cd0000 guibg=#00cd00 ctermfg=1 ctermbg=2
+      let colors = airline#themes#get_highlight('Foo')
+      Expect colors[0] == '#cd0000'
+      Expect colors[1] == '#00cd00'
+      Expect colors[2] == '1'
+      Expect colors[3] == '2'
+    end
+  endif
 
   it 'should extract from normal if colors unavailable'
     call airline#highlighter#reset_hlcache()
     highlight Normal ctermfg=100 ctermbg=200
     highlight Foo ctermbg=2
     let colors = airline#themes#get_highlight('Foo')
+    Expect colors[0] == 'NONE'
+    Expect colors[1] == 'NONE'
     Expect colors[2] == '100'
     Expect colors[3] == '2'
   end
 
   it 'should flip target group if it is reversed'
     call airline#highlighter#reset_hlcache()
-    highlight Foo ctermbg=222 ctermfg=103 term=reverse
+    highlight Foo ctermbg=222 ctermfg=103 cterm=reverse
     let colors = airline#themes#get_highlight('Foo')
+    Expect colors[0] == 'NONE'
+    Expect colors[1] == 'NONE'
     Expect colors[2] == '222'
     Expect colors[3] == '103'
   end
@@ -33,10 +52,10 @@ describe 'themes'
     call airline#highlighter#reset_hlcache()
     hi clear Normal
     let hl = airline#themes#get_highlight('Foo', 'bold', 'italic')
-    Expect hl == ['', '', 'NONE', 'NONE', 'bold,italic']
+    Expect hl == ['NONE', 'NONE', 'NONE', 'NONE', 'bold,italic']
 
     let hl = airline#themes#get_highlight2(['Foo','bg'], ['Foo','fg'], 'italic', 'bold')
-    Expect hl == ['', '', 'NONE', 'NONE', 'italic,bold']
+    Expect hl == ['NONE', 'NONE', 'NONE', 'NONE', 'italic,bold']
   end
 
   it 'should generate color map with mirroring'


### PR DESCRIPTION
This is needed for Neovim, because an external UI could be attached to
the same neovim server, so it does not make sense to define highlighting
groups with either only the cterm or the guifg attribute set.

So refactor the code slightly got get rid of this variable (and since
this variable is not needed anymore, we can also get rid of the guienter
and OptionSet autocommand).

fixes: #2261