### PR TITLE
Change event for tabline autoshow

### DIFF
--- a/autoload/airline/extensions/tabline/autoshow.vim
+++ b/autoload/airline/extensions/tabline/autoshow.vim
@@ -30,7 +30,7 @@ function! airline#extensions#tabline#autoshow#on()
         autocmd BufEnter  * call <sid>show_tabline(s:buf_min_count, len(airline#extensions#tabline#buflist#list()))
         autocmd BufUnload * call <sid>show_tabline(s:buf_min_count, len(airline#extensions#tabline#buflist#list()) - 1)
       else
-        autocmd TabEnter  * call <sid>show_tabline(s:tab_min_count, tabpagenr('$'))
+        autocmd TabNew,TabClosed  * call <sid>show_tabline(s:tab_min_count, tabpagenr('$'))
       endif
     endif
 


### PR DESCRIPTION
Use TabNew/TabClosed for the "autoshow" event when tabline is used only
for tabs (show_buffers==0).  This fixes case of visible tabline when
tab_min_count == 2 and user executes ':tabonly' command - the tabline
should disappear but there is no TabEnter event triggered in this case.

Closes #2389