### PR TITLE
Custom Spell Check Command Support

### DIFF
--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -66,7 +66,7 @@ endfunction
 
 function! airline#parts#spell()
   let spelllang = g:airline_detect_spelllang ? printf(" [%s]", toupper(substitute(&spelllang, ',', '/', 'g'))) : ''
-  if g:airline_detect_spell && &spell
+  if g:airline_detect_spell && (&spell || (exists('g:airline_spell_check_command') && eval(g:airline_spell_check_command)))
     let winwidth = airline#util#winwidth()
     if winwidth >= 90
       return g:airline_symbols.spell . spelllang


### PR DESCRIPTION
Could you consider spell check plugin such as [Spelunker](https://github.com/kamykn/spelunker.vim) ?

Currently it checks only `&spell` setting for spell status.

Besides it, add user-defined spell-check-flag checking command (`g:airline_spell_check_command`).

For spelunker, setting like below works:

```vim
let g:airline_spell_check_command = 'exists("b:enable_spelunker_vim") && b:enable_spelunker_vim || !exists("b:enable_spelunker_vim") && exists("g:enable_spelunker_vim") && g:enable_spelunker_vim'
```
