### PR TITLE
Remove gitgutter hunks summary dependency on branch

### DIFF
--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -52,16 +52,9 @@ function! s:get_hunks_coc() abort
   return result
 endfunction
 
-function! s:is_branch_empty() abort
-  return exists('*airline#extensions#branch#head') &&
-        \ empty(get(b:, 'airline_head', ''))
-endfunction
-
 function! s:get_hunks_gitgutter() abort
-  if !get(g:, 'gitgutter_enabled', 0) || s:is_branch_empty()
-    return ''
-  endif
-  return GitGutterGetHunkSummary()
+  let hunks = GitGutterGetHunkSummary()
+  return hunks == [0, 0, 0] ? [] : hunks
 endfunction
 
 function! s:get_hunks_changes() abort


### PR DESCRIPTION
I am using vim-gitgutter and want to visualize hunks summary without branch in the status line. However, `let g:airline_section_b = airline#section#create(['file', g:airline_symbols.space, 'hunks'])` doesn't give me the hunks summary for a changed git tracked file, although `let g:airline_section_b = airline#section#create(['file', g:airline_symbols.space, 'hunks', 'branch'])` works fine. 

After some investigation, I find gitgutter extension, unlike other hunk summary extension, requires the dependency on the branch extension. So this PR removes this dependency.