### PR TITLE
Fix missing hyperlink in docs

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -165,7 +165,7 @@ values):
 <
   Note: Only the dark theme is distributed with vim-airline. For more themes,
   checkout the vim-airline-themes repository
-  (github.com/vim-airline/vim-airline-themes)
+  (https://github.com/vim-airline/vim-airline-themes)
 
 * if you want to patch the airline theme before it gets applied, you can
   supply the name of a function where you can modify the palette. >


### PR DESCRIPTION
This pull-request speaks for itself.

Signed-off-by: Kamil Zabielski <kamil@zabielscy.com>