### PR TITLE
Fix typo in checking if gen_tags plugin is loaded

### DIFF
--- a/autoload/airline/extensions/gen_tags.vim
+++ b/autoload/airline/extensions/gen_tags.vim
@@ -5,7 +5,7 @@
 
 scriptencoding utf-8
 
-if !(get(g:, 'loaded_gentags#gtags', 0) || !get(g:, 'loaded_gentags#ctags', 0))
+if !(get(g:, 'loaded_gentags#gtags', 0) || get(g:, 'loaded_gentags#ctags', 0))
   finish
 endif
 


### PR DESCRIPTION
Very sorry. It should be:

> if not (plugin gtags is loaded or plugin ctags is loaded) then finish.

and it was:

> if not (plugin gtags is loaded or plugin ctags is **not** loaded) then finish.

I managed to get `function gen_tags#job#is_running() doesn't exists` kind of error in one of my setups. Please confirm - I believe I made a typo, I'm sorry.