### PR TITLE
Revert Section Z default value

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -86,16 +86,13 @@ function! airline#init#bootstrap()
     call s:check_defined('g:airline_left_alt_sep', "\ue0b1")  " 
     call s:check_defined('g:airline_right_sep', "\ue0b2")     " 
     call s:check_defined('g:airline_right_alt_sep', "\ue0b3") " 
-    " ro=, ws=☲, lnr=, mlnr=☰, colnr=, br=, nx=Ɇ, crypt=🔒, dirty=⚡
-    "  Note: For powerline, we add an extra space after maxlinenr symbol,
-    "  because it is usually setup as a ligature in most powerline patched
-    "  fonts. It can be over-ridden by configuring a custom maxlinenr
+    " ro=, ws=☲, lnr=☰, mlnr=, colnr=:, br=, nx=Ɇ, crypt=🔒, dirty=⚡
     call extend(g:airline_symbols, {
           \ 'readonly': "\ue0a2",
           \ 'whitespace': "\u2632",
-          \ 'maxlinenr': "\u2630 ",
-          \ 'linenr': " \ue0a1:",
-          \ 'colnr': " \ue0a3:",
+          \ 'linenr': "\u2630 ",
+          \ 'maxlinenr': " \ue0a1",
+          \ 'colnr': ":",
           \ 'branch': "\ue0a0",
           \ 'notexists': "\u0246",
           \ 'dirty': "\u26a1",
@@ -107,13 +104,13 @@ function! airline#init#bootstrap()
     call s:check_defined('g:airline_left_alt_sep', "")
     call s:check_defined('g:airline_right_sep', "")
     call s:check_defined('g:airline_right_alt_sep', "")
-    " ro=⊝, ws=☲, lnr=㏑, mlnr=☰, colnr=℅, br=ᚠ, nx=Ɇ, crypt=🔒
+    " ro=⊝, ws=☲, lnr=☰, mlnr=㏑, colnr=:, br=ᚠ, nx=Ɇ, crypt=🔒
     call extend(g:airline_symbols, {
           \ 'readonly': "\u229D",
           \ 'whitespace': "\u2632",
-          \ 'maxlinenr': "\u2630",
-          \ 'linenr': " \u33d1:",
-          \ 'colnr': " \u2105:",
+          \ 'linenr': "\u2630 ",
+          \ 'maxlinenr': " \u33D1",
+          \ 'colnr': ":",
           \ 'branch': "\u16A0",
           \ 'notexists': "\u0246",
           \ 'crypt': nr2char(0x1F512),
@@ -128,9 +125,9 @@ function! airline#init#bootstrap()
     call extend(g:airline_symbols, {
           \ 'readonly': 'RO',
           \ 'whitespace': '!',
-          \ 'linenr': ' ln:',
-          \ 'maxlinenr': '',
-          \ 'colnr': ' cn:',
+          \ 'linenr': 'ln ',
+          \ 'maxlinenr': ' ',
+          \ 'colnr': ':',
           \ 'branch': '',
           \ 'notexists': '?',
           \ 'crypt': 'cr',
@@ -236,9 +233,9 @@ function! airline#init#sections()
   endif
   if !exists('g:airline_section_z')
     if airline#util#winwidth() > 79
-      let g:airline_section_z = airline#section#create(['windowswap', 'obsession', '%p%%', 'linenr', 'maxlinenr', 'colnr'])
+      let g:airline_section_z = airline#section#create(['windowswap', 'obsession', '%p%%'.spc, 'linenr', 'maxlinenr', 'colnr'])
     else
-      let g:airline_section_z = airline#section#create(['%p%%', 'linenr', 'colnr'])
+      let g:airline_section_z = airline#section#create(['%p%%'.spc, 'linenr', 'colnr'])
     endif
   endif
   if !exists('g:airline_section_error')

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -71,14 +71,12 @@ section  meaning (example)~
          optionally may contain Byte Order Mark `[BOM]` and missing end of last
          line `[!EOL]`
   Z      current position in the file
-           percentage % ln: current line/number of lines ☰ cn: column
-           So this: 10% ln:10/100☰ cn:20
-	   means: >
+           percentage % ☰ current line/number of lines ln : column
+           So this: 10% ☰ 10/100 ln : 20   means: >
               10%     - 10 percent
-	      ln:     - line number is
-              10/100☰ - 10 of 100 total lines
-	      cn:     - column number is
-              20      - 20
+              ☰ 10    - current line 10
+              /100 ln - of 100 lines
+              : 20    - current column 20
 <
   [...]  additional sections (warning/errors/statistics)
          from external plugins (e.g. YCM/syntastic/...)
@@ -345,16 +343,6 @@ CUSTOMIZATION                                        *airline-customization*
 The following are some unicode symbols for customizing the left/right
 separators, as well as the powerline font glyphs.
 
-Note: Some additional characters like spaces and colons may be included in the
-default. Including them within the symbol definitions rather than outside of
-them allows you to eliminate or otherwise alter them.
-
-Note: Be aware that some of these glyphs are defined as ligatures, so they may
-show up different (usually bigger) if followed by a space. This only happens
-if both the font and terminal implementation used support ligatures. If you
-want to follow a glyph with a space _without_ the alternate ligature being
-rendered, follow it with a non-breaking-space character.
-
 Note: You must define the dictionary first before setting values. Also, it's
 a good idea to check whether it exists as to avoid accidentally overwriting
 its contents. >
@@ -367,12 +355,12 @@ its contents. >
   let g:airline_left_sep = '▶'
   let g:airline_right_sep = '«'
   let g:airline_right_sep = '◀'
-  let g:airline_symbols.colnr = ' ㏇:'
-  let g:airline_symbols.colnr = ' ℅:'
+  let g:airline_symbols.colnr = '㏇'
+  let g:airline_symbols.colnr = '℅'
   let g:airline_symbols.crypt = '🔒'
   let g:airline_symbols.linenr = '☰'
-  let g:airline_symbols.linenr = ' ␊:'
-  let g:airline_symbols.linenr = ' ␤:'
+  let g:airline_symbols.linenr = '␊'
+  let g:airline_symbols.linenr = '␤'
   let g:airline_symbols.linenr = '¶'
   let g:airline_symbols.maxlinenr = ''
   let g:airline_symbols.maxlinenr = '㏑'
@@ -390,10 +378,10 @@ its contents. >
   let g:airline_right_sep = ''
   let g:airline_right_alt_sep = ''
   let g:airline_symbols.branch = ''
-  let g:airline_symbols.colnr = ' :'
+  let g:airline_symbols.colnr = ':'
   let g:airline_symbols.readonly = ''
-  let g:airline_symbols.linenr = ' :'
-  let g:airline_symbols.maxlinenr = '☰ '
+  let g:airline_symbols.linenr = '☰'
+  let g:airline_symbols.maxlinenr = ''
   let g:airline_symbols.dirty='⚡'
 
   " old vim-powerline symbols


### PR DESCRIPTION
PR #2374 and #2385 broke Section Z on macOS and now looks like this:

Terminal, SF Mono:
<img width="150" alt="butchered-section-z-terminal-sf-mono" src="https://user-images.githubusercontent.com/238528/132932195-112905c7-52c0-48c1-9f25-5efd724efe7a.png">

Iterm2, Menlo:
<img width="150" alt="butchered-section-z-iterm2-sf-menlo" src="https://user-images.githubusercontent.com/238528/132932211-a0dd514d-9583-415f-9afd-d05d78d27163.png">

And they had problems: 

- It started from a non-issue, #2373 contradicts what is clearly described in the README about Section Z symbols.

- #2385 added extra colons to something that was clean and simple before and broke the section Z for the `:terminal` command, that now looks like this with extra space that cannot be removed:

  <img width="150" alt="Captura de Pantalla 2021-09-10 a la(s) 22 23 16" src="https://user-images.githubusercontent.com/238528/132932353-e3c94743-8418-4f83-8380-f4607b5b5176.png">

- Even if it makes sense to swap `☰` and `㏑`, it introduces a bunch of spacing issues that were not a problem with the original layout, as commented on #2374. And the proposed solution seems to have been "too hard to figure out a good default, introduce the configuration and let the user fix them", which I think is just wrong. The plugin should provide sane defaults, not making things look bad and let the user figure out how to fix it.

- Also, using `℅` for the default column number symbol is not a good choice on a 10-12 pt fixed font terminal. It looks like a `%`, and it is confusing.

This reverts the Section Z to what is was before those PRs, and as it is still described in the README. It has worked fine all this time, no reason to fix what is not broken.

Keep the added `colnr` configuration, which was a good nice addition.

Anyone that has a different preference of spaces, adding extra colons, using random unicode characters, they can still change all the parts to their like.