### PR TITLE
Update util.vim

### DIFF
--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -216,7 +216,7 @@ function! airline#util#is_popup_window(winnr)
    if exists('*win_gettype')
      return win_gettype(a:winnr) ==# 'popup' || win_gettype(a:winnr) ==# 'autocmd'
    else
-      return getwinvar(a:winnr, '&buftype', '') ==# 'popup'
+      return airline#util#getwinvar(a:winnr, '&buftype', '') ==# 'popup'
   endif
 endfunction
 


### PR DESCRIPTION
using getwinvar directly with 7.3 version of vim display the following error, at startup and when changing buffers
```
E118: Too many arguments for function: getwinvar
E15: Invalid expression: getwinvar(a:winnr, '&buftype', '') ==# 'popup'
```