### PR TITLE
Correct line number for coc.nvim warnings.

### DIFF
--- a/autoload/airline/extensions/coc.vim
+++ b/autoload/airline/extensions/coc.vim
@@ -38,7 +38,7 @@ function! airline#extensions#coc#get(type) abort
   if empty(cnt)
     return ''
   else
-    let lnum = printf('(L%d)', (info.lnums)[0])
+    let lnum = printf('(L%d)', (info.lnums)[is_err ? 0 : 1])
     return (is_err ? s:error_symbol : s:warning_symbol).cnt.lnum
   endif
 endfunction


### PR DESCRIPTION
When using the extension for coc.nvim, the line number for the first warning is not being displayed correctly (it's always 0). In the `coc_diagnostic_info` buffer variable, the `lnums` property is an array of four numbers. The first number is the error line number and the second is the warning line number:

https://github.com/neoclide/coc.nvim/blob/9be0d9e053b3097c0bb84ea470217e9671fe0156/src/diagnostic/buffer.ts#L187-L208

I've added a simple condition to use the correct index when accessing the `lnums` property based on the `is_err` boolean.