### PR TITLE
unicode: Fix check for :UnicodeTable buffer

### DIFF
--- a/autoload/airline/extensions/unicode.vim
+++ b/autoload/airline/extensions/unicode.vim
@@ -9,7 +9,7 @@ if !get(g:, 'loaded_unicodePlugin', 0)
 endif
 
 function! airline#extensions#unicode#apply(...)
-  if exists(":UnicodeTable") == 2 && bufname('') =~# '/UnicodeTable.txt'
+  if exists(':UnicodeTable') == 2 && bufname('') =~# '/UnicodeTable.txt'
     call airline#parts#define('unicode', {
           \ 'text': '[UnicodeTable]',
           \ 'accent': 'bold' })

--- a/autoload/airline/extensions/unicode.vim
+++ b/autoload/airline/extensions/unicode.vim
@@ -9,7 +9,7 @@ if !get(g:, 'loaded_unicodePlugin', 0)
 endif
 
 function! airline#extensions#unicode#apply(...)
-  if exists(":UnicodeTable") == 2 && bufname('') ==# 'UnicodeTable'
+  if exists(":UnicodeTable") == 2 && bufname('') =~# '/UnicodeTable.txt'
     call airline#parts#define('unicode', {
           \ 'text': '[UnicodeTable]',
           \ 'accent': 'bold' })


### PR DESCRIPTION
[With the slight concern there is something screwy about my configuration causing this problem…]

The buffer name for `:UnicodeTable` doesn't match the test in the airline extension, this tiny change fixes that.

Thanks,

James
