### PR TITLE
Allow user to hide CoC status in the section C

### DIFF
--- a/autoload/airline/extensions/coc.vim
+++ b/autoload/airline/extensions/coc.vim
@@ -6,6 +6,7 @@ scriptencoding utf-8
 
 let s:error_symbol = get(g:, 'airline#extensions#coc#error_symbol', 'E:')
 let s:warning_symbol = get(g:, 'airline#extensions#coc#warning_symbol', 'W:')
+let s:show_coc_status = get(g:, 'airline#extensions#coc#show_coc_status', 1)
 
 function! airline#extensions#coc#get_warning() abort
   return airline#extensions#coc#get('warning')
@@ -37,7 +38,8 @@ endfunction
 
 function! airline#extensions#coc#get_status() abort
   " Shorten text for windows < 91 characters
-  return airline#util#shorten(get(g:, 'coc_status', ''), 91, 9)
+  let status = airline#util#shorten(get(g:, 'coc_status', ''), 91, 9)
+  return (s:show_coc_status ? status : '')
 endfunction
 
 function! airline#extensions#coc#get_current_function() abort

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -636,6 +636,9 @@ coc <https://github.com/neoclide/coc.nvim>
 * change warning symbol: >
   let airline#extensions#coc#warning_symbol = 'W:'
 <
+* enable/disable coc status display >
+  g:airline#extensions#coc#show_coc_status = 1
+<
 -------------------------------------                    *airline-commandt*
 command-t <https://github.com/wincent/command-t>
 


### PR DESCRIPTION
Hello.
This PR should solve my pain as CoC user, that CoC status takes too much space in the C section, right after the file path. 
It looks like a waste of space on splitscreen or a small screen.
![image](https://user-images.githubusercontent.com/10850158/140059957-0afb1113-e7e6-4a68-89c4-6fdf747ba344.png)

So I added an option to set
g:airline#extensions#coc#show_coc_status = 0
and the status will be hidden. 
![image](https://user-images.githubusercontent.com/10850158/140060206-b795b72b-0da5-4d3f-aa2f-b8b8baf1dbc2.png)


By default it works like usual.