### PR TITLE
Add improved short path tabline formatter

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/short_path.vim
+++ b/autoload/airline/extensions/tabline/formatters/short_path.vim
@@ -3,8 +3,6 @@
 
 scriptencoding utf-8
 
-let s:fnamecollapse = get(g:, 'airline#extensions#tabline#fnamecollapse', 1)
-
 function! airline#extensions#tabline#formatters#short_path#format(bufnr, buffers)
   let fmod = get(g:, 'airline#extensions#tabline#fnamemod', ':p:h:t')
   let _ = ''

--- a/autoload/airline/extensions/tabline/formatters/short_path_improved.vim
+++ b/autoload/airline/extensions/tabline/formatters/short_path_improved.vim
@@ -1,0 +1,36 @@
+" MIT License. Copyright (c) 2013-2021 Bailey Ling et al.
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+function! airline#extensions#tabline#formatters#short_path_improved#format(bufnr, buffers) abort
+  let name = bufname(a:bufnr)
+  if empty(name)
+    return airline#extensions#tabline#formatters#default#wrap_name(a:bufnr, '[No Name]')
+  endif
+
+  let tail = s:tail(a:bufnr)
+  let tails = s:tails(a:bufnr, a:buffers)
+
+  if has_key(tails, tail)
+    " Use short path for duplicates
+    return airline#extensions#tabline#formatters#short_path#format(a:bufnr, a:buffers)
+  endif
+
+  " Use tail for unique filenames
+  return airline#extensions#tabline#formatters#default#wrap_name(a:bufnr, tail)
+endfunction
+
+function! s:tails(self, buffers) abort
+  let tails = {}
+  for nr in a:buffers
+    if nr != a:self
+      let tails[s:tail(nr)] = 1
+    endif
+  endfor
+  return tails
+endfunction
+
+function! s:tail(bufnr) abort
+  return fnamemodify(bufname(a:bufnr), ':t')
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1315,12 +1315,11 @@ Note: Not displayed if the number of tabs is less than 1
       let g:airline#extensions#tabline#fnamemod = ':p:.'
       let g:airline#extensions#tabline#fnamecollapse = 1
 
-  " The `unique_tail_improved` - another algorithm, that will smartly
-  " uniquify buffers names with similar filename, suppressing common
-  " parts of paths.
+  " The `unique_tail_improved` algorithm will uniquify buffers names with
+  " similar filename, suppressing common parts of paths.
   let g:airline#extensions#tabline#formatter = 'unique_tail_improved'
 
-  " The `short_path` - is a simple formatter, that will show the
+  " The `short_path` algorithm is a simple formatter, that will show the
   filename, with its extension, and the first parent directory only.
 
   e.g.
@@ -1334,6 +1333,11 @@ Note: Not displayed if the number of tabs is less than 1
 
   " or display file name as relative to the home directory, if possible
   let g:airline#extensions#tabline#fnamemod = ':~:h'
+
+  " The `short_path_improved` algorithm will only show the short path for
+  " duplicate buffer names, otherwise suppressing directories.
+
+  let g:airline#extensions#tabline#formatter = 'short_path_improved'
 
 * defines the customized format() function to display tab title in tab mode. >
   let g:airline#extensions#tabline#tabtitle_formatter = 'MyTabTitleFormatter'


### PR DESCRIPTION
This formatter removes the parent directory for unique files, which helps reduce the footprint.