### PR TITLE
[add] test case for init.vim / When autochdir is enabled

### DIFF
--- a/t/init.vim
+++ b/t/init.vim
@@ -33,6 +33,13 @@ describe 'init sections'
     Expect g:airline_section_c == '%<%f%m %#__accent_red#%{airline#util#wrap(airline#parts#readonly(),0)}%#__restore__#%#__accent_bold#%#__restore__#%#__accent_bold#%#__restore__#'
   end
 
+  it 'section c should be path and coc_status'
+    set autochdir
+    call s:clear()
+    call airline#init#sections()
+    Expect g:airline_section_c == '%<%F%m %#__accent_red#%{airline#util#wrap(airline#parts#readonly(),0)}%#__restore__#%#__accent_bold#%#__restore__#%#__accent_bold#%#__restore__#'
+  end
+
   it 'section x should be filetype'
     Expect g:airline_section_x == '%#__accent_bold#%#__restore__#%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#prepend("",0)}%{airline#util#wrap(airline#parts#filetype(),0)}'
   end


### PR DESCRIPTION
I have added a test case to verify that the status line string is correct when `set autochdir` is enabled.