### PR TITLE
Show flag when `detect_spelllang` is `'flag'`, do not when it is 0.

### DIFF
--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -146,7 +146,7 @@ function! airline#parts#spell()
   let spelllang = g:airline_detect_spelllang ? printf(" [%s]", toupper(substitute(&spelllang, ',', '/', 'g'))) : ''
   if g:airline_detect_spell && (&spell || (exists('g:airline_spell_check_command') && eval(g:airline_spell_check_command)))
 
-    if g:airline_detect_spelllang && g:airline_detect_spelllang ==? 'flag'
+    if g:airline_detect_spelllang !=? '0' && g:airline_detect_spelllang ==? 'flag'
       let spelllang = tolower(&spelllang)
       if has_key(s:flags, spelllang)
         return s:flags[spelllang]


### PR DESCRIPTION
927e142e9474f6a4211c62ac4f26481b216efc22 broke the "show the lang flag"
functionality, as the check `if g:airline_detect_spelllang` is always
false when this variable is `'flag'`. Explicitly check whether this
variable is the string `'0'` to detect whether the feature should be
disabled.