### PR TITLE
coc: Show the current function in section_x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This is the Changelog for the vim-airline project.
     - [gen_tags.vim](https://github.com/jsfaint/gen_tags.vim) support
 - Improvements
   - git branch can also be displayed using [gina.vim](https://github.com/lambdalisue/gina.vim)
-  - coc extensions can also show additional status messages
+  - coc extensions can also show additional status messages as well as the current function
   - [coc-git](https://github.com/neoclide/coc-git) extension integrated into hunks extension
 - Other
   - Changed CI from travis-ci.org to GitHub Actions

--- a/autoload/airline/extensions/coc.vim
+++ b/autoload/airline/extensions/coc.vim
@@ -48,8 +48,13 @@ function! airline#extensions#coc#get_status() abort
   return airline#util#shorten(get(g:, 'coc_status', ''), 91, 9)
 endfunction
 
+function! airline#extensions#coc#get_current_function() abort
+  return get(b:, 'coc_current_function', '')
+endfunction
+
 function! airline#extensions#coc#init(ext) abort
   call airline#parts#define_function('coc_error_count', 'airline#extensions#coc#get_error')
   call airline#parts#define_function('coc_warning_count', 'airline#extensions#coc#get_warning')
   call airline#parts#define_function('coc_status', 'airline#extensions#coc#get_status')
+  call airline#parts#define_function('coc_current_function', 'airline#extensions#coc#get_current_function')
 endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -164,6 +164,10 @@ function! airline#init#bootstrap()
         \ 'raw': '',
         \ 'accent': 'bold'
         \ })
+  call airline#parts#define('coc_current_function', {
+        \ 'raw': '',
+        \ 'accent': 'bold'
+        \ })
   call airline#parts#define('lsp_progress', {
         \ 'raw': '',
         \ 'accent': 'bold'
@@ -211,7 +215,7 @@ function! airline#init#sections()
     let g:airline_section_gutter = airline#section#create(['%='])
   endif
   if !exists('g:airline_section_x')
-    let g:airline_section_x = airline#section#create_right(['bookmark', 'tagbar', 'vista', 'gutentags', 'gen_tags', 'omnisharp', 'grepper', 'filetype'])
+    let g:airline_section_x = airline#section#create_right(['coc_current_function', 'bookmark', 'tagbar', 'vista', 'gutentags', 'gen_tags', 'omnisharp', 'grepper', 'filetype'])
   endif
   if !exists('g:airline_section_y')
     let g:airline_section_y = airline#section#create_right(['ffenc'])

--- a/t/init.vim
+++ b/t/init.vim
@@ -34,7 +34,7 @@ describe 'init sections'
   end
 
   it 'section x should be filetype'
-    Expect g:airline_section_x == '%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
+    Expect g:airline_section_x == '%#__accent_bold#%#__restore__#%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
   end
 
   it 'section y should be fenc and ff'
@@ -81,6 +81,7 @@ describe 'init sections'
     Expect airline#parts#get('languageclient_error_count').raw == ''
     Expect airline#parts#get('languageclient_warning_count').raw == ''
     Expect airline#parts#get('coc_status').raw == ''
+    Expect airline#parts#get('coc_current_function').raw == ''
     Expect airline#parts#get('vista').raw == ''
     Expect airline#parts#get('coc_warning_count').raw == ''
     Expect airline#parts#get('coc_error_count').raw == ''


### PR DESCRIPTION
coc.nvim exposes the name of the function the cursor is currently in
through b:coc_current_function.

For this to work, the key coc.preferences.currentFunctionSymbolAutoUpdate
must be set to 'true' in the coc config.

The value is only updated on CursorHold, so the value may not always be
accurate when moving around.

Here is an example of how this could look (the function is called `request`):

![2021-03-20-003621_2300x24_scrot](https://user-images.githubusercontent.com/2452038/111852101-0ae50880-8916-11eb-9951-0257d3ff1e22.png)

This is my first contribution here, so I'm not really sure how to properly add new parts. I tried to follow how it was done for the other parts in the coc extension. Please let me know if I should change anything.
