### PR TITLE
Add search-count configuration

### DIFF
--- a/autoload/airline/extensions/searchcount.vim
+++ b/autoload/airline/extensions/searchcount.vim
@@ -18,10 +18,16 @@ function! airline#extensions#searchcount#apply(...) abort
 endfunction
 
 function! s:search_term()
+  let show_search_term = get(g:, 'airline#extensions#searchcount#show_search_term', 1)
+  let search_term_limit = get(g:, 'airline#extensions#searchcount#search_term_limit', 8)
+
+  if show_search_term == 0
+    return ''
+  endif
   " shorten for all width smaller than 300 (this is just a guess)
   " this uses a non-breaking space, because it looks like
   " a leading space is stripped :/
-  return "\ua0" .  '/' . airline#util#shorten(getreg('/'), 300, 8)
+  return "\ua0" .  '/' . airline#util#shorten(getreg('/'), 300, search_term_limit)
 endfunction
 
 function! airline#extensions#searchcount#status() abort
@@ -31,7 +37,7 @@ function! airline#extensions#searchcount#status() abort
       return ''
     endif
     if result.incomplete ==# 1     " timed out
-      return printf('%s [?/??]', s:search_term())
+      return printf('%s[?/??]', s:search_term())
     elseif result.incomplete ==# 2 " max count exceeded
       if result.total > result.maxcount &&
             \  result.current > result.maxcount

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1072,6 +1072,12 @@ highlighting (e.g. using |:nohls|), it this will be disabled.
 
 * enable/disable searchcount integration >
   let g:airline#extensions#searchcount#enabled = 1
+
+* enable/disable displaying search term >
+  let g:airline#extensions#searchcount#show_search_term = 1
+
+* truncate long search terms to a fixed length >
+  let g:airline#extensions#searchcount#search_term_limit = 8
 <
 -------------------------------------                    *airline-syntastic*
 syntastic <https://github.com/vim-syntastic/syntastic>


### PR DESCRIPTION
Allow disabling displaying the search term.
Displaying the search term consumes space on the status bar.

Allow setting the length for truncating the search term.
The display limit was hardcoded to 8.

Make status format consistent.
The format for timed out was inconsistent.