### PR TITLE
Prevent duplicate inactive statusline functions being added

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -4,22 +4,32 @@
 scriptencoding utf-8
 
 let g:airline_statusline_funcrefs = get(g:, 'airline_statusline_funcrefs', [])
+let g:airline_inactive_funcrefs = get(g:, 'airline_inactive_statusline_funcrefs', [])
 
 let s:sections = ['a','b','c','gutter','x','y','z', 'error', 'warning']
-let s:inactive_funcrefs = []
 let s:contexts = {}
 let s:core_funcrefs = [
       \ function('airline#extensions#apply'),
       \ function('airline#extensions#default#apply') ]
 
 
-function! airline#add_statusline_func(name)
-  call airline#add_statusline_funcref(function(a:name))
+function! airline#add_statusline_func(name, ...)
+  let warn = get(a:, 1, 1)
+  call airline#add_statusline_funcref(function(a:name), warn)
 endfunction
 
-function! airline#add_statusline_funcref(function)
+function! airline#add_inactive_statusline_func(name, ...)
+  let warn = get(a:, 1, 1)
+  call airline#add_inactive_statusline_funcref(function(a:name), warn)
+endfunction
+
+
+function! airline#add_statusline_funcref(function, ...)
   if index(g:airline_statusline_funcrefs, a:function) >= 0
-    call airline#util#warning(printf('The airline statusline funcref "%s" has already been added.', string(a:function)))
+    let warn = get(a:, 1, 1)
+    if warn > 0
+      call airline#util#warning(printf('The airline statusline funcref "%s" has already been added.', string(a:function)))
+    endif
     return
   endif
   call add(g:airline_statusline_funcrefs, a:function)
@@ -32,8 +42,15 @@ function! airline#remove_statusline_func(name)
   endif
 endfunction
 
-function! airline#add_inactive_statusline_func(name)
-  call add(s:inactive_funcrefs, function(a:name))
+function! airline#add_inactive_statusline_funcref(function, ...)
+  if index(g:airline_inactive_funcrefs, a:function) >= 0
+    let warn = get(a:, 1, 1)
+    if warn > 0
+      call airline#util#warning(printf('The airline inactive statusline funcref "%s" has already been added.', string(a:function)))
+    endif
+    return
+  endif
+  call add(g:airline_inactive_funcrefs, function(a:function))
 endfunction
 
 function! airline#load_theme()
@@ -168,7 +185,7 @@ function! airline#update_statusline_inactive(range)
             \ 'left_sep': g:airline_left_alt_sep,
             \ 'right_sep': g:airline_right_alt_sep }, 'keep')
     endif
-    call s:invoke_funcrefs(context, s:inactive_funcrefs)
+    call s:invoke_funcrefs(context, g:airline_inactive_funcrefs)
   endfor
 endfunction
 

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -262,7 +262,7 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'bookmark')
   endif
 
-  if get(g:, 'airline#extensions#scrollbar#enabled', 1)
+  if get(g:, 'airline#extensions#scrollbar#enabled', 0)
     call airline#extensions#scrollbar#init(s:ext)
     call add(s:loaded_ext, 'scrollbar')
   endif

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1360,7 +1360,7 @@ groups:
 Displays an Ascii Scrollbar for active windows with a width > 200.
 
 * enable/disable scrollbar integration >
-  let g:airline#extensions#scrollbar#enabled = 1 (default: 1)
+  let g:airline#extensions#scrollbar#enabled = 1 (default: 0)
 -------------------------------------                        *airline-taboo*
 taboo.vim <https://github.com/gcmt/taboo.vim>
 


### PR DESCRIPTION
While I was trying to implement adding window numbers in front of mode, as described [here](https://github.com/vim-airline/vim-airline/wiki/Configuration-Examples-and-Snippets#a-different-example-add-the-window-number-in-front-of-the-mode), I noticed that reloading the configuration file would result in the inactive statusline being added twice. This patch switches the inactive status line function list to match the `airline_statuslen_funcrefs` list and prevent and warn if an attempt is made to add a function twice.

One annoying thing about this is that if you use the configuration recommended in the wiki, in every time you reload the config you will receive warnings about the functions not being added, added an optional argument `warn` to these functions so that you can optionally prevent them from noisily telling you something you perhaps already know. For example I call them this way from my config now, to prevent the warnings:

```
call airline#add_statusline_func('WindowNumber', 0)
call airline#add_inactive_statusline_func('WindowNumber', 0)
```

I'm not sure why the `4c3b147` commit files are showing up here, but hopefully you can just remove them? They don't show up as an actual change in my branch, I'm a little confused. 