### PR TITLE
tagbar: add missing default search method

### DIFF
--- a/autoload/airline/extensions/tagbar.vim
+++ b/autoload/airline/extensions/tagbar.vim
@@ -43,7 +43,7 @@ function! airline#extensions#tagbar#currenttag()
     endif
     " function tagbar#currenttag does not exist, if filetype is not enabled
     if s:airline_tagbar_last_lookup_time != localtime() && exists("*tagbar#currenttag")
-      let s:airline_tagbar_last_lookup_val = tagbar#currenttag('%s', '', s:flags, get(g:, 'airline#extensions#tagbar#searchmethod', ''))
+      let s:airline_tagbar_last_lookup_val = tagbar#currenttag('%s', '', s:flags, get(g:, 'airline#extensions#tagbar#searchmethod', 'nearest-stl'))
       let s:airline_tagbar_last_lookup_time = localtime()
     endif
     return s:airline_tagbar_last_lookup_val


### PR DESCRIPTION
If `g:airline#extensions#tagbar#searchmethod` is unset, empty string is passed to `currenttag`, which makes tagbar integration not work properly.