### PR TITLE
🩹 fix deprecation warning: Node.js 12 actions are deprecated.

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
     name: runner / vint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: vint
         uses: reviewdog/action-vint@v1
         with:


### PR DESCRIPTION
For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout@master
Using version v3, latest or master: actions/checkout#689