### PR TITLE
Ensure correct checking of LSP support on neovim

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -338,7 +338,8 @@ function! airline#extensions#load()
   endif
 
   if (get(g:, 'airline#extensions#nvimlsp#enabled', 1)
-        \ && has("nvim"))
+        \ && has('nvim')
+        \ && luaeval('vim.lsp ~= nil'))
     call airline#extensions#nvimlsp#init(s:ext)
     call add(s:loaded_ext, 'nvimlsp')
   endif

--- a/autoload/airline/extensions/nvimlsp.vim
+++ b/autoload/airline/extensions/nvimlsp.vim
@@ -5,7 +5,8 @@
 scriptencoding utf-8
 
 if !(get(g:, 'airline#extensions#nvimlsp#enabled', 1)
-      \ && has("nvim"))
+      \ && has('nvim')
+      \ && luaeval('vim.lsp ~= nil'))
   finish
 endif
 
@@ -14,8 +15,7 @@ function! s:airline_nvimlsp_count(cnt, symbol) abort
 endfunction
 
 function! airline#extensions#nvimlsp#get(type) abort
-  if !exists("v:lua.vim.lsp.buf_get_clients()") || 
-        \ empty(v:lua.vim.lsp.buf_get_clients(0))
+  if luaeval('vim.tbl_isempty(vim.lsp.buf_get_clients(0))')
     return ''
   endif
 


### PR DESCRIPTION
Check for differing neovim versions with different APIs for LSP.

If possible I would like this to be tested by a fulltime neovim v0.4.4 user, as I don't have a good vimrc to test with.

Fixes #2324