### PR TITLE
Don't lock git repo when checking status

### DIFF
--- a/autoload/airline/extensions/branch.vim
+++ b/autoload/airline/extensions/branch.vim
@@ -17,8 +17,8 @@ scriptencoding utf-8
 let s:vcs_config = {
 \  'git': {
 \    'exe': 'git',
-\    'cmd': 'git status --porcelain -- ',
-\    'dirty': 'git status -uno --porcelain --ignore-submodules',
+\    'cmd': 'git status --porcelain --no-optional-locks -- ',
+\    'dirty': 'git status -uno --porcelain --no-optional-locks --ignore-submodules',
 \    'untracked_mark': '??',
 \    'exclude': '\.git',
 \    'update_branch': 's:update_git_branch',


### PR DESCRIPTION
Fix "fatal: Unable to create '.git/index.lock': File exists." when doing fugitive commands.

Since upgrading fugitive from tpope/vim-fugitive@7c1f2ed to 5f0d280, I occasionally hit this lock error when using `ZZ` to save and close the fugitive rebase window.

I have no other windows or tabs open (nothing that might be invoking git). I get the error around 1 in 5 attempts on a larger git repo and less often on small repos (like vim-fugitive's repo).

However, I have airline and have the git branch name and dirty status in my **statusline**. A minimal repro of just sensible, fugitive, and vim-airline with no custom airline configuration produces the issue. If I use `:AirlineToggle` to turn off the statusline, it seems to go away.

Airline uses fugitive to get the branch name (with `FugitiveHead()`) and strip the `fugitive://` name from buffers (with `FugitiveReal()`).

I tried removing ShellCmdPost fugitiveline.vim and that *seems* to fix it, but I don't understand why.

What makes more sense is that the dirty check is asynchronous and is trying to check status when fugitive is trying to rebase. Because the repo is large, it takes longer to get status (true for just running `git status` too).

I have async enabled:
    :echo g:airline#init#vim_async
    1

tpope suggests using --no-optional-locks to solve: https://github.com/tpope/vim-fugitive/issues/1624

That also appears to fix the issue.

This flag was introduced to git in 2017 which would make airline fail on older gits:
https://github.com/git/git/commit/27344d6a6c8056664966e11acf674e5da6dd7ee3 There's also GIT_OPTIONAL_LOCKS=0 environment variable, but that requires more infra work. Not sure if airline already supports 6 year old git?