### PR TITLE
Allow to define own path for short_path formatter

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/short_path.vim
+++ b/autoload/airline/extensions/tabline/formatters/short_path.vim
@@ -6,6 +6,7 @@ scriptencoding utf-8
 let s:fnamecollapse = get(g:, 'airline#extensions#tabline#fnamecollapse', 1)
 
 function! airline#extensions#tabline#formatters#short_path#format(bufnr, buffers)
+  let fmod = get(g:, 'airline#extensions#tabline#fnamemod', ':p:h:t')
   let _ = ''
 
   let name = bufname(a:bufnr)
@@ -15,7 +16,7 @@ function! airline#extensions#tabline#formatters#short_path#format(bufnr, buffers
     " Neovim Terminal
     let _ = substitute(name, '\(term:\)//.*:\(.*\)', '\1 \2', '')
   else
-    let _ .= fnamemodify(name, ':p:h:t') . '/' . fnamemodify(name, ':t')
+    let _ .= fnamemodify(name, fmod) . '/' . fnamemodify(name, ':t')
   endif
 
   return airline#extensions#tabline#formatters#default#wrap_name(a:bufnr, _)

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1321,6 +1321,13 @@ Note: Not displayed if the number of tabs is less than 1
 
   let g:airline#extensions#tabline#formatter = 'short_path'
 
+  " `short_path` can also display file name as relative to the current
+  " directory, if possible
+  let g:airline#extensions#tabline#fnamemod = ':h'
+
+  " or display file name as relative to the home directory, if possible
+  let g:airline#extensions#tabline#fnamemod = ':~:h'
+
 * defines the customized format() function to display tab title in tab mode. >
   let g:airline#extensions#tabline#tabtitle_formatter = 'MyTabTitleFormatter'
 <


### PR DESCRIPTION
This PR allows to define your own path for short_path formatter.

How to use it:

```
let g:airline#extensions#tabline#formatter = 'short_path'
let g:airline#extensions#tabline#fnamemod = ':h'
```
![image](https://user-images.githubusercontent.com/15939365/209222734-ce402a33-14d0-4174-95d0-bfd6ae8b1012.png)
