### PR TITLE
Prevent selecting GitGutter when its loaded but not enabled

### DIFF
--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -89,7 +89,7 @@ function! airline#extensions#hunks#get_raw_hunks() abort
   if !exists('b:source_func') || get(b:, 'source_func', '') is# 's:get_hunks_empty'
     if get(g:, 'loaded_signify') && sy#buffer_is_active()
       let b:source_func = 's:get_hunks_signify'
-    elseif exists('*GitGutterGetHunkSummary')
+    elseif exists('*GitGutterGetHunkSummary') && get(g:, 'gitgutter_enabled')
       let b:source_func = 's:get_hunks_gitgutter'
     elseif exists('*changes#GetStats')
       let b:source_func = 's:get_hunks_changes'


### PR DESCRIPTION
If `GitGutter` is loaded but not enabled, it will be selected in `get_raw_hunks()`, rather than another possibly loaded and enabled plugin.

I looked at adding something like `sy#buffer_is_active()` to `GitGutter`, however it seems that these two plugins differ slightly with regard to when their buffer enabled status is set. The function I came up with provided little difference to simply checking `gitgutter_enabled` in `get_raw_hunks()`.

This PR allows a user to have `GitGutter` in their configuration, but disabled, and have a plugin with lower priority (in the if-else-if order) to provide the hunk summary (e.g. `Gitsigns`).