### PR TITLE
[fix] short path formatter's space

### DIFF
--- a/autoload/airline/formatter/short_path.vim
+++ b/autoload/airline/formatter/short_path.vim
@@ -2,7 +2,7 @@ scriptencoding utf-8
 
 function! airline#formatter#short_path#format(val) abort
   if get(g:, 'airline_stl_path_style', 'default') ==# 'short'
-    return '%{pathshorten(expand("'.a:val.'"))}%'
+    return '%{pathshorten(expand("'.a:val.'"))}'
   endif
   return a:val
 endfunction


### PR DESCRIPTION
Fixed a bug that caused a space between the READONLY icon and the READONLY icon to be lost when using a short_path formatter, as shown in the following figure.

## before

<img width="155" alt="スクリーンショット 2020-11-05 23 49 54" src="https://user-images.githubusercontent.com/36619465/98256203-9f7f4780-1fc1-11eb-9719-9a1cf75cf52d.png">

## after

<img width="180" alt="スクリーンショット 2020-11-05 23 49 02" src="https://user-images.githubusercontent.com/36619465/98256145-8ffffe80-1fc1-11eb-880b-0dea221c0698.png">

## mentiond comment

https://github.com/vim-airline/vim-airline/commit/b322ee6728ea418d99028bc2606c12dbc3b95530#r43628183