### PR TITLE
Treat R Markdown the same as Markdown

### DIFF
--- a/autoload/airline/extensions/whitespace.vim
+++ b/autoload/airline/extensions/whitespace.vim
@@ -52,7 +52,7 @@ endfunction
 function! s:conflict_marker()
   " Checks for git conflict markers
   let annotation = '\%([0-9A-Za-z_.:]\+\)\?'
-  if match(['rst', 'markdown'], &ft) >= 0
+  if match(['rst', 'markdown', 'rmd'], &ft) >= 0
     " rst filetypes use '=======' as header
     let pattern = '^\%(\%(<\{7} '.annotation. '\)\|\%(>\{7\} '.annotation.'\)\)$'
   else

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -91,8 +91,8 @@ endfunction
 " airline functions {{{1
 " default filetypes:
 function! airline#extensions#wordcount#apply(...)
-  let filetypes = get(g:, 'airline#extensions#wordcount#filetypes', 
-    \ ['asciidoc', 'help', 'mail', 'markdown', 'nroff', 'org', 'rst', 'plaintex', 'tex', 'text'])
+  let filetypes = get(g:, 'airline#extensions#wordcount#filetypes',
+    \ ['asciidoc', 'help', 'mail', 'markdown', 'rmd', 'nroff', 'org', 'rst', 'plaintex', 'tex', 'text'])
   " export current filetypes settings to global namespace
   let g:airline#extensions#wordcount#filetypes = filetypes
 

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1556,7 +1556,7 @@ virtualenv <https://github.com/jmcantrell/vim-virtualenv>
 <
 * enable virtualenv for additional filetypes:
   (default: python): >
-  let g:airline#extensions#virtualenv#ft = ['python', 'markdown']
+  let g:airline#extensions#virtualenv#ft = ['python', 'markdown', 'rmd']
 <
 -------------------------------------                   *airline-vista*
 vista.vim <https://github.com/liuchengxu/vista.vim>
@@ -1662,7 +1662,7 @@ vim-windowswap <https://github.com/wesQ3/vim-windowswap>
   " The default value matches filetypes typically used for documentation
   " such as markdown and help files. Default is:
   let g:airline#extensions#wordcount#filetypes =
-    \ ['asciidoc', 'help', 'mail', 'markdown', 'nroff', 'org', 'plaintex', 'rst', 'tex', 'text'])
+    \ ['asciidoc', 'help', 'mail', 'markdown', 'rmd' 'nroff', 'org', 'plaintex', 'rst', 'tex', 'text'])
   " Use ['all'] to enable for all filetypes.
 
 * defines the name of a formatter for word count will be displayed: >


### PR DESCRIPTION
R Markdown is basically the same as Markdown but it supports R. Anything that applies to Markdown should also apply to R Markdown.