### PR TITLE
Use mode minwidth to configure truncation

### DIFF
--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -53,7 +53,9 @@ endfunction
 " }}}
 
 function! airline#parts#mode()
-  return airline#util#shorten(get(w:, 'airline_current_mode', ''), 79, 1)
+  let part = airline#parts#get('mode')
+  let minwidth = get(part, 'minwidth', 79)
+  return airline#util#shorten(get(w:, 'airline_current_mode', ''), minwidth, 1)
 endfunction
 
 function! airline#parts#crypt()


### PR DESCRIPTION
A width of 79 is excessive for minimalist airline setups.

It looks like the mode's minwidth is not configured for anything at the moment, so this should be safe.