### PR TITLE
Changed bufloaded back to buflisted

### DIFF
--- a/autoload/airline/extensions/tabline/buflist.vim
+++ b/autoload/airline/extensions/tabline/buflist.vim
@@ -52,7 +52,7 @@ function! airline#extensions#tabline#buflist#list()
   " Basically branch 535 already does it, but since it relies on
   " BufAdd autocommand, I'd like to avoid this if possible.
   for nr in list
-    if bufloaded(nr)
+    if buflisted(nr)
       " Do not add to the bufferlist, if either
       " 1) bufnr is exclude_buffers list
       " 2) buffername matches one of exclude_paths patterns


### PR DESCRIPTION
The last PR (#2522) caused some issues for me, and the author @KSR-Yasuda suggested that this change could be the culprit. `__CtrlSF__` and `[No Name]` tabs appearing, and adding them to `airline#extensions#tabline#ignore_bufadd_pat` just made the whole tabline disappear.

I also use the Startify plugin with session saving, and found that when restoring a session, the tabs would no longer appear until I had visited a buffer again, whereas beforehand they would load up a soon as I opened Vim. So I commented out my entire vimrc, and could reproduce this issue by opening an existing session with `vim -S mysession`. Without this fix, only a single buffer from the session is shown in the tabline.

I'm using regular Vim on the command line, version 8.2 on MacOS 12.3.1.