### PR TITLE
feat: allow setting vim-obsession paused indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is the Changelog for the vim-airline project.
   - coc extensions can also show additional status messages as well as the current function
   - [coc-git](https://github.com/neoclide/coc-git) extension integrated into hunks extension
   - rewrote parts using Vim9 Script for performance improvements
+  - [vim-obsession](https://github.com/tpope/vim-obsession) allow to set paused indicator
 - Other
   - Changed CI from travis-ci.org to GitHub Actions
   - Introduce Vim script static analysis using [reviewdog](https://github.com/reviewdog/action-vint)

--- a/autoload/airline/extensions/obsession.vim
+++ b/autoload/airline/extensions/obsession.vim
@@ -14,10 +14,14 @@ if !exists('g:airline#extensions#obsession#indicator_text')
   let g:airline#extensions#obsession#indicator_text = '$'
 endif
 
+if !exists('g:airline#extensions#obsession#indicator_text_paused')
+  let g:airline#extensions#obsession#indicator_text_paused = '' " vim-obsession defaults to 'S'
+endif
+
 function! airline#extensions#obsession#init(ext)
   call airline#parts#define_function('obsession', 'airline#extensions#obsession#get_status')
 endfunction
 
 function! airline#extensions#obsession#get_status()
-  return ObsessionStatus((g:airline#extensions#obsession#indicator_text . s:spc), '')
+  return ObsessionStatus((g:airline#extensions#obsession#indicator_text . s:spc), (g:airline#extensions#obsession#indicator_text_paused . s:spc))
 endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -999,8 +999,11 @@ vim-obsession <https://github.com/tpope/vim-obsession>
 * enable/disable vim-obsession integration >
   let g:airline#extensions#obsession#enabled = 1
 
-* set marked window indicator string >
+* set marked window indicator string when recording session>
   let g:airline#extensions#obsession#indicator_text = '$'
+
+* set marked window indicator string when recording session is paused>
+  let g:airline#extensions#obsession#indicator_text_paused = ''
 <
 -------------------------------------                    *airline-omnisharp*
 OmniSharp <https://github.com/OmniSharp/omnisharp-vim>


### PR DESCRIPTION
This PR adds changes to allow for setting the `vim-obsession` paused indicator as well.
The existing code base was hard-coded to empty string.

_Example (excerpt) .vimrc:_

```vimrc
if has_key(plugs, 'vim-airline')
  " (...)
  if has_key(plugs, 'vim-obsession')
    let g:airline#extensions#obsession#indicator_text        = '$'
    let g:airline#extensions#obsession#indicator_text_paused = 'S'
  endif
  " (...)
endif
```

_Example `vim-obsession` paused: (Nerd Font Glyph: `nf-md-pause_circle`)_
<img width="1105" height="33" alt="image" src="https://github.com/user-attachments/assets/1e04f9b8-0a18-49fd-842f-050046ff1ab4" />

_Example `vim-obsession` tracking: (Nerd Font Glyph: `nf-md-check_circle`)_
<img width="1106" height="32" alt="image" src="https://github.com/user-attachments/assets/53e3f113-a5c1-4a1e-a892-7a91a5a58fc2" />

Note: The default `g:airline#extensions#obsession#indicator_text_paused` is an empty string to keep backwards compatibility with existing configurations.
