### PR TITLE
Fix NUL file created when opening a .po file

### DIFF
--- a/autoload/airline/extensions/po.vim
+++ b/autoload/airline/extensions/po.vim
@@ -65,8 +65,9 @@ function! airline#extensions#po#stats()
     return b:airline_po_stats
   endif
 
+  " Write stdout to null because we only want to see warnings.
   if g:airline#init#is_windows
-    let cmd = 'msgfmt --statistics -o NUL '
+    let cmd = 'msgfmt --statistics -o /NUL '
   else
     let cmd = 'msgfmt --statistics -o /dev/null -- '
   endif


### PR DESCRIPTION
Write msgfmt output to /NUL instead of NUL.

Using -o NUL actually creates a file called NUL in the current
directory. Using /NUL doesn't create one in C:\ (the drive the file is
located on) or any visible drive.

Despite msgfmt being able to create the file NUL (which isn't supposed
to be allowed), it's difficult to delete NUL (windows explorer can't
handle it but WSL's unix rm can remove it).

Test
Open po file and see the same warnings as before, but no NUL file
created.
Using msgfmt.exe provided by git (installed via scoop).