### PR TITLE
Fix the number of splits in a tab displayed in the tabline

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/tabnr.vim
+++ b/autoload/airline/extensions/tabline/formatters/tabnr.vim
@@ -7,14 +7,12 @@ function! airline#extensions#tabline#formatters#tabnr#format(tab_nr, buflist)
   let spc=g:airline_symbols.space
   let tab_nr_type = get(g:, 'airline#extensions#tabline#tab_nr_type', 0)
   if tab_nr_type == 0 " nr of splits
-    " TODO: This doesn't seem to be the actual number of splits,
-    " but seems to behave like what users expect.
-    return spc. len(tabpagebuflist(a:buflist[0]))
+    return spc. len(tabpagebuflist(a:tab_nr))
   elseif tab_nr_type == 1 " tab number
     " Return only the current tab number
     return spc. a:tab_nr
   else " tab_nr_type == 2 splits and tab number
     " return the tab number followed by the number of buffers (in the tab)
-    return spc. a:tab_nr. spc. len(tabpagebuflist(a:buflist[0]))
+    return spc. a:tab_nr. spc. len(tabpagebuflist(a:tab_nr))
   endif
 endfunction


### PR DESCRIPTION
With this option `let g:airline#extensions#tabline#tab_nr_type` set to show the number of splits in a tab on the tabline there's an error with the previous code, it was calling the function `tabpagebuflist()` and giving it the number of the current buffer, which is wrong, it should give it the number of the current tab so that it returns the list of buffer splits on that tab.

Event though the parameter `buflist` is not needed anymore I didn't change the signature of the function since users can have their custom implementation depending on this.