### PR TITLE
coc: Show line number for warnings and errors.

### DIFF
--- a/autoload/airline/extensions/coc.vim
+++ b/autoload/airline/extensions/coc.vim
@@ -38,7 +38,8 @@ function! airline#extensions#coc#get(type) abort
   if empty(cnt)
     return ''
   else
-    return (is_err ? s:error_symbol : s:warning_symbol).cnt
+    let lnum = printf('(L%d)', (info.lnums)[0])
+    return (is_err ? s:error_symbol : s:warning_symbol).cnt.lnum
   endif
 endfunction
 


### PR DESCRIPTION
This PR adds functionality to show the line number of the first warning/error. This is my first time writing a vim script so improvements might be possible here and there, but I wanted to direct attention towards https://github.com/neoclide/coc.nvim/issues/1191.
This PR works fine. Here's how it looks.
![image](https://user-images.githubusercontent.com/31820255/109412653-3b005200-79cf-11eb-879f-29067d844fca.png)

L34 tells that the first error occurs at line 34.