### PR TITLE
buf_diagnostics_count is deprecated. Use 'vim.lsp.diagnostic.get_count'

### DIFF
--- a/autoload/airline/extensions/nvimlsp.vim
+++ b/autoload/airline/extensions/nvimlsp.vim
@@ -25,7 +25,11 @@ function! airline#extensions#nvimlsp#get(type) abort
 
   let symbol = is_err ? error_symbol : warning_symbol
 
-  let num = v:lua.vim.lsp.util.buf_diagnostics_count(a:type)
+  if luaeval("pcall(require, 'vim.lsp.diagnostic')")
+    let num = v:lua.vim.lsp.diagnostic.get_count(0, a:type)
+  else
+    let num = v:lua.vim.lsp.util.buf_diagnostics_count(a:type)
+  endif
 
   return s:airline_nvimlsp_count(num, symbol)
 endfunction


### PR DESCRIPTION
this pr fix this deprecation warning:

```
Error detected while processing function airline#extensions#nvimlsp#get_warning[1]..airline#extensions#nvimlsp#get:
buf_diagnostics_count is deprecated. Use 'vim.lsp.diagnostic.get_count'
```

![image](https://user-images.githubusercontent.com/4319104/99057763-30b07880-25d7-11eb-9d30-4b90d8d38288.png)
