### PR TITLE
Allow overriding trailing ws regexp per buffer

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -78,7 +78,8 @@ function! airline#extensions#whitespace#check()
     let check = 'trailing'
     if index(checks, check) > -1 && index(get(skip_check_ft, &ft, []), check) < 0
       try
-        let regexp = get(g:, 'airline#extensions#whitespace#trailing_regexp', '\s$')
+        let regexp = get(b:, 'airline_whitespace_trailing_regexp',
+              \ get(g:, 'airline#extensions#whitespace#trailing_regexp', '\s$'))
         let trailing = search(regexp, 'nw')
       catch
         call airline#util#warning(printf('Whitespace: error occurred evaluating "%s"', regexp))

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1558,6 +1558,9 @@ vista.vim <https://github.com/liuchengxu/vista.vim>
 * configure custom trailing whitespace regexp rule >
   let g:airline#extensions#whitespace#trailing_regexp = '\s$'
 
+  " this can also be configured for an individual buffer
+  let b:airline_whitespace_trailing_regexp = '\s$'
+
 * configure, which filetypes have special treatment of /* */ comments,
   matters for mix-indent-file algorithm: >
   let airline#extensions#c_like_langs =


### PR DESCRIPTION
Adds a variable `b:airline_whitespace_trailing_regexp` so that the trailing whitespace regexp can be configured on a per-buffer basis, say according to filetype.

For example, if you add the line
```vimscript
let b:airline_whitespace_trailing_regexp = '\t$\|\s\{3,\}$\|[^ ] $'
```
into `after/ftplugin/markdown.vim`, then you can use double-space to start a paragraph in markdown, without throwing an error in that buffer, while leaving other buffers intact.

Feel free to close if you're not interested in trivial pull requests like this.