### PR TITLE
Make tabline#show_buffers more prominent in documentation

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1114,6 +1114,11 @@ are supported!
 
 * enable/disable enhanced tabline. (c) >
   let g:airline#extensions#tabline#enabled = 0
+<
+* enable/disable displaying buffers with a single tab. (c) >
+  let g:airline#extensions#tabline#show_buffers = 1
+
+  Note: With `show_buffers = 0`, tabs behave like the vim default tabline.
 
 * enable/disable displaying open splits per tab (only when tabs are opened) >
   let g:airline#extensions#tabline#show_splits = 1
@@ -1121,9 +1126,6 @@ are supported!
 * switch position of buffers and tabs on splited tabline (c)
   (only supported for ctrlspace plugin). >
   let g:airline#extensions#tabline#switch_buffers_and_tabs = 0
-<
-* enable/disable displaying buffers with a single tab. (c) >
-  let g:airline#extensions#tabline#show_buffers = 1
 
 Note: If you are using neovim (has('tablineat') = 1), then you can click
 on the tabline with the left mouse button to switch to that buffer, and
@@ -1139,6 +1141,8 @@ with the middle mouse button to delete that buffer.
 
 * enable/disable displaying tabs, regardless of number. (c) >
   let g:airline#extensions#tabline#show_tabs = 1
+
+  Note: To display only tabs and no buffers, set `show_buffers=0` in addition.
 
 * enable/disable displaying number of tabs in the right side (c) >
   let g:airline#extensions#tabline#show_tab_count = 1


### PR DESCRIPTION
Fixes #2662

The vim default tabline shows tabs, not buffers. Airline's tabline defaults to buffers. Make the setting to restore the default more prominent in the documentation, and distinguish it from the similarly named `#show_tabs`.