### PR TITLE
Set bufname for [Scratch] (buftype = nofile)

### DIFF
--- a/autoload/airline/extensions/fugitiveline.vim
+++ b/autoload/airline/extensions/fugitiveline.vim
@@ -34,6 +34,9 @@ function! airline#extensions#fugitiveline#bufname()
 
   let fmod = s:ModifierFlags()
   if empty(b:fugitive_name)
+    if empty(bufname('%'))
+      return &buftype ==# 'nofile' ? '[Scratch]' : '[No Name]'
+    endif
     return fnamemodify(bufname('%'), fmod)
   else
     return fnamemodify(b:fugitive_name, fmod). " [git]"


### PR DESCRIPTION
Couldn't you show bufname to know whether it is a scratch buffer (`&buftype == 'nofile'`) or not,
as `:file` command is showing?
