### PR TITLE
Mark the end of the close button

### DIFF
--- a/autoload/airline/extensions/tabline/tabs.vim
+++ b/autoload/airline/extensions/tabline/tabs.vim
@@ -85,7 +85,7 @@ function! airline#extensions#tabline#tabs#get()
 
   if get(g:, 'airline#extensions#tabline#show_close_button', 1)
     call b.add_section('airline_tab_right', ' %999X'.
-          \ get(g:, 'airline#extensions#tabline#close_symbol', 'X').' ')
+          \ get(g:, 'airline#extensions#tabline#close_symbol', 'X').'%X ')
   endif
 
   if get(g:, 'airline#extensions#tabline#show_splits', 1) == 1


### PR DESCRIPTION
Not marking the end makes the rest of line (after the close button) also clickable and react as if the close button was clicked. That is very confusing and incorrect behavior.