### PR TITLE
Reduce truncation for section y to 80 chars

### DIFF
--- a/autoload/airline/extensions/default.vim
+++ b/autoload/airline/extensions/default.vim
@@ -7,7 +7,7 @@ let s:section_use_groups     = get(g:, 'airline#extensions#default#section_use_g
 let s:section_truncate_width = get(g:, 'airline#extensions#default#section_truncate_width', {
       \ 'b': 79,
       \ 'x': 60,
-      \ 'y': 88,
+      \ 'y': 80,
       \ 'z': 45,
       \ 'warning': 80,
       \ 'error': 80,

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -729,7 +729,7 @@ you can use.
   let g:airline#extensions#default#section_truncate_width = {
       \ 'b': 79,
       \ 'x': 60,
-      \ 'y': 88,
+      \ 'y': 80,
       \ 'z': 45,
       \ 'warning': 80,
       \ 'error': 80,


### PR DESCRIPTION
Many terminals default to 80 characters wide. Having section y truncated away at this width causes lots of user confusion (https://github.com/vim-airline/vim-airline/issues/1087, https://github.com/vim-airline/vim-airline/issues/1099, https://github.com/vim-airline/vim-airline/issues/1685, https://github.com/vim-airline/vim-airline/issues/2336)

This drove me crazy too, since I would only _sometimes_ see my configured content in section y. Until I finally determined that the root cause is terminal width. This explains why both lots of folks are hitting this, yet many others have had trouble reproducing the issue. (You might want to add terminal size to the github issue template!)

#### environment

- vim: 8.1.3741
- vim-airline: master as of this writing, 2cea8346cfaf0d92da079c27708bec7c092cef84
- OS: macOS 12.5.1 ssh'd into Ubuntu 20.04.5 LTS (Focal Fossa) 
- Have you reproduced with a minimal vimrc: Yes, see below
- What is your airline configuration: See below

if you are using terminal:
- terminal: iTerm2
- $TERM variable: xterm-256color
- color configuration (:set t_Co?): t_Co=256

if you are using Neovim:
- does it happen in Vim: n/a, using vim

#### repro

I was able to reproduce the problem, workaround (resizing terminal), and fix (this PR) on a completely fresh OS, vim, and airline install:

```bash
sudo docker run -it --rm ubuntu:focal bash

apt update && apt install -y vim git
git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
export TERM=xterm-256color

cat <<EOF > ~/.vimrc
  set nocompatible
  filetype off
  set rtp+=~/.vim/bundle/Vundle.vim
  call vundle#begin()
  Plugin 'VundleVim/Vundle.vim'

  Plugin 'vim-airline/vim-airline'

  call vundle#end()
  filetype plugin indent on

  autocmd User AirlineAfterInit call AirlineInit()
  function! AirlineInit()
    let g:airline_section_a = airline#section#create(['a'])
    let g:airline_section_b = airline#section#create(['b'])
    let g:airline_section_c = airline#section#create(['c'])
    let g:airline_section_x = airline#section#create(['x'])
    let g:airline_section_y = airline#section#create(['y'])
    let g:airline_section_z = airline#section#create(['z'])
  endfunc
EOF

vim +PluginInstall +qall
vim
```

#### actual behavior

I can configure sections `a b c x z` just fine, but `y` is surprisingly missing until I make the terminal wider (80 -> 88 columns)

#### expected behavior

I expect `a b c` to show up on the left side of the airline, and `x y z` to show up on the right side. Especially since there is no reason to drop sections this aggressively to save space. An airline configured this way could fit into a 20-column terminal, and certainly into 80.

#### screen shot (if possible)

80x25 terminal:

<img width="682" alt="スクリーンショット 2022-09-20 23 09 59" src="https://user-images.githubusercontent.com/45430/191405855-dc897c31-4455-4b92-ac1e-db373eb03029.png">

Once I hit 88 characters wide, then the `y` section appears:

<img width="738" alt="スクリーンショット 2022-09-20 23 29 27" src="https://user-images.githubusercontent.com/45430/191408015-e8e0e11d-bf86-406a-b17c-5eb579c8bdb3.png">

#### fix

One PR discussions mentioned "section_y is really not different than any other section". But, it is! The default configuration collapses it first, and it's the only one with a minimum width of less than 80 chars (which is an important width to handle correctly):

```vim
  let g:airline#extensions#default#section_truncate_width = {
      \ 'b': 79,
      \ 'x': 60,
      \ 'y': 88,  " <--
      \ 'z': 45,
      \ 'warning': 80,
      \ 'error': 80,
      \ }
```

So this PR changes that default.

This should also reduce user confusion as, now, quite a few sections will collapse immediately below the 80-character breakpoint, which should better communicate that truncation is intentional. Otherwise users like me get confused why section y is special, try disabling all other plugins, etc.

Separately, I'd also like to see this become less of an issue by _dynamically_ truncating based on the measured size of the content in each section. Perhaps with user-defined truncation priorities per section. But, I can appreciate that is a much heavier lift with possible performance implications.