### PR TITLE
[add] github-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        vim_version:
+        - 'v8.2.1000'
+        - 'v8.2.0000'
+        - 'v8.1.0000'
+        - 'v8.0.0000'
+        - 'v7.4'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@master
+
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+
+    - name: Setup Bundle
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+
+    - name: Setup Vim
+      uses: thinca/action-setup-vim@v1
+      with:
+        vim_version: ${{ matrix.vim_version }}
+
+    - name: Install Dependencies
+      run: | 
+        curl -f -L "https://raw.githubusercontent.com/vim-airline/vim-airline-themes/master/autoload/airline/themes/simple.vim" -o autoload/airline/themes/simple.vim
+        curl -f -L "https://raw.githubusercontent.com/vim-airline/vim-airline-themes/master/autoload/airline/themes/molokai.vim" -o autoload/airline/themes/molokai.vim
+        mkdir colors && curl -f -L 'https://raw.githubusercontent.com/tomasr/molokai/master/colors/molokai.vim' -o colors/molokai.vim
+
+    - name: Run Test
+      run: rake ci


### PR DESCRIPTION
According to an email from travis-ci, `travis-ci.org` will be officially closed down completely on December 31st, 2020
Therefore, We should consider migrating vim-airline's CI.

I wrote a PR to add github-actions because I thought it was less restrictive and faster to build with github-actions than travis-ci.com.

Could you check this PR? @chrisbra .

Note: This is the result of running the same test as travis-ci.org on github-actions.
> https://github.com/kazukazuinaina/vim-airline/actions/runs/410053041