### PR TITLE
fix: remove stale separators of unloaded buffers

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -186,6 +186,10 @@ if !exists(":def") || !airline#util#has_vim9_script()
     call <sid>exec_separator({}, a:from, a:to, a:inverse, '')
   endfunction
 
+  function! airline#highlighter#remove_separators_for_bufnr(bufnr) abort
+    call filter(s:separators, 'stridx(v:key, a:bufnr) < 0')
+  endfunction
+
   function! s:exec_separator(dict, from, to, inverse, suffix) abort
     if pumvisible()
       return
@@ -529,6 +533,10 @@ else
     s:exec_separator({}, from, to, inverse, '')
   enddef
 
+  def airline#highlighter#remove_separators_for_bufnr(bufnr: string): void
+    filter(s:separators, (k, v) => stridx(k, bufnr) < 0)
+  enddef
+
   def s:exec_separator(dict: dict<any>, from_arg: string, to_arg: string, inverse: bool, suffix: string): void
     if pumvisible()
       return
@@ -681,5 +689,5 @@ else
         endfor
       endif
     endfor
-	enddef
+  enddef
 endif

--- a/plugin/airline.vim
+++ b/plugin/airline.vim
@@ -72,6 +72,10 @@ function! s:on_window_changed(event)
   let g:airline_last_window_changed = l:key
   call s:init()
   call airline#update_statusline()
+
+  if a:event ==# 'BufUnload'
+    call airline#highlighter#remove_separators_for_bufnr(expand('<abuf>'))
+  endif
 endfunction
 
 function! s:on_focus_gained()


### PR DESCRIPTION
Closes #2701

This issue is more general than the specific issue of #2701 as currently any buffer that is hidden then deleted will result in stale separators lying around in the list.

NOTE: the Vim9 code is untested, please verify!