### PR TITLE
remove work-around for vista.vim

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -47,10 +47,6 @@ function! s:init()
   call airline#util#doautocmd('AirlineAfterInit')
 endfunction
 
-function! s:do_vim_enter()
-  call <sid>on_window_changed('VimEnter')
-endfunction
-
 let s:active_winnr = -1
 function! s:on_window_changed(event)
   " don't trigger for Vim popup windows
@@ -140,7 +136,7 @@ function! s:airline_toggle()
       " Refresh airline for :syntax off
       autocmd SourcePre */syntax/syntax.vim
             \ call airline#extensions#tabline#buffers#invalidate()
-      autocmd VimEnter * call <sid>do_vim_enter()
+      autocmd VimEnter * call <sid>on_window_changed('VimEnter')
       autocmd WinEnter * call <sid>on_window_changed('WinEnter')
       autocmd FileType * call <sid>on_window_changed('FileType')
       autocmd BufWinEnter * call <sid>on_window_changed('BufWinEnter')

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -48,10 +48,6 @@ function! s:init()
 endfunction
 
 function! s:do_vim_enter()
-  " Needed for the Vista extension #2009
-  if get(g:, 'airline#extensions#vista#enabled', 1) && exists(':Vista')
-    call vista#RunForNearestMethodOrFunction()
-  endif
   call <sid>on_window_changed('VimEnter')
 endfunction
 


### PR DESCRIPTION
This workaround doesn't seem to be needed anymore, or at least it is breaking the plugin on the latest nightly of Neovim.

https://github.com/liuchengxu/vista.vim/issues/355

The error is that at that point it seems like no lsp server is registered yet and the Neovim lsp client returns 
```
RPC[Error] code_name = MethodNotFound, message = "method textDocument/documentSymbol is not supported by any of the servers registered for the current buffer
```

removing the workaround fixed it and I still have working symbols in my airline status line.