### PR TITLE
Modifies the wordcount to use the vimtex wordcount function when editing

### DIFF
--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -52,16 +52,9 @@ function! s:get_hunks_coc() abort
   return result
 endfunction
 
-function! s:is_branch_empty() abort
-  return exists('*airline#extensions#branch#head') &&
-        \ empty(get(b:, 'airline_head', ''))
-endfunction
-
 function! s:get_hunks_gitgutter() abort
-  if !get(g:, 'gitgutter_enabled', 0) || s:is_branch_empty()
-    return ''
-  endif
-  return GitGutterGetHunkSummary()
+  let hunks = GitGutterGetHunkSummary()
+  return hunks == [0, 0, 0] ? [] : hunks
 endfunction
 
 function! s:get_hunks_changes() abort

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -9,8 +9,13 @@ if exists('*wordcount')
     if get(g:, 'actual_curbuf', '') != bufnr('')
       return
     endif
-    let query = a:visual_mode_active ? 'visual_words' : 'words'
-    return get(wordcount(), query, 0)
+    if &filetype ==# 'tex' && exists('b:vimtex')
+" We're in a TeX file and vimtex is a plugin, so use vimtex's wordcount...
+      return vimtex#misc#wordcount()
+    else
+      let query = a:visual_mode_active ? 'visual_words' : 'words'
+      return get(wordcount(), query, 0)
+    endif
   endfunction
 else  " Pull wordcount from the g_ctrl-g stats
   function! s:get_wordcount(visual_mode_active)

--- a/t/commands.vim
+++ b/t/commands.vim
@@ -9,21 +9,34 @@ describe 'commands'
     Expect exists('#airline') to_be_true
   end
 
-  it 'should toggle whitespace off and on'
+  it 'should toggle whitespace off'
     call airline#extensions#load()
     execute 'AirlineToggleWhitespace'
     Expect exists('#airline_whitespace') to_be_false
+  end
+
+  it 'should toggle whitespace on'
+    call airline#extensions#load()
     execute 'AirlineToggleWhitespace'
     Expect exists('#airline_whitespace') to_be_true
   end
 
-  it 'should display theme name with no args'
+  it 'should display theme name "simple"'
     execute 'AirlineTheme simple'
     Expect g:airline_theme == 'simple'
+  end
+
+  it 'should display theme name "dark"'
     execute 'AirlineTheme dark'
     Expect g:airline_theme == 'dark'
+  end
+
+  it 'should display theme name "dark" because specifying a name that does not exist'
     execute 'AirlineTheme doesnotexist'
     Expect g:airline_theme == 'dark'
+  end
+
+  it 'should display theme name molokai'
     colors molokai
     Expect g:airline_theme == 'molokai'
   end

--- a/t/extensions_default.vim
+++ b/t/extensions_default.vim
@@ -11,13 +11,33 @@ describe 'default'
     let s:builder = airline#builder#new({'active': 1})
   end
 
-  it 'should use the layout'
+  it 'should use the layout "airline_a_to_airline_b"'
     call airline#extensions#default#apply(s:builder, { 'winnr': 1, 'active': 1 })
     let stl = s:builder.build()
     Expect stl =~ 'airline_c_to_airline_a'
+  end
+
+  it 'should use the layout "airline_a_to_airline_b"'
+    call airline#extensions#default#apply(s:builder, { 'winnr': 1, 'active': 1 })
+    let stl = s:builder.build()
     Expect stl =~ 'airline_a_to_airline_b'
+  end
+
+  it 'should use the layout "airline_b_to_airline_warning"'
+    call airline#extensions#default#apply(s:builder, { 'winnr': 1, 'active': 1 })
+    let stl = s:builder.build()
     Expect stl =~ 'airline_b_to_airline_warning'
+  end
+
+  it 'should use the layout "airline_x_to_airline_z"'
+    call airline#extensions#default#apply(s:builder, { 'winnr': 1, 'active': 1 })
+    let stl = s:builder.build()
     Expect stl =~ 'airline_x_to_airline_z'
+  end
+
+  it 'should use the layout "airline_z_to_airline_y"'
+    call airline#extensions#default#apply(s:builder, { 'winnr': 1, 'active': 1 })
+    let stl = s:builder.build()
     Expect stl =~ 'airline_z_to_airline_y'
   end
 


### PR DESCRIPTION
TeX files and the vimtex plugin is loaded.

With help from Karl Lervag's suggestion on how to reliably tell when the
above mentioned conditions are the case for the current buffer

Checked to work with other filetypes that use the wordcount in
vim-airline, and these seem to work as before.

Also checked that if two of these filetypes (one TeX and the other
another type, such as markdown) the two coexist peacefully, with TeX
using Karl's wordcount function, and the other using the (I assume)
native wordcount?