### PR TITLE
added power support arch ppc64le on yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # This config is based on lightline.vim <https://github.com/itchyny/lightline.vim/blob/master/.travis.yml>
-
+arch:
+  - amd64
+  - ppc64le
 language: ruby
 before_install:
   - curl -f -L "https://raw.githubusercontent.com/vim-airline/vim-airline-themes/master/autoload/airline/themes/simple.vim" -o autoload/airline/themes/simple.vim


### PR DESCRIPTION
Hi Team,
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
continuous integration build has passed without any failures after adding power support arch ppc64le on yml file.
please check close this component.

