### PR TITLE
Return nothing when there is no lsp-progress

### DIFF
--- a/autoload/airline/extensions/lsp.vim
+++ b/autoload/airline/extensions/lsp.vim
@@ -80,9 +80,9 @@ function! airline#extensions#lsp#progress() abort
         let message = airline#util#shorten(s:lsp_progress['message'] . percent, 91, 9)
         return s:lsp_progress['server'] . ':' . s:title . ' ' . message
       endif
-      return ''
     endif
   endif
+  return ''
 endfunction
 
 let s:timer = 0


### PR DESCRIPTION
Fix: a literal '0' appears after filename on older versions of vim-lsp.

0c8164b1b3c8017770296320a67a164b3c2aad39 added support for showing lsp
progress, but didn't always explicitly return a value. Vim uses 0 as a
return value when none are supplied, so when used with an older version
of vim-lsp that doesn't have the progress feature a 0 appeared in the
statusline.
