### PR TITLE
taglist: load taglist variants only once

### DIFF
--- a/autoload/airline/extensions/taglist.vim
+++ b/autoload/airline/extensions/taglist.vim
@@ -10,15 +10,15 @@ endif
 
 function! airline#extensions#taglist#currenttag()
   " Update tag list if taglist is not loaded (else we get an empty tag name)
+  " Load yegappan/taglist and vim-scripts/taglist.vim only once.
   let tlist_updated = v:false
-  if !exists('*Tlist_Get_Filenames()')
+  if !exists('*taglist#Tlist_Get_Tagname_By_Line()') && !exists('*Tlist_Get_Tagname_By_Line()')
       TlistUpdate
       let tlist_updated = v:true
   endif
-  if !tlist_updated
+  if  !tlist_updated && exists('*Tlist_Get_Filenames()')
       if stridx(Tlist_Get_Filenames(), expand('%:p')) < 0
           TlistUpdate
-          let tlist_updated = v:true
       endif
   endif
   " Is this function is not present it'means you use the old vertsion of


### PR DESCRIPTION
Because Tlist_Get_Filenames() only exists within yegappan/taglist,
TlistUpdate was being envoked on every call when using other taglist
versions.(Like vim-scripts/taglist.) This caused visual artifacts and
slowdowns.

We now check for a function from both taglist variants to see if either
one has been loaded.

fixes vim-airline/#2470