### PR TITLE
fix line number shown by nvimlsp being off by one

### DIFF
--- a/autoload/airline/extensions/nvimlsp.vim
+++ b/autoload/airline/extensions/nvimlsp.vim
@@ -47,7 +47,7 @@ endfunction
 
 function! s:airline_nvimlsp_get_line_number(cnt, type) abort
   let severity = a:type == 'Warning' ? 'Warn' : a:type
-  let num = v:lua.vim.diagnostic.get(0, { 'severity': severity })[0].lnum
+  let num = v:lua.vim.diagnostic.get(0, { 'severity': severity })[0].lnum + 1
 
   let l:open_lnum_symbol  =
     \ get(g:, 'airline#extensions#nvimlsp#open_lnum_symbol', '(L')


### PR DESCRIPTION
The line number `vim.diagnostic.get()` returns is 0-indexed, but displayed line numbers are 1-indexed.