### PR TITLE
line numbers for nvimlsp like ale

### DIFF
--- a/autoload/airline/extensions/nvimlsp.vim
+++ b/autoload/airline/extensions/nvimlsp.vim
@@ -21,6 +21,7 @@ function! airline#extensions#nvimlsp#get(type) abort
 
   let error_symbol = get(g:, 'airline#extensions#nvimlsp#error_symbol', 'E:')
   let warning_symbol = get(g:, 'airline#extensions#nvimlsp#warning_symbol', 'W:')
+  let show_line_numbers = get(g:, 'airline#extensions#nvimlsp', 1)
 
   let is_err = a:type ==# 'Error'
 
@@ -35,7 +36,23 @@ function! airline#extensions#nvimlsp#get(type) abort
     let num = v:lua.vim.lsp.util.buf_diagnostics_count(a:type)
   endif
 
-  return s:airline_nvimlsp_count(num, symbol)
+  if show_line_numbers == 1 && luaeval("pcall(require, 'vim.diagnostic')") && num > 0
+    return s:airline_nvimlsp_count(num, symbol) . <sid>airline_nvimlsp_get_line_number(num, a:type)
+  else
+    return s:airline_nvimlsp_count(num, symbol)
+  endif
+endfunction
+
+function! s:airline_nvimlsp_get_line_number(cnt, type) abort
+  let severity = a:type == 'Warning' ? 'Warn' : a:type
+  let num = v:lua.vim.diagnostic.get(0, { 'severity': severity })[0].lnum
+
+  let l:open_lnum_symbol  =
+    \ get(g:, 'airline#extensions#nvimlsp#open_lnum_symbol', '(L')
+  let l:close_lnum_symbol =
+    \ get(g:, 'airline#extensions#nvimlsp#close_lnum_symbol', ')')
+
+  return open_lnum_symbol . num . close_lnum_symbol
 endfunction
 
 function! airline#extensions#nvimlsp#get_warning() abort

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -966,8 +966,17 @@ nvimlsp <https://github.com/neovim/nvim-lsp>
 * nvimlsp error_symbol >
   let airline#extensions#nvimlsp#error_symbol = 'E:'
 <
-* nvimlsp warning >
+* nvimlsp warning - needs v:lua.vim.diagnostic.get
   let airline#extensions#nvimlsp#warning_symbol = 'W:'
+
+* nvimlsp show_line_numbers - needs v:lua.vim.diagnostic.get
+  let airline#extensions#nvimlsp#show_line_numbers = 1
+
+* nvimlsp open_lnum_symbol - needs v:lua.vim.diagnostic.get
+  let airline#extensions#nvimlsp#open_lnum_symbol = '(L'
+
+* nvimlsp close_lnum_symbol - needs v:lua.vim.diagnostic.get
+  let airline#extensions#nvimlsp#close_lnum_symbol = ')'
 
 -------------------------------------                    *airline-obsession*
 vim-obsession <https://github.com/tpope/vim-obsession>


### PR DESCRIPTION
Good morning,

This PR adds support for line number for the first warning/error for **nvimlsp** like with **ALE**.

This works on versions of NeoVim which support the `vim.diagnostic.get` function, I added the necessary conditions.

I don't do much vimscript so don't hesitate to comment on coding/styling mistakes.