### PR TITLE
Fix: [vim9lsp] ErrorCount method updated

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -472,7 +472,7 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'battery')
   endif
 
-  if (get(g:, 'airline#extensions#vim9lsp#enabled', 1) && exists('*lsp#errorCount'))
+  if (get(g:, 'airline#extensions#vim9lsp#enabled', 1) && exists('*lsp#lsp#ErrorCount'))
     call airline#extensions#vim9lsp#init(s:ext)
     call add(s:loaded_ext, 'vim9lsp')
   endif

--- a/autoload/airline/extensions/vim9lsp.vim
+++ b/autoload/airline/extensions/vim9lsp.vim
@@ -4,7 +4,7 @@
 
 scriptencoding utf-8
 
-if !exists('*lsp#errorCount')
+if !exists('*lsp#lsp#ErrorCount')
     finish
 endif
 
@@ -12,12 +12,12 @@ let s:error_symbol = get(g:, 'airline#extensions#vim9lsp#error_symbol', 'E:')
 let s:warning_symbol = get(g:, 'airline#extensions#vim9lsp#warning_symbol', 'W:')
 
 function! airline#extensions#vim9lsp#get_warnings() abort
-    let res = get(lsp#errorCount(), 'Warn', 0)
+    let res = get(lsp#lsp#ErrorCount(), 'Warn', 0)
     return res > 0 ? s:warning_symbol . res : ''
 endfunction
 
 function! airline#extensions#vim9lsp#get_errors() abort
-    let res = get(lsp#errorCount(), 'Error', 0)
+    let res = get(lsp#lsp#ErrorCount(), 'Error', 0)
     return res > 0 ? s:error_symbol . res : ''
 endfunction
 


### PR DESCRIPTION
In the recent version of the [vim9 yegappan lsp](https://github.com/yegappan/lsp) the error count method has changed.

This update the corresponding extention according to the recent version.