### PR TITLE
Fix #2375: themes and extensions globbing

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -465,7 +465,7 @@ function! airline#extensions#load()
   if !get(g:, 'airline#extensions#disable_rtp_load', 0)
     " load all other extensions, which are not part of the default distribution.
     " (autoload/airline/extensions/*.vim outside of our s:script_path).
-    for file in split(globpath(&rtp, "autoload/airline/extensions/*.vim"), "\n")
+    for file in split(globpath(&rtp, "autoload/airline/extensions/*.vim", 1), "\n")
       " we have to check both resolved and unresolved paths, since it's possible
       " that they might not get resolved properly (see #187)
       if stridx(tolower(resolve(fnamemodify(file, ':p'))), s:script_path) < 0

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -182,7 +182,7 @@ function! airline#util#doautocmd(event)
 endfunction
 
 function! airline#util#themes(match)
-  let files = split(globpath(&rtp, 'autoload/airline/themes/'.a:match.'*.vim'), "\n")
+  let files = split(globpath(&rtp, 'autoload/airline/themes/'.a:match.'*.vim', 1), "\n")
   return sort(map(files, 'fnamemodify(v:val, ":t:r")') + ('random' =~ a:match ? ['random'] : []))
 endfunction
 

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -239,7 +239,7 @@ endfu
 
 function! s:airline_extensions()
   let loaded = airline#extensions#get_loaded_extensions()
-  let files = split(globpath(&rtp, "autoload/airline/extensions/*.vim"), "\n")
+  let files = split(globpath(&rtp, "autoload/airline/extensions/*.vim", 1), "\n")
   call map(files, 'fnamemodify(v:val, ":t:r")')
   if empty(files)
     echo "No extensions loaded"


### PR DESCRIPTION
Ignore wildignore when globbing for themes and extensions.

This can be a problem when you have a wildignore containing *.vim.