### PR TITLE
Fix #2460 : Unknown function: taglist#Tlist_Get_Tagname_By_Line

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -251,6 +251,7 @@ function! airline#extensions#load()
   endif
   if get(g:, 'airline#extensions#taglist#enabled', 1)
         \ && exists(':TlistShowTag')
+        \ && exists('*taglist#Tlist_Get_Tagname_By_Line')
     call airline#extensions#taglist#init(s:ext)
     call add(s:loaded_ext, 'taglist')
   endif

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -249,9 +249,7 @@ function! airline#extensions#load()
     call airline#extensions#tagbar#init(s:ext)
     call add(s:loaded_ext, 'tagbar')
   endif
-  if get(g:, 'airline#extensions#taglist#enabled', 1)
-        \ && exists(':TlistShowTag')
-        \ && exists('*taglist#Tlist_Get_Tagname_By_Line')
+  if get(g:, 'airline#extensions#taglist#enabled', 1) && exists(':TlistShowTag')
     call airline#extensions#taglist#init(s:ext)
     call add(s:loaded_ext, 'taglist')
   endif

--- a/autoload/airline/extensions/taglist.vim
+++ b/autoload/airline/extensions/taglist.vim
@@ -4,7 +4,7 @@
 
 scriptencoding utf-8
 
-if !exists(':TlistShowTag')
+if !exists(':TlistShowTag') && !exists('*taglist#Tlist_Get_Tagname_By_Line')
   finish
 endif
 

--- a/autoload/airline/extensions/taglist.vim
+++ b/autoload/airline/extensions/taglist.vim
@@ -4,7 +4,7 @@
 
 scriptencoding utf-8
 
-if !exists(':TlistShowTag') && !exists('*taglist#Tlist_Get_Tagname_By_Line')
+if !exists(':TlistShowTag')
   finish
 endif
 

--- a/autoload/airline/extensions/taglist.vim
+++ b/autoload/airline/extensions/taglist.vim
@@ -21,7 +21,14 @@ function! airline#extensions#taglist#currenttag()
           let tlist_updated = v:true
       endif
   endif
-  return taglist#Tlist_Get_Tagname_By_Line()
+  " Is this function is not present it'means you use the old vertsion of
+  " tag list : https://github.com/vim-scripts/taglist.vim.
+  " Please use the new version : https://github.com/yegappan/taglist.
+  if exists('*taglist#Tlist_Get_Tagname_By_Line()')
+      return taglist#Tlist_Get_Tagname_By_Line()
+  else
+      return ''
+  endif
 endfunction
 
 function! airline#extensions#taglist#init(ext)


### PR DESCRIPTION
Avoid the error `Unknown function: taglist#Tlist_Get_Tagname_By_Line`
when using the old tag tlist plugin.