### PR TITLE
[fix] Fix meaningless tests.

### DIFF
--- a/t/airline.vim
+++ b/t/airline.vim
@@ -69,14 +69,14 @@ describe 'airline'
   it 'should collapse the inactive split if the variable is set true'
     let g:airline_inactive_collapse = 1
     wincmd s
-    Expect getwinvar(2, '&statusline') !~ 'airline#parts#mode'
+    Expect airline#statusline(2) !~ 'airline#parts#mode'
     wincmd c
   end
 
   it 'should not collapse the inactive split if the variable is set false'
     let g:airline_inactive_collapse = 0
     wincmd s
-    Expect getwinvar(2, '&statusline') != 'airline#parts#mode'
+    Expect airline#statusline(2) =~ 'airline#parts#mode'
     wincmd c
   end
 


### PR DESCRIPTION
@chrisbra I'm sorry I haven't been very active lately.


I fixed airline.vim's test.

## Before

I intentionally failed the test before fixing it.

```vim
  it 'should collapse the inactive split if the variable is set true'
    let g:airline_inactive_collapse = 1
    wincmd s
    Expect getwinvar(2, '&statusline') =~ 'airline#parts#mode'
    wincmd c
  end

  it 'should not collapse the inactive split if the variable is set false'
    let g:airline_inactive_collapse = 0
    wincmd s
    Expect getwinvar(2, '&statusline') =~ 'airline#parts#mode'
    wincmd c
  end

```

### Log

```
not ok 7 - airline should collapse the inactive split if the variable is set true
# Expected getwinvar(2, '&statusline') =~ 'airline#parts#mode' at line 3
#       Actual value: "%!airline#statusline(2)"
#     Expected value: "airline#parts#mode"
not ok 8 - airline should not collapse the inactive split if the variable is set false
# Expected getwinvar(2, '&statusline') =~ 'airline#parts#mode' at line 3
#       Actual value: "%!airline#statusline(2)"
#     Expected value: "airline#parts#mode"
```

Looking at the log, I thought I should have compared airline#statusline(2).


## After

```vim
  it 'should collapse the inactive split if the variable is set true'
    let g:airline_inactive_collapse = 1
    wincmd s
    Expect airline#statusline(2) !~ 'airline#parts#mode'
    wincmd c
  end

  it 'should not collapse the inactive split if the variable is set false'
    let g:airline_inactive_collapse = 0
    wincmd s
    Expect airline#statusline(2) =~ 'airline#parts#mode'
    wincmd c
  end
```

When it is `let g:airline_inactive_collapse = 1`, it does not match the assert, and when it is `let g:airline_inactive_collapse = 0`, it does match, so the validation is successful.