### PR TITLE
Add extention to support yegappan/taglist

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -249,6 +249,11 @@ function! airline#extensions#load()
     call airline#extensions#tagbar#init(s:ext)
     call add(s:loaded_ext, 'tagbar')
   endif
+  if get(g:, 'airline#extensions#taglist#enabled', 1)
+        \ && exists(':TlistShowTag')
+    call airline#extensions#taglist#init(s:ext)
+    call add(s:loaded_ext, 'taglist')
+  endif
 
   if get(g:, 'airline#extensions#vista#enabled', 1)
         \ && exists(':Vista')

--- a/autoload/airline/extensions/taglist.vim
+++ b/autoload/airline/extensions/taglist.vim
@@ -1,0 +1,29 @@
+" MIT License. Copyright (c) 2021       DEMAREST Maxime (maxime@indelog.fr)
+" Plugin: https://github.com/yegappan/taglist/
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+if !exists(':TlistShowTag')
+  finish
+endif
+
+function! airline#extensions#taglist#currenttag()
+  " Update tag list if taglist is not loaded (else we get an empty tag name)
+  let tlist_updated = v:false
+  if !exists('*Tlist_Get_Filenames()')
+      TlistUpdate
+      let tlist_updated = v:true
+  endif
+  if !tlist_updated
+      if stridx(Tlist_Get_Filenames(), expand('%:p')) < 0
+          TlistUpdate
+          let tlist_updated = v:true
+      endif
+  endif
+  return taglist#Tlist_Get_Tagname_By_Line()
+endfunction
+
+function! airline#extensions#taglist#init(ext)
+  call airline#parts#define_function('taglist', 'airline#extensions#taglist#currenttag')
+endfunction

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -186,7 +186,7 @@ function! airline#init#bootstrap()
         \ 'accent': 'bold'
         \ })
   call airline#parts#define_empty(['obsession', 'tagbar', 'syntastic-warn',
-        \ 'syntastic-err', 'eclim', 'whitespace','windowswap',
+        \ 'syntastic-err', 'eclim', 'whitespace','windowswap', 'taglist',
         \ 'ycm_error_count', 'ycm_warning_count', 'neomake_error_count',
         \ 'neomake_warning_count', 'ale_error_count', 'ale_warning_count',
         \ 'lsp_error_count', 'lsp_warning_count', 'scrollbar',
@@ -229,7 +229,7 @@ function! airline#init#sections()
     let g:airline_section_gutter = airline#section#create(['%='])
   endif
   if !exists('g:airline_section_x')
-    let g:airline_section_x = airline#section#create_right(['coc_current_function', 'bookmark', 'scrollbar', 'tagbar', 'vista', 'gutentags', 'gen_tags', 'omnisharp', 'grepper', 'filetype'])
+    let g:airline_section_x = airline#section#create_right(['coc_current_function', 'bookmark', 'scrollbar', 'tagbar', 'taglist', 'vista', 'gutentags', 'gen_tags', 'omnisharp', 'grepper', 'filetype'])
   endif
   if !exists('g:airline_section_y')
     let g:airline_section_y = airline#section#create_right(['ffenc'])

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1420,6 +1420,12 @@ tagbar <https://github.com/majutsushi/tagbar>
   let g:airline#extensions#tagbar#searchmethod = 'nearest'
   let g:airline#extensions#tagbar#searchmethod = 'scoped-stl'
 <
+-------------------------------------                       *airline-taglist*
+taglist <https://github.com/yegappan/taglist>
+
+* enable/disable taglist integration >
+  let g:airline#extensions#taglist#enabled = 1
+<
 -------------------------------------                     *airline-tmuxline*
 tmuxline <https://github.com/edkolev/tmuxline.vim>
 


### PR DESCRIPTION
[taglist](https://github.com/yegappan/taglist/) is a good alternative to [tagbar](https://github.com/preservim/tagbar). This add an extension to have possibility to see current tag in `airline_section_x`.