### PR TITLE
tabline: add command for skip to tenth buffer.

### DIFF
--- a/autoload/airline/extensions/tabline/buffers.vim
+++ b/autoload/airline/extensions/tabline/buffers.vim
@@ -161,13 +161,10 @@ function! s:get_number(index)
     return a:index
   endif
   let bidx_mode = get(g:, 'airline#extensions#tabline#buffer_idx_mode', 0)
-  if bidx_mode > 1
-    let l:count = bidx_mode == 2 ? a:index+11 : a:index+1
-    return join(map(split(printf('%02d', l:count), '\zs'),
-          \ 'get(s:number_map, v:val, "")'), '')
-  else
-    return get(s:number_map, a:index+1, '')
-  endif
+  let number_format = bidx_mode > 1 ? '%02d' : '%d'
+  let l:count = bidx_mode == 2 ? a:index+11 : a:index+1
+  return join(map(split(printf(number_format, l:count), '\zs'),
+        \ 'get(s:number_map, v:val, "")'), '')
 endfunction
 
 function! s:select_tab(buf_index)
@@ -199,8 +196,8 @@ function! s:map_keys()
   let bidx_mode = get(g:, 'airline#extensions#tabline#buffer_idx_mode', 1)
   if bidx_mode > 0
     if bidx_mode == 1
-      for i in range(1, 9)
-        exe printf('noremap <silent> <Plug>AirlineSelectTab%d :call <SID>select_tab(%d)<CR>', i, i-1)
+      for i in range(1, 10)
+        exe printf('noremap <silent> <Plug>AirlineSelectTab%d :call <SID>select_tab(%d)<CR>', i%10, i-1)
       endfor
     else
       let start_idx = bidx_mode == 2 ? 11 : 1

--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -107,8 +107,8 @@ function! airline#extensions#tabline#tabs#map_keys()
   endif
   let bidx_mode = get(g:, 'airline#extensions#tabline#buffer_idx_mode', 1)
   if bidx_mode == 1
-    for i in range(1, 9)
-      exe printf('noremap <silent> <Plug>AirlineSelectTab%d :%dtabn<CR>', i, i)
+    for i in range(1, 10)
+      exe printf('noremap <silent> <Plug>AirlineSelectTab%d :%dtabn<CR>', i%10, i)
     endfor
   else
       for i in range(11, 99)

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1117,10 +1117,11 @@ Note: Not displayed if the number of tabs is less than 1
   `buffer_idx_mode` allows 3 different modes to access buffers from the
   tabline. When enabled, numbers will be displayed in the tabline and
   mappings will be exposed to allow you to select a buffer directly.
-  In default mode, when the variable is 1 Up to 11 mappings will be
-  exposed. Note: Those mappings are not automatically created, vim-airline
-  just exposes those `<Plug>AirlineSeelctTab` keys for you to map to a
-  convenient key >
+  In default mode, when the variable is 1 Up to 10 mappings will be
+  exposed. Note: As 10 and 1 have same prefix, we use 0 to replace 10. So,
+  <leader>0 will jump to tenth buffer. Those mappings are not automatically
+  created, vim-airline just exposes those `<Plug>AirlineSeelctTab` keys
+  for you to map to a convenient key >
 
   let g:airline#extensions#tabline#buffer_idx_mode = 1
   nmap <leader>1 <Plug>AirlineSelectTab1
@@ -1132,6 +1133,7 @@ Note: Not displayed if the number of tabs is less than 1
   nmap <leader>7 <Plug>AirlineSelectTab7
   nmap <leader>8 <Plug>AirlineSelectTab8
   nmap <leader>9 <Plug>AirlineSelectTab9
+  nmap <leader>0 <Plug>AirlineSelectTab0
   nmap <leader>- <Plug>AirlineSelectPrevTab
   nmap <leader>+ <Plug>AirlineSelectNextTab
 <


### PR DESCRIPTION
Expose `<Plug>AirlineSelectTab0` to jump to tenth buffer, as `<Plug>AirlineSelectTab10` has same prefix with `<Plug>AirlineSelectTab1` which will add an delay when you want to skip to the first buffer.