### PR TITLE
chore: Pin actions's version main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@main
 
     - name: Checkout vim-themis
-      uses: actions/checkout@v3
+      uses: actions/checkout@main
       with:
         repository: thinca/vim-themis
         path: vim-themis

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
     name: runner / vint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - name: vint
         uses: reviewdog/action-vint@v1
         with:


### PR DESCRIPTION
https://github.com/actions/checkout 's default branch name is main.
If you always follow the main branch, I think the maintenance cost will be reduced.