### PR TITLE
Support Vue.js file extension in jsformatter

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/jsformatter.vim
+++ b/autoload/airline/extensions/tabline/formatters/jsformatter.vim
@@ -7,7 +7,7 @@ function! airline#extensions#tabline#formatters#jsformatter#format(bufnr, buffer
   let buf = bufname(a:bufnr)
   let filename = fnamemodify(buf, ':t')
 
-  if filename == 'index.js' || filename == 'index.jsx' || filename == 'index.ts' || filename == 'index.tsx'
+  if filename ==# 'index.js' || filename ==# 'index.jsx' || filename ==# 'index.ts' || filename ==# 'index.tsx' || filename ==# 'index.vue'
     return fnamemodify(buf, ':p:h:t') . '/i'
   else
     return airline#extensions#tabline#formatters#unique_tail_improved#format(a:bufnr, a:buffers)


### PR DESCRIPTION
Included `.vue` extension to jsformatter for supporting Vue.js files. Vue files follow the same path resolution as js files: https://vue-loader.vuejs.org/spec.html#src-imports