### PR TITLE
Check LanguageClient-neovim's status before getting diagnostics

### DIFF
--- a/autoload/airline/extensions/languageclient.vim
+++ b/autoload/airline/extensions/languageclient.vim
@@ -66,6 +66,10 @@ function! s:airline_languageclient_get_line_number(type) abort
 endfunction
 
 function! airline#extensions#languageclient#get(type)
+  if get(b:, 'LanguageClient_isServerRunning', 0) ==# 0
+    return ''
+  endif
+
   let is_err = a:type == s:severity_error
   let symbol = is_err ? s:error_symbol : s:warning_symbol
 


### PR DESCRIPTION
This PR makes use of the buf var `LanguageClient_isServerRunning` that was added in version `0.1.157' in `LanguageClient-neovim` and that can be used to check if there is a language server running for the filetype of the current buffer. Checking that enables vim-airline to exit early if there is no server running and saves a few cycles which could be meaningful in big files.

See https://github.com/autozimu/LanguageClient-neovim/pull/1121#issuecomment-722936948 for an example of where this might be an issue.

There are a few things to note here, the first one is that my original intention was to place that check on the `init` function instead, but that doesn't really work with "slow" language servers, since the server may not be running by the time the extension is loaded.
The other thing to note is that this could potentially silently break the extension for users that update `vim-airline` but are running an old version of LanguageClient-neovim, but defaulting to `1` instead of `0` in that `get(b:, 'LanguageClient_isServerRunning, 0)` call wouldn't work either. In any case, I think the risk is quite low, since I would assume that anyone that updates `vim-airline` also updated or will update `LanguageClient-neovim`.

I tried to compare the results of this change by just opening a file and scrolling through it and I think the results are quite promising:

Before this change:
```

FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
  602   0.180755   0.131427  airline#check_mode()
  602   0.172847   0.136300  airline#extensions#whitespace#check()
 1204   0.164142   0.071897  airline#extensions#languageclient#get()
  602   0.108541   0.015403  airline#extensions#languageclient#get_warning()
 1204   0.092246             <SNR>58_diagnostics_for_buffer()
  602   0.089229   0.028680  airline#parts#readonly()
  602   0.085552   0.014547  airline#extensions#languageclient#get_error()
 4214   0.082683             airline#util#append()
 1204   0.072048   0.047910  airline#util#shorten()
  602   0.060549             airline#util#ignore_buf()
    2   0.047991   0.007472  airline#highlighter#highlight()
  602   0.047253   0.011752  airline#parts#mode()
 3612   0.046621             airline#util#prepend()
 4214   0.042628             airline#util#wrap()
  602   0.040146             airline#extensions#keymap#status()
  576   0.037270   0.028315  <SNR>26_on_cursor_moved()
 1806   0.036805             airline#util#winwidth()
   70   0.032214   0.007628  airline#highlighter#exec()
  602   0.031345             airline#parts#ffenc()
  602   0.030698             airline#extensions#tagbar#currenttag()

FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  602   0.172847   0.136300  airline#extensions#whitespace#check()
  602   0.180755   0.131427  airline#check_mode()
 1204              0.092246  <SNR>58_diagnostics_for_buffer()
 4214              0.082683  airline#util#append()
 1204   0.164142   0.071897  airline#extensions#languageclient#get()
  602              0.060549  airline#util#ignore_buf()
 1204   0.072048   0.047910  airline#util#shorten()
 3612              0.046621  airline#util#prepend()
 4214              0.042628  airline#util#wrap()
  602              0.040146  airline#extensions#keymap#status()
 1806              0.036805  airline#util#winwidth()
  602              0.031345  airline#parts#ffenc()
  602              0.030698  airline#extensions#tagbar#currenttag()
  602              0.029539  airline#parts#spell()
  602   0.089229   0.028680  airline#parts#readonly()
  576   0.037270   0.028315  <SNR>26_on_cursor_moved()
  602              0.019228  airline#statusline()
  602   0.028321   0.015654  airline#parts#filetype()
  602   0.108541   0.015403  airline#extensions#languageclient#get_warning()
  602   0.085552   0.014547  airline#extensions#languageclient#get_error()
```


After this change
```

FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
  857   0.261987   0.206031  airline#extensions#whitespace#check()
  857   0.217363   0.173794  airline#check_mode()
  857   0.123911   0.039633  airline#parts#readonly()
 5999   0.114340             airline#util#append()
 1714   0.102367   0.067052  airline#util#shorten()
  857   0.084279             airline#util#ignore_buf()
 5142   0.064251             airline#util#prepend()
  857   0.063434   0.017023  airline#parts#mode()
 5999   0.062603             airline#util#wrap()
  857   0.055333             airline#extensions#keymap#status()
  846   0.053950   0.041439  <SNR>26_on_cursor_moved()
 2571   0.053452             airline#util#winwidth()
  857   0.044507             airline#parts#ffenc()
  857   0.044301             airline#extensions#tagbar#currenttag()
    2   0.042181   0.006354  airline#highlighter#highlight()
  857   0.040884             airline#parts#spell()
  857   0.039457   0.021319  airline#parts#filetype()
  857   0.030216   0.020119  airline#extensions#languageclient#get_warning()
  857   0.029413   0.019909  airline#extensions#languageclient#get_error()
   70   0.028493   0.006749  airline#highlighter#exec()

FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  857   0.261987   0.206031  airline#extensions#whitespace#check()
  857   0.217363   0.173794  airline#check_mode()
 5999              0.114340  airline#util#append()
  857              0.084279  airline#util#ignore_buf()
 1714   0.102367   0.067052  airline#util#shorten()
 5142              0.064251  airline#util#prepend()
 5999              0.062603  airline#util#wrap()
  857              0.055333  airline#extensions#keymap#status()
 2571              0.053452  airline#util#winwidth()
  857              0.044507  airline#parts#ffenc()
  857              0.044301  airline#extensions#tagbar#currenttag()
  846   0.053950   0.041439  <SNR>26_on_cursor_moved()
  857              0.040884  airline#parts#spell()
  857   0.123911   0.039633  airline#parts#readonly()
  857              0.025783  airline#statusline()
  857   0.039457   0.021319  airline#parts#filetype()
  857   0.030216   0.020119  airline#extensions#languageclient#get_warning()
  857   0.029413   0.019909  airline#extensions#languageclient#get_error()
 1714              0.019601  airline#extensions#languageclient#get()
  857   0.063434   0.017023  airline#parts#mode()
```