### PR TITLE
Add searchmethod setting for tagbar extension

### DIFF
--- a/autoload/airline/extensions/tagbar.vim
+++ b/autoload/airline/extensions/tagbar.vim
@@ -43,7 +43,7 @@ function! airline#extensions#tagbar#currenttag()
     endif
     " function tagbar#currenttag does not exist, if filetype is not enabled
     if s:airline_tagbar_last_lookup_time != localtime() && exists("*tagbar#currenttag")
-      let s:airline_tagbar_last_lookup_val = tagbar#currenttag('%s', '', s:flags)
+      let s:airline_tagbar_last_lookup_val = tagbar#currenttag('%s', '', s:flags, get(g:, 'airline#extensions#tagbar#searchmethod', ''))
       let s:airline_tagbar_last_lookup_time = localtime()
     endif
     return s:airline_tagbar_last_lookup_val

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1377,6 +1377,11 @@ tagbar <https://github.com/majutsushi/tagbar>
   let g:airline#extensions#tagbar#flags = 's'
   let g:airline#extensions#tagbar#flags = 'p'
 <
+* configure how to search for the nearest tag (:help tagbar-statusline) >
+  let g:airline#extensions#tagbar#searchmethod = 'nearest-stl' (default)
+  let g:airline#extensions#tagbar#searchmethod = 'nearest'
+  let g:airline#extensions#tagbar#searchmethod = 'scoped-stl'
+<
 -------------------------------------                     *airline-tmuxline*
 tmuxline <https://github.com/edkolev/tmuxline.vim>
 


### PR DESCRIPTION
The current implementation of tagbar does not allow for setting the
search-method in the `tagbar#currenttag` function. In
https://github.com/preservim/tagbar/pull/696, tagbar implemented this,
which has three options: nearest, neartest-stl, and scoped-stl.

The reason for adding this - for me, at least - is to use the scoped-stl
option, so that the statusline will display the proper function when
there are nested functions. (Otherwise, once you go past a nested
function, tagbar#currenttag still returns the nested function rather
than the function it was nested in.)