### PR TITLE
[add] airline_sectionc_filename_onlyfilename option

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -145,7 +145,11 @@ function! airline#init#bootstrap()
         \ 'function': 'airline#parts#readonly',
         \ 'accent': 'red',
         \ })
-  call airline#parts#define_raw('file', airline#formatter#short_path#format('%f%m'))
+  if get(g:, 'airline_section_c_only_filename',0)
+    call airline#parts#define_raw('file', '%t%m')
+  else
+    call airline#parts#define_raw('file', airline#formatter#short_path#format('%f%m'))
+  endif
   call airline#parts#define_raw('path', '%F%m')
   call airline#parts#define('linenr', {
         \ 'raw': '%{g:airline_symbols.linenr}%l',

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -296,6 +296,9 @@ values):
 * Display a short path in statusline: >
   let g:airline_stl_path_style = 'short'
 >
+* Display a only file name in statusline: >
+  let g:airline_section_c_only_filename = 1
+>
 =============================================================================
 COMMANDS                                                  *airline-commands*
 


### PR DESCRIPTION
I added a new option in airline_section_c's filename.
This option allows you to display only the file name in airline_section_c.

## let g:airline_sectionc_filename_onlyfilename = 0 or undefined

<img width="1131" alt="スクリーンショット 2021-04-23 2 22 18" src="https://user-images.githubusercontent.com/36619465/115759165-e976b100-a3da-11eb-9fc7-d1fa3e64a7d4.png">

## let g:airline_sectionc_filename_onlyfilename = 1

<img width="774" alt="スクリーンショット 2021-04-23 2 22 53" src="https://user-images.githubusercontent.com/36619465/115759155-e67bc080-a3da-11eb-919d-801696418ecc.png">