### PR TITLE
Test for the correct fern loaded variable.

### DIFF
--- a/autoload/airline/extensions/fern.vim
+++ b/autoload/airline/extensions/fern.vim
@@ -3,7 +3,7 @@
 " vim: et ts=2 sts=2 sw=2
 
 scriptencoding utf-8
-if !get(g:, 'fern_loaded', 0)
+if !get(g:, 'loaded_fern', 0)
   finish
 endif
 


### PR DESCRIPTION
The Fern plugin recently removed some deprecated code, including the loaded boolean that the vim-airline fern extension is testing for.

The correct variable `g:loaded_fern` was [introduced almost 2 years ago](https://github.com/lambdalisue/fern.vim/commit/ad432d2c3247fd4ffc0481a7b45eb5d8483e1710#diff-2b6ed8f982ee6fee895f9f6230605075da8b0af4cc66179c2793e430e5aa503d), so I don't think this change will break many peoples' setups. The deprecated variable `g:fern_loaded` was removed [here](https://github.com/lambdalisue/fern.vim/commit/df9404e8a59b6a74b15a5a5df42867f84677a353#diff-2b6ed8f982ee6fee895f9f6230605075da8b0af4cc66179c2793e430e5aa503dL9). If we want to be more conservative here we could test for the presence of both variables.