### PR TITLE
extensions: Add a tabpanel extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -400,6 +400,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'tabline')
   endif
 
+  if get(g:, 'airline#extensions#tabpanel#enabled', 0)
+    call airline#extensions#tabpanel#Init(s:ext)
+    call add(s:loaded_ext, 'tabpanel')
+  endif
+
   if get(g:, 'airline#extensions#tmuxline#enabled', 1) && exists(':Tmuxline')
     call airline#extensions#tmuxline#init(s:ext)
     call add(s:loaded_ext, 'tmuxline')

--- a/autoload/airline/extensions/tabpanel.vim
+++ b/autoload/airline/extensions/tabpanel.vim
@@ -1,0 +1,118 @@
+vim9script
+
+# MIT License. Copyright (c) 2013-2026 Christian Brabandt et al.
+# vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+var spc = g:airline_symbols.space
+
+def IsTabModified(tabnr: number): bool
+  if !g:airline_detect_modified
+    return false
+  endif
+  for bi in tabpagebuflist(tabnr)
+    if getbufvar(bi, '&modified')
+      return true
+    endif
+  endfor
+  return false
+enddef
+
+export def Get(): string
+  var tabnr = g:actual_curtabpage
+  var curtab = tabpagenr()
+  var label = ''
+
+  if tabnr == 1
+    label ..= '%#airline_tabfill#'
+    label ..= get(g:, 'airline#extensions#tabpanel#label', '[tabs]') .. "\n"
+  endif
+
+  var buflist = tabpagebuflist(tabnr)
+  var winnr = tabpagewinnr(tabnr)
+  var bufnr = buflist[winnr - 1]
+  var title = fnamemodify(bufname(bufnr), ':t')
+  if empty(title)
+    title = '[No Name]'
+  endif
+
+  if tabnr == curtab
+    if IsTabModified(tabnr)
+      label ..= '%#airline_tabmod#'
+    else
+      label ..= '%#airline_tabsel#'
+    endif
+  else
+    if IsTabModified(tabnr)
+      label ..= '%#airline_tabmod_unsel#'
+    else
+      label ..= '%#airline_tab#'
+    endif
+  endif
+
+  if get(g:, 'airline#extensions#tabline#show_tab_nr', 1)
+    label ..= spc .. tabnr
+    label ..= spc
+  endif
+
+  label ..= title .. spc
+  return label
+enddef
+
+def LinkHighlights(): void
+  highlight! link TabPanelFill airline_tabfill
+  highlight! link TabPanelSel airline_tabsel
+  highlight! link TabPanel airline_tab
+enddef
+
+export def LoadTheme(_: dict<any>): number
+  LinkHighlights()
+  return 0
+enddef
+
+def Enable(): void
+  LinkHighlights()
+  &tabpanel = '%!airline#extensions#tabpanel#Get()'
+  var cols = get(g:, 'airline#extensions#tabpanel#columns', 20)
+  var align = get(g:, 'airline#extensions#tabpanel#align', '')
+  var opts = 'columns:' .. cols
+  if !empty(align)
+    opts ..= ',align:' .. align
+  endif
+  &tabpanelopt = opts
+  &showtabpanel = 2
+enddef
+
+def Disable(): void
+  highlight! link TabPanelFill NONE
+  highlight! link TabPanelSel NONE
+  highlight! link TabPanel NONE
+  &tabpanel = ''
+  &tabpanelopt = ''
+  &showtabpanel = 0
+enddef
+
+export def Init(ext: dict<any>): void
+  if !exists('+tabpanel')
+    return
+  endif
+
+  autocmd_add([{
+    group: 'airline_tabpanel',
+    event: 'User',
+    pattern: 'AirlineToggledOn',
+    cmd: 'Enable()',
+    replace: true,
+  }])
+  autocmd_add([{
+    group: 'airline_tabpanel',
+    event: 'User',
+    pattern: 'AirlineToggledOff',
+    cmd: 'Disable()',
+    replace: true,
+  }])
+
+  ext.add_theme_func('airline#extensions#tabpanel#LoadTheme')
+  Enable()
+enddef

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -1448,6 +1448,30 @@ groups:
   airline_tabhid:	hidden buffer
   airline_tabhid_right: idem, but on the right
 
+-------------------------------------                      *airline-tabpanel*
+
+Vim supports a vertical tab panel (see |'tabpanelexpr'|) that displays tab
+pages in a side column. This extension provides airline-styled formatting for
+the tab panel. Requires a Vim version that supports |'tabpanelexpr'|.
+
+* enable/disable tabpanel integration >
+  let g:airline#extensions#tabpanel#enabled = 1
+< default: 0
+
+* configure the width of the tab panel (in columns) >
+  let g:airline#extensions#tabpanel#columns = 20
+< default: 20
+
+* configure the alignment of the tab panel >
+  let g:airline#extensions#tabpanel#align = 'left'
+< default: '' (uses Vim's default)
+
+Note: The tabpanel extension reuses the tabline highlight groups
+(|airline-tabline-hlgroups|) and respects the tabline tab number settings
+(|g:airline#extensions#tabline#show_tab_nr|,
+|g:airline#extensions#tabline#tab_nr_type|,
+|g:airline#extensions#tabline#tabnr_formatter|).
+
 -------------------------------------                      *airline-scrollbar*
 
 Displays an Ascii Scrollbar for active windows with a width > 200.


### PR DESCRIPTION
Add a new tabpanel extension that provides airline-styled formatting for Vim's vertical tab panel feature. Uses airline tabline highlight groups (TabPanelFill, TabPanelSel, TabPanel) and refreshes them on theme changes. Requires a Vim version with 'tabpanel' support.

Extension implemented using Vim9Script so not Neovim compatible