### PR TITLE
Add linediff extension

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -541,6 +541,11 @@ function! airline#extensions#load()
     call add(s:loaded_ext, 'zhihu')
   endif
 
+  if (get(g:, 'airline#extensions#linediff#enabled', 1) && exists('g:loaded_linediff'))
+    call airline#extensions#linediff#init(s:ext)
+    call add(s:loaded_ext, 'linediff')
+  endif
+
 endfunction
 
 function! airline#extensions#get_loaded_extensions()

--- a/autoload/airline/extensions/linediff.vim
+++ b/autoload/airline/extensions/linediff.vim
@@ -1,0 +1,14 @@
+" MIT License. Copyright (c) 2026 Shad
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+function! airline#extensions#linediff#init(ext)
+  call a:ext.add_statusline_func('airline#extensions#linediff#apply')
+endfunction
+
+function! airline#extensions#linediff#apply(...)
+  if exists('b:differ.description')
+    let w:airline_section_c = b:differ.description
+  endif
+endfunction

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -917,6 +917,12 @@ LanguageClient <https://github.com/autozimu/LanguageClient-neovim>
 * languageclient close_lnum_symbol >
   let g:airline#extensions#languageclient#close_lnum_symbol = ')'
 
+-------------------------------------                      *airline-linediff*
+linediff.vim <https://github.com/AndrewRadev/linediff.vim>
+
+* enable/disable linediff buffername and position integration >
+  let g:airline#extensions#linediff#enabled = 1
+
 -------------------------------------                   *airline-localsearch*
 localsearch <https://github.com/mox-mox/vim-localsearch>
 


### PR DESCRIPTION
[linediff](https://github.com/AndrewRadev/linediff.vim) is a plugin allowing to diff to part of the same file.
When used, it create temporary buffers containing the parts to be diffed. when no `statusline` set or set with a `%f`, the statusline of each window should contain the original filename followed by start and end lines of selected parts to be diffed. with vim-airline, the statusline contain the temporary buffer name.

linediff with vim-airline without this patch
<img width="1491" height="50" alt="airline-without-linediff" src="https://github.com/user-attachments/assets/bc50803f-ff55-49e2-aa8a-ef7b2dd3c41b" />

linediff with vim-airline with this patch
<img width="1491" height="50" alt="airline-with-linediff" src="https://github.com/user-attachments/assets/cceadc90-7de5-40cc-ace9-f82adb600577" />