### PR TITLE
Fix issue with fugitive and airline displaying an error message

### DIFF
--- a/autoload/airline/extensions/fugitiveline.vim
+++ b/autoload/airline/extensions/fugitiveline.vim
@@ -8,7 +8,7 @@ if !airline#util#has_fugitive()
   finish
 endif
 
-let s:has_percent_eval = v:version > 802 || (v:version == 802 && has("patch2854"))
+let s:has_percent_eval = v:version >= 900 || (v:version >= 900 && has("patch2854"))
 
 function! airline#extensions#fugitiveline#bufname() abort
   if !exists('b:fugitive_name')

--- a/autoload/airline/extensions/zhihu.vim
+++ b/autoload/airline/extensions/zhihu.vim
@@ -8,7 +8,7 @@ if !airline#util#has_zhihu()
   finish
 endif
 
-let s:has_percent_eval = v:version > 802 || (v:version == 802 && has("patch2854"))
+let s:has_percent_eval = v:version >= 900 || (v:version >= 900 && has("patch2854"))
 
 function! airline#extensions#zhihu#bufname() abort
   let fmod = (exists("+autochdir") && &autochdir) ? ':p' : ':.'


### PR DESCRIPTION
Hello! 

I had an issue with Vim showcasing "E15: Invalid expresion: %airline#extensions#fugitiveline#bufname()%" when you have both Fugitive and Airline enabled at the same time, the cause was an issue with the version displayed by fugitiveline.vim and a similar occurrence may also occur with zhihu.vim as well, after this change though it should work well on newer versions of Vim and the error is also no more! 