### PR TITLE
Fix "Cannot allocate color none"

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -178,8 +178,8 @@ values):
 * if you want to update your highlights without affecting the airline theme,
   you can do so using the AirlineAfterTheme autocmd. >
   function! s:update_highlights()
-    hi CursorLine ctermbg=none guibg=none
-    hi VertSplit ctermbg=none guibg=none
+    hi CursorLine ctermbg=none guibg=NONE
+    hi VertSplit ctermbg=none guibg=NONE
   endfunction
   autocmd User AirlineAfterTheme call s:update_highlights()
 <


### PR DESCRIPTION
## Reproduce the bug

### ~/.vim/vimrc

```vimscript
fu! s:update_highlights()
	hi CursorLine ctermbg=none guibg=none
	hi VertSplit ctermbg=none guibg=none
endf
au User AirlineAfterTheme cal s:update_highlights()

```

Open vim.

## Describe the bug

 My gvim (8.2 MS-WINDWOS 64-bit GUI 1-3204) gives the following warning with the following config from airline.txt

```
Error detected while processing BufWinEnter Autocommands for "*"..function <SNR>17_on_window_changed[22]..<SNR>17_init[29]..<SNR>17_on_colorscheme_changed[9]..airline#load_theme[18]..airline#util#doautocmd[5]..User Autocommands for "AirlineAfterTheme"..function <SNR>1_update_highlights:
line    1:
E254: Cannot allocate color none
line    2:
E254: Cannot allocate color none
```

Looking at the manual for highlight-guibg

```vimscript
  guifg={color-name}                                      highlight-guifg
  guibg={color-name}                                      highlight-guibg
  guisp={color-name}                                      highlight-guisp
          These give the foreground (guifg), background (guibg) and special
          (guisp) color to use in the GUI.  "guisp" is used for undercurl and
          strikethrough.
          There are a few special names:
                  NONE            no color (transparent)
                  bg              use normal background color
                  background      use normal background color
                  fg              use normal foreground color
                  foreground      use normal foreground color
          To use a color name with an embedded space or other special character,
          put it in single quotes.  The single quote cannot be used then.
          Example:
              :hi comment guifg='salmon pink' 
```

The patch is case-sensitive.