### PR TITLE
only set laststatus when airline is not on top

### DIFF
--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -185,7 +185,9 @@ function! s:airline_toggle()
     if !airline#util#stl_disabled(winnr())
       if &laststatus < 2
         let _scroll=&scroll
-        set laststatus=2
+        if !get(g:, 'airline_statusline_ontop', 0)
+          set laststatus=2
+        endif
         if &scroll != _scroll
           let &scroll = _scroll
         endif


### PR DESCRIPTION
When airline is configured to show on top (`let g:airline_statusline_ontop = 1`) and vim's `laststatus` option is configured to be hidden (`set laststatus=0`) then there is no need to override its setting and airline should honor the user configuration.