### PR TITLE
Add vim-rufo extension support to section z.

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -500,6 +500,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'omnisharp')
   endif
 
+  if (get(g:, 'airline#extensions#rufo#enabled', 0) && get(g:, 'rufo_loaded', 0))
+    call airline#extensions#rufo#init(s:ext)
+    call add(s:loaded_ext, 'rufo')
+  endif
+
 endfunction
 
 function! airline#extensions#get_loaded_extensions()

--- a/autoload/airline/extensions/rufo.vim
+++ b/autoload/airline/extensions/rufo.vim
@@ -1,0 +1,38 @@
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+if !exists('g:rufo_loaded')
+  finish
+endif
+
+let s:spc = g:airline_symbols.space
+
+if !exists('g:airline#extensions#rufo#symbol')
+  let g:airline#extensions#rufo#symbol = 'RuFo'
+endif
+
+function! airline#extensions#rufo#init(ext)
+   call airline#parts#define_raw('rufo', '%{airline#extensions#rufo#get_status}')
+   call a:ext.add_statusline_func('airline#extensions#rufo#apply')
+endfunction
+
+function! airline#extensions#rufo#get_status()
+  let out = ''
+  if &ft == "ruby" && g:rufo_auto_formatting == 1
+    let out .= s:spc.g:airline_left_alt_sep.s:spc.g:airline#extensions#rufo#symbol
+  endif
+  return out
+endfunction
+
+" This function will be invoked just prior to the statusline getting modified.
+function! airline#extensions#rufo#apply(...)
+  " First we check for the filetype.
+  if &filetype == "ruby"
+    " section_z.
+    let w:airline_section_z = get(w:, 'airline_section_z', g:airline_section_z)
+
+    " Then we just append this extenion to it, optionally using separators.
+    let w:airline_section_z .= '%{airline#extensions#rufo#get_status()}'
+  endif
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1022,6 +1022,19 @@ title accordingly.
 * configure the title text for location list buffers >
   let g:airline#extensions#quickfix#location_text = 'Location'
 <
+-------------------------------------                     *airline-rufo*
+rufo <https://github.com/ruby-formatter/rufo-vim>
+
+The rufo (Ruby Formatter) extension merely displays whether vim-rufo is
+currently enabled, in the z sction of the statusline.
+
+* enable/disable vim-rufo integration >
+  let g:airline#extensions#rufo#enabled = 1
+<
+* configure the symbol, or text, to display when vim-rufo auto formatting
+  is on >
+  let g:airline#extensions#rufo#symbol = 'R'
+<
 -------------------------------------                     *airline-searchcount*
 The searchcount extension supports the searchcount() function in Vim script.
 Note: This is only enabled when 'hls' is on. When you turn off search


### PR DESCRIPTION
Displays whether you have the ruby formatter enabled or not for the session you are in.

Enable with:
let g:airline#extensions#rufo#enabled = 1

Configure with:
let g:airline#extensions#rufo#symbol = '💎'