### PR TITLE
git: allow to show git project dir

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -199,6 +199,8 @@ function! airline#init#bootstrap()
         \ })
   if get(g:, 'airline_section_c_only_filename',0)
     call airline#parts#define_raw('file', '%t%m')
+  elseif get(g:, 'airline_stl_path_style', 'default') ==# 'gitrepo'
+    call airline#parts#define_function('file', 'airline#parts#gitrepo')
   else
     call airline#parts#define_raw('file', airline#formatter#short_path#format('%f%m'))
   endif

--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -214,3 +214,24 @@ function! airline#parts#executable()
     return ''
   endif
 endfunction
+
+function! airline#parts#gitrepo() abort
+  if !exists('*FugitiveFind')
+    return expand('%:p')
+  endif
+  let toplevel = FugitiveFind(':/', bufnr(''))
+  if empty(toplevel)
+    return expand('%:p')
+  endif
+  " Remove trailing separator
+  let toplevel = substitute(toplevel, '[/\\]$', '', '')
+  let reponame = fnamemodify(toplevel, ':t')
+  let fullpath = resolve(expand('%:p'))
+  " Get file path relative to repo root
+  if fullpath[:len(toplevel)-1] ==# toplevel
+    let relpath = fullpath[len(toplevel)+1:]
+  else
+    let relpath = expand('%:t')
+  endif
+  return reponame .. ':' .. relpath .. (&modified ? '[+]' : '')
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -306,6 +306,13 @@ values):
 * Display a short path in statusline: >
   let g:airline_stl_path_style = 'short'
 >
+* Display the file path relative to the git repository toplevel directory: >
+  let g:airline_stl_path_style = 'gitrepo'
+<
+  This shows the path as `reponame:path/to/file` instead of the full path.
+  Requires vim-fugitive (https://github.com/tpope/vim-fugitive).
+  Falls back to the full path for non-git files.
+
 * Display a only file name in statusline: >
   let g:airline_section_c_only_filename = 1
 >


### PR DESCRIPTION
This extension shows the project dir. It depends on Futivedir, so will
only work when the fugitive plugin is available.

closes #2505