### PR TITLE
Checks for the existence of the vimtex wordcount function, and then

### DIFF
--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -4,7 +4,13 @@
 scriptencoding utf-8
 
 " get wordcount {{{1
-if exists('*wordcount')
+if exists('*vimtex#misc#wordcount')
+" We're in a TeX file and vimtex is a plugin, so use it's wordcount...
+  function! s:get_wordcount(visual_mode_active)
+    let value = vimtex#misc#wordcount()
+    return value
+  endfunction
+elseif exists('*wordcount')
   function! s:get_wordcount(visual_mode_active)
     if get(g:, 'actual_curbuf', '') != bufnr('')
       return

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -4,8 +4,8 @@
 scriptencoding utf-8
 
 " get wordcount {{{1
-if exists('b:vimtex')
-"if &filetype==& 'tex' && exists('*vimtex#misc#wordcount')
+"if exists('b:vimtex')
+if &filetype==& 'tex' && exists('*vimtex#misc#wordcount')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -5,7 +5,8 @@ scriptencoding utf-8
 
 " get wordcount {{{1
 "if exists('b:vimtex')
-if &filetype ==# 'tex' && exists('b:vimtex')
+"if &filetype ==# 'tex' && exists('b:vimtex')
+if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -13,7 +13,8 @@ if exists('*wordcount')
     if get(g:, 'actual_curbuf', '') != bufnr('')
       return
     endif
-    if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
+    if &filetype ==# 'tex' && exists('b:vimtex')
+"   if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
       echo 'woot'
       let value = vimtex#misc#wordcount()
       return value

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -4,9 +4,9 @@
 scriptencoding utf-8
 
 " get wordcount {{{1
-if exists('b:vimtex')
+"if exists('b:vimtex')
 "if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
-"if &filetype ==# 'tex' && exists('b:vimtex')
+if &filetype ==# 'tex' && exists('b:vimtex')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -6,16 +6,16 @@ scriptencoding utf-8
 " get wordcount {{{1
 "if exists('b:vimtex')
 "if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
-if &filetype ==# 'tex' && exists('b:vimtex')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
+if exists('*wordcount')
   function! s:get_wordcount(visual_mode_active)
-    let value = vimtex#misc#wordcount()
-    return value
-  endfunction
-elseif exists('*wordcount')
-  function! s:get_wordcount(visual_mode_active)
+"   if &filetype ==# 'tex' && exists('b:vimtex')
     if get(g:, 'actual_curbuf', '') != bufnr('')
       return
+    endif
+    if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
+      let value = vimtex#misc#wordcount()
+      return value
     endif
     let query = a:visual_mode_active ? 'visual_words' : 'words'
     return get(wordcount(), query, 0)

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -5,7 +5,7 @@ scriptencoding utf-8
 
 " get wordcount {{{1
 "if exists('b:vimtex')
-if &filetype==& 'tex' && exists('*vimtex#misc#wordcount')
+if &filetype==# 'tex' && exists('*vimtex#misc#wordcount')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -14,6 +14,7 @@ if exists('*wordcount')
       return
     endif
     if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
+      echo 'woot'
       let value = vimtex#misc#wordcount()
       return value
     endif

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -4,7 +4,8 @@
 scriptencoding utf-8
 
 " get wordcount {{{1
-if exists('*vimtex#misc#wordcount')
+if exists('b:vimtex')
+"if &filetype==& 'tex' && exists('*vimtex#misc#wordcount')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -5,7 +5,7 @@ scriptencoding utf-8
 
 " get wordcount {{{1
 "if exists('b:vimtex')
-if &filetype==# 'tex' && exists('*vimtex#misc#wordcount')
+if &filetype==# 'tex' && exists('b:vimtex')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -5,7 +5,7 @@ scriptencoding utf-8
 
 " get wordcount {{{1
 "if exists('b:vimtex')
-if &filetype==# 'tex' && exists('b:vimtex')
+if exists('b:vimtex') && &filetype==# 'tex' 
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -4,9 +4,9 @@
 scriptencoding utf-8
 
 " get wordcount {{{1
-"if exists('b:vimtex')
+if exists('b:vimtex')
+"if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
 "if &filetype ==# 'tex' && exists('b:vimtex')
-if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -4,23 +4,19 @@
 scriptencoding utf-8
 
 " get wordcount {{{1
-"if exists('b:vimtex')
-"if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
-" We're in a TeX file and vimtex is a plugin, so use it's wordcount...
 if exists('*wordcount')
   function! s:get_wordcount(visual_mode_active)
-"   if &filetype ==# 'tex' && exists('b:vimtex')
     if get(g:, 'actual_curbuf', '') != bufnr('')
       return
     endif
     if &filetype ==# 'tex' && exists('b:vimtex')
-"   if &filetype ==# 'tex' && exists('vimtex#misc#wordcount')
-      echo 'woot'
+" We're in a TeX file and vimtex is a plugin, so use it's wordcount...
       let value = vimtex#misc#wordcount()
       return value
+    else
+      let query = a:visual_mode_active ? 'visual_words' : 'words'
+      return get(wordcount(), query, 0)
     endif
-    let query = a:visual_mode_active ? 'visual_words' : 'words'
-    return get(wordcount(), query, 0)
   endfunction
 else  " Pull wordcount from the g_ctrl-g stats
   function! s:get_wordcount(visual_mode_active)

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -5,7 +5,7 @@ scriptencoding utf-8
 
 " get wordcount {{{1
 "if exists('b:vimtex')
-if exists('b:vimtex') && &filetype==# 'tex' 
+if &filetype ==# 'tex' && exists('b:vimtex')
 " We're in a TeX file and vimtex is a plugin, so use it's wordcount...
   function! s:get_wordcount(visual_mode_active)
     let value = vimtex#misc#wordcount()


### PR DESCRIPTION
uses that for a wordcount rather than the standard wordcount.

This makes the wordcount use TeXcount if that exists, and gives an
accurate word count for the TeX document.

I'm not a vim script master, but this hack (pretty simple) seems to work
perfectly as far as I've seen, and doesn't interfere on other file
types.