### PR TITLE
Fix error: key not present in dictionary "percentage"

### DIFF
--- a/autoload/airline/extensions/lsp.vim
+++ b/autoload/airline/extensions/lsp.vim
@@ -71,14 +71,14 @@ function! airline#extensions#lsp#progress() abort
 
       " show only most new progress
       let s:lsp_progress = s:lsp_progress[0]
-      if s:lsp_progress['message'] !=# '' && s:lsp_progress['percentage'] !=# 100
+      if s:lsp_progress['message'] !=# ''
         let percent = ''
-        if s:lsp_progress['percentage'] >= 0
+        if has_key(s:lsp_progress, 'percentage') && s:lsp_progress['percentage'] >= 0
           let percent = ' ' . string(s:lsp_progress['percentage']) . '%'
         endif
         let s:title = s:lsp_progress['title']
         let message = airline#util#shorten(s:lsp_progress['message'] . percent, 91, 9)
-        return s:lsp_progress['server'] . ':' . s:title . ' ' . message
+        return s:lsp_progress['server'] . ': ' . s:title . ' ' . message
       endif
     endif
   endif


### PR DESCRIPTION
https://github.com/prabirshrestha/vim-lsp/blob/a3b58eb7c478bddbc6cb93c83839a43ef88aec11/doc/vim-lsp.txt#L1371

percentage key is optional