### PR TITLE
Use the coc status variable to format error/warning text

### DIFF
--- a/autoload/airline/extensions/coc.vim
+++ b/autoload/airline/extensions/coc.vim
@@ -20,18 +20,23 @@ function! airline#extensions#coc#get(type) abort
   if !exists(':CocCommand')
     return ''
   endif
-  let _backup = get(g:, 'coc_stl_format', '')
+
   let is_err = (a:type  is# 'error')
   let info = get(b:, 'coc_diagnostic_info', {})
   if empty(info) | return '' | endif
 
+ if is_err
+    let format = get(g:, 'airline#extensions#coc#stl_format_err', '(L%d)')
+  else
+    let format = get(g:, 'airline#extensions#coc#stl_format_warn', '(L%d)')
+  endif
 
   let cnt = get(info, a:type, 0)
 
   if empty(cnt)
     return ''
   else
-    let lnum = printf('(L%d)', (info.lnums)[is_err ? 0 : 1])
+    let lnum = printf(format, (info.lnums)[is_err ? 0 : 1])
     return (is_err ? s:error_symbol : s:warning_symbol).cnt.lnum
   endif
 endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -649,6 +649,12 @@ coc <https://github.com/neoclide/coc.nvim>
 <
 * enable/disable coc status display >
   g:airline#extensions#coc#show_coc_status = 1
+
+* change the error format: >
+  let airline#extensions#coc#stl_format_err = '(L%d)'
+<
+* change the warning format: >
+  let airline#extensions#coc#stl_format_warn = '(L%d)'
 <
 -------------------------------------                    *airline-commandt*
 command-t <https://github.com/wincent/command-t>


### PR DESCRIPTION
Following this issue #2437 there is no way to change the way the error is displayed but in `:h coc-status` it  is still described that it's possible to configure error format on the status line:
```
Change error format:
>
	let airline#extensions#coc#stl_format_err = '%E{[%e(#%fe)]}'
<
Change warning format:
>
	let airline#extensions#coc#stl_format_warn = '%W{[%w(#%fw)]}'
```

However by the way the `airline#extensions#coc#get(type)` is implemented we get a list of diagnostic from coc like this:
```
{'information': 1, 'hint': 0, 'lnums': [245, 242, 25, 0], 'warning': 1, 'error': 1}
```
So there isn't much to customize besides the line number and that's why this pull request allows you to do, keeping the previous format as default.
Do you have a clue how we could honour a format like this ` '%W{[%w(#%fw)]}' ` with all that information in it ?

If you merge this fix the documentation on coc aswell.

Cheers!